### PR TITLE
Add keras.utils.cuda_graph for torch inference graph capture

### DIFF
--- a/keras/api/_tf_keras/keras/utils/__init__.py
+++ b/keras/api/_tf_keras/keras/utils/__init__.py
@@ -55,6 +55,7 @@ from keras.src.utils.audio_dataset_utils import (
     audio_dataset_from_directory as audio_dataset_from_directory,
 )
 from keras.src.utils.config import Config as Config
+from keras.src.utils.cuda_graph_utils import cuda_graph as cuda_graph
 from keras.src.utils.dataset_utils import split_dataset as split_dataset
 from keras.src.utils.file_utils import get_file as get_file
 from keras.src.utils.image_dataset_utils import (

--- a/keras/api/utils/__init__.py
+++ b/keras/api/utils/__init__.py
@@ -55,6 +55,7 @@ from keras.src.utils.audio_dataset_utils import (
     audio_dataset_from_directory as audio_dataset_from_directory,
 )
 from keras.src.utils.config import Config as Config
+from keras.src.utils.cuda_graph_utils import cuda_graph as cuda_graph
 from keras.src.utils.dataset_utils import split_dataset as split_dataset
 from keras.src.utils.file_utils import get_file as get_file
 from keras.src.utils.image_dataset_utils import (

--- a/keras/src/utils/cuda_graph_utils.py
+++ b/keras/src/utils/cuda_graph_utils.py
@@ -1,0 +1,133 @@
+"""CUDA graph capture for keras-on-torch inference.
+
+Records the GPU kernel sequence of a forward pass once, then replays it on
+subsequent calls without going through PyTorch's dispatcher or keras's
+Python call path. Speedups of 3-25x are typical depending on the
+overhead-vs-compute ratio of the model.
+
+Constraints:
+
+- Torch backend only. Other backends raise `ValueError`.
+- Inputs must be on CUDA. CPU inputs raise `ValueError`.
+- The captured graph is keyed to a single input shape. Calls with a
+  different shape raise `ValueError`. Wrap the model again with the new
+  shape to capture for it.
+- Inference only. The capture is taken under `torch.no_grad`.
+- No CPU sync points inside the model (`.cpu()`, `.item()`, Python
+  branches on tensor values, prints). These either break capture or
+  produce wrong results on replay.
+- Random ops (e.g. `Dropout`) need the graph-safe RNG path or the same
+  mask replays on every call.
+"""
+
+from keras.src import backend
+from keras.src.api_export import keras_export
+
+
+@keras_export("keras.utils.cuda_graph")
+def cuda_graph(model, sample_input):
+    """Capture a model's forward pass as a CUDA graph and return a replay
+    callable.
+
+    The returned callable accepts an input tensor of the same shape and
+    dtype as `sample_input`, copies it into a fixed capture buffer, replays
+    the captured graph, and returns the model's output (a view of the
+    capture output buffer that is overwritten on the next call).
+
+    Args:
+        model: A `keras.Model` or any callable that runs on the torch
+            backend.
+        sample_input: A torch tensor on CUDA representing the input shape
+            and dtype the graph will be captured for. The model is run on
+            a clone of this tensor during capture, so the tensor itself is
+            not modified.
+
+    Returns:
+        A callable `run(x)` that replays the captured graph with `x` as
+        input. The returned tensor aliases an internal capture buffer and
+        will be overwritten by the next call; clone or copy it if you need
+        to retain the result across calls.
+
+    Raises:
+        ValueError: If the keras backend is not `torch`, if `sample_input`
+            is not a CUDA tensor, or if a call to the returned function
+            receives an input whose shape or dtype differs from
+            `sample_input`.
+
+    Example:
+
+    Requires the torch backend (set via `KERAS_BACKEND=torch` before
+    importing keras).
+
+    >>> import torch, keras
+    >>> model = keras.Sequential([keras.layers.Dense(64)])
+    >>> model.build((None, 32))
+    >>> x = torch.randn(4, 32, device="cuda")
+    >>> graphed = keras.utils.cuda_graph(model, x)
+    >>> y = graphed(x)
+    """
+    if backend.backend() != "torch":
+        raise ValueError(
+            "`keras.utils.cuda_graph` requires the torch backend. "
+            f"Current backend is `{backend.backend()}`."
+        )
+
+    import torch
+
+    if not isinstance(sample_input, torch.Tensor):
+        raise ValueError(
+            "`sample_input` must be a `torch.Tensor`. "
+            f"Got `{type(sample_input).__name__}`."
+        )
+    if sample_input.device.type != "cuda":
+        raise ValueError(
+            "`sample_input` must be on a CUDA device. "
+            f"Got device `{sample_input.device}`."
+        )
+
+    static_input = torch.empty_like(sample_input)
+    static_input.copy_(sample_input)
+
+    # Run a few warm-up iterations on a side stream so allocator and
+    # autotuner state are settled before we record. The recommended count
+    # from torch is three.
+    side_stream = torch.cuda.Stream()
+    side_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side_stream):
+        with torch.no_grad():
+            for _ in range(3):
+                _ = model(static_input)
+    torch.cuda.current_stream().wait_stream(side_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.no_grad(), torch.cuda.graph(graph):
+        static_output = model(static_input)
+
+    captured_shape = tuple(static_input.shape)
+    captured_dtype = static_input.dtype
+
+    def run(x):
+        if not isinstance(x, torch.Tensor):
+            raise ValueError(
+                "Input to a `cuda_graph` callable must be a `torch.Tensor`. "
+                f"Got `{type(x).__name__}`."
+            )
+        if tuple(x.shape) != captured_shape:
+            raise ValueError(
+                "Input shape does not match the shape captured by "
+                "`cuda_graph`. Captured "
+                f"{captured_shape}, received {tuple(x.shape)}. "
+                "Capture a new graph for the new shape."
+            )
+        if x.dtype != captured_dtype:
+            raise ValueError(
+                "Input dtype does not match the dtype captured by "
+                "`cuda_graph`. Captured "
+                f"{captured_dtype}, received {x.dtype}. "
+                "Capture a new graph for the new dtype."
+            )
+        static_input.copy_(x, non_blocking=True)
+        graph.replay()
+        return static_output
+
+    return run

--- a/keras/src/utils/cuda_graph_utils_test.py
+++ b/keras/src/utils/cuda_graph_utils_test.py
@@ -1,0 +1,96 @@
+import pytest
+
+from keras.src import backend
+from keras.src import layers
+from keras.src import testing
+from keras.src.utils.cuda_graph_utils import cuda_graph
+
+
+def _torch_cuda_available():
+    if backend.backend() != "torch":
+        return False
+    try:
+        import torch
+    except ImportError:
+        return False
+    return torch.cuda.is_available()
+
+
+class CudaGraphUtilsTest(testing.TestCase):
+    def test_non_torch_backend_raises(self):
+        if backend.backend() == "torch":
+            self.skipTest("Test is for non-torch backends.")
+        with self.assertRaisesRegex(ValueError, "torch backend"):
+            cuda_graph(lambda x: x, sample_input=None)
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="Remaining tests require the torch backend.",
+    )
+    def test_non_tensor_input_raises(self):
+        with self.assertRaisesRegex(ValueError, "torch.Tensor"):
+            cuda_graph(lambda x: x, sample_input=[1.0, 2.0, 3.0])
+
+    @pytest.mark.skipif(not _torch_cuda_available(), reason="Requires CUDA.")
+    def test_cpu_tensor_raises(self):
+        import torch
+
+        with self.assertRaisesRegex(ValueError, "CUDA device"):
+            cuda_graph(lambda x: x, sample_input=torch.zeros(2, 3))
+
+    @pytest.mark.skipif(not _torch_cuda_available(), reason="Requires CUDA.")
+    def test_replay_matches_eager(self):
+        import torch
+
+        model = layers.Dense(8)
+        model.build((None, 4))
+        x = torch.randn(3, 4, device="cuda")
+        with torch.no_grad():
+            eager = model(x)
+        graphed = cuda_graph(model, x)
+        replayed = graphed(x)
+        # The capture buffer aliases the returned tensor. Convert to numpy
+        # first so the comparison doesn't read stale data after a future
+        # replay.
+        self.assertAllClose(
+            eager.detach().cpu().numpy(),
+            replayed.detach().cpu().numpy(),
+            atol=1e-5,
+        )
+
+    @pytest.mark.skipif(not _torch_cuda_available(), reason="Requires CUDA.")
+    def test_wrong_shape_raises(self):
+        import torch
+
+        model = layers.Dense(8)
+        model.build((None, 4))
+        x = torch.randn(3, 4, device="cuda")
+        graphed = cuda_graph(model, x)
+        with self.assertRaisesRegex(ValueError, "shape"):
+            graphed(torch.randn(5, 4, device="cuda"))
+
+    @pytest.mark.skipif(not _torch_cuda_available(), reason="Requires CUDA.")
+    def test_wrong_dtype_raises(self):
+        import torch
+
+        model = layers.Dense(8)
+        model.build((None, 4))
+        x = torch.randn(3, 4, device="cuda", dtype=torch.float32)
+        graphed = cuda_graph(model, x)
+        with self.assertRaisesRegex(ValueError, "dtype"):
+            graphed(torch.randn(3, 4, device="cuda", dtype=torch.float16))
+
+    @pytest.mark.skipif(not _torch_cuda_available(), reason="Requires CUDA.")
+    def test_replay_reflects_new_input(self):
+        import torch
+
+        model = layers.Dense(4)
+        model.build((None, 4))
+        x1 = torch.randn(2, 4, device="cuda")
+        x2 = torch.randn(2, 4, device="cuda")
+        graphed = cuda_graph(model, x1)
+        y1 = graphed(x1).detach().clone()
+        y2 = graphed(x2).detach().clone()
+        # Different inputs through the same captured graph must produce
+        # different outputs.
+        self.assertGreater(float((y1 - y2).abs().max()), 0.0)


### PR DESCRIPTION
## Description

Adds `keras.utils.cuda_graph(model, sample_input)`, a small utility that captures a
model's forward pass as a `torch.cuda.CUDAGraph` once and replays it on later calls.
Replay skips the PyTorch dispatcher and the keras Python call path entirely, so per-call
latency drops to an input copy plus one graph replay.

Pure utility. No `Model` API surface change. Wiring it into `model.predict` is a separate
PR if this one lands.

### Why the speedups are this big on keras

CUDA graphs typically give pure PyTorch 2-5x because pure PyTorch has thin wrappers. Keras
`Layer.__call__` is much heavier (input-spec checks, mask propagation, dtype policy, build
state, dispatch), and that runs every call. The graph captures the resulting GPU op
sequence and bypasses all of it on replay. The numbers below are that overhead becoming
visible.

### Benchmark (Colab A100, torch 2.10.0+cu128)

Steady-state per-call latency, sync per call.

| workload          | master   | this PR  | speedup |
|-------------------|----------|----------|---------|
| CNN (B=4)         | 2.513 ms | 0.119 ms | 21.18x  |
| MLP (B=32)        | 3.105 ms | 0.222 ms | 13.96x  |
| Transformer (B=8) | 7.169 ms | 0.267 ms | 26.87x  |

Numerical parity exact on the CNN workload: `max |eager - graphed| = 0.000e+00`.

### Constraints

These are in the module docstring and in `Raises`, but worth listing here:

- Torch backend only, raises `ValueError` on other backends.
- Inputs must be on CUDA.
- Captured graph is keyed to one input shape and dtype. Different shape or dtype raises,
  re-wrap to capture for the new one.
- Inference only, capture is under `torch.no_grad`.
- No CPU sync points in the captured region (`.cpu()`, `.item()`, Python branches on
  tensor values). These break capture or produce wrong replay output.
- Dropout needs the graph-safe RNG path or the same mask replays every call.
- Returned tensor aliases the capture output buffer, clone if you need to keep it across
  calls.

### Tests

`cuda_graph_utils_test.py`:

- `test_non_torch_backend_raises` (runs on non-torch backends).
- `test_non_tensor_input_raises`, `test_cpu_tensor_raises` (input validation).
- `test_replay_matches_eager` (numerical parity to `atol=1e-5`).
- `test_wrong_shape_raises`, `test_wrong_dtype_raises`.
- `test_replay_reflects_new_input` (proves the captured graph actually runs, isn't
  returning a constant).

CUDA-dependent tests gate on `torch.cuda.is_available()` and skip otherwise.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.