### PR TITLE
Respect Compiled Trainable State Across Backends

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -384,7 +384,6 @@ class JAXTrainer(base_trainer.Trainer):
         if max_epochs and max_epochs < epochs:
             warnings.warn("Limiting epochs to %d" % max_epochs)
             epochs = max_epochs
-        # TODO: respect compiled trainable state
         self._eval_epoch_iterator = None
         if validation_split and validation_data is None:
             # Create the validation data using the training data. Only supported
@@ -560,7 +559,6 @@ class JAXTrainer(base_trainer.Trainer):
         **kwargs,
     ):
         self._assert_compile_called("evaluate")
-        # TODO: respect compiled trainable state
         use_cached_eval_dataset = kwargs.pop("_use_cached_eval_dataset", False)
         if kwargs:
             raise ValueError(f"Arguments not recognized: {kwargs}")
@@ -888,11 +886,14 @@ class JAXTrainer(base_trainer.Trainer):
         optimizer_variables = self._jax_state.get("optimizer_variables", None)
         metrics_variables = self._jax_state.get("metrics_variables", None)
         if trainable_variables:
-            for ref_v, v in zip(self.trainable_variables, trainable_variables):
+            for ref_v, v in zip(
+                self._trainable_variables_at_compile, trainable_variables
+            ):
                 ref_v.assign(v)
         if non_trainable_variables:
             for ref_v, v in zip(
-                self.non_trainable_variables, non_trainable_variables
+                self._non_trainable_variables_at_compile,
+                non_trainable_variables,
             ):
                 ref_v.assign(v)
         if optimizer_variables:
@@ -905,10 +906,10 @@ class JAXTrainer(base_trainer.Trainer):
 
     def _get_state_sharding_spec(self):
         trainable_shardings = [
-            v.value.sharding for v in self.trainable_variables
+            v.value.sharding for v in self._trainable_variables_at_compile
         ]
         non_trainable_shardings = [
-            v.value.sharding for v in self.non_trainable_variables
+            v.value.sharding for v in self._non_trainable_variables_at_compile
         ]
         if hasattr(self, "optimizer") and self.optimizer is not None:
             optimizer_shardings = [
@@ -952,8 +953,11 @@ class JAXTrainer(base_trainer.Trainer):
             return
 
         var_shard_pairs = itertools.chain(
-            zip(self.trainable_variables, trainable_shardings),
-            zip(self.non_trainable_variables, non_trainable_shardings),
+            zip(self._trainable_variables_at_compile, trainable_shardings),
+            zip(
+                self._non_trainable_variables_at_compile,
+                non_trainable_shardings,
+            ),
             zip(
                 (
                     self.optimizer.variables
@@ -1024,10 +1028,10 @@ class JAXTrainer(base_trainer.Trainer):
         `jax_state_sync()`.
         """
         if trainable_variables:
-            for v in self.trainable_variables:
+            for v in self._trainable_variables_at_compile:
                 v._value = None
         if non_trainable_variables:
-            for v in self.non_trainable_variables:
+            for v in self._non_trainable_variables_at_compile:
                 v._value = None
         if optimizer_variables:
             for v in self.optimizer.variables:
@@ -1046,9 +1050,13 @@ class JAXTrainer(base_trainer.Trainer):
     ):
         state = []
         if trainable_variables:
-            state.append([v.value for v in self.trainable_variables])
+            state.append(
+                [v.value for v in self._trainable_variables_at_compile]
+            )
         if non_trainable_variables:
-            state.append([v.value for v in self.non_trainable_variables])
+            state.append(
+                [v.value for v in self._non_trainable_variables_at_compile]
+            )
         if optimizer_variables:
             state.append([v.value for v in self.optimizer.variables])
         if metrics_variables:

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -146,7 +146,10 @@ class NumpyTrainer(base_trainer.Trainer):
                     y_pred,
                     sample_weight=sample_weight,
                 )
-        if self._compiled_trainable_variables is None:
+        if (
+            self.compiled
+            and getattr(self, "_compiled_trainable_variables", None) is None
+        ):
             self.__dict__["_compiled_trainable_variables"] = (
                 self.trainable_variables
             )

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -146,6 +146,13 @@ class NumpyTrainer(base_trainer.Trainer):
                     y_pred,
                     sample_weight=sample_weight,
                 )
+        if self._compiled_trainable_variables is None:
+            self.__dict__["_compiled_trainable_variables"] = (
+                self.trainable_variables
+            )
+            self.__dict__["_compiled_non_trainable_variables"] = (
+                self.non_trainable_variables
+            )
         self._post_build()
 
     def fit(

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -76,8 +76,8 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 loss = self.optimizer.scale_loss(loss)
 
         # Compute gradients
-        if self.trainable_weights:
-            trainable_weights = self.trainable_weights
+        if self._trainable_variables_at_compile:
+            trainable_weights = self._trainable_variables_at_compile
             gradients = tape.gradient(loss, trainable_weights)
 
             # Update weights
@@ -337,7 +337,6 @@ class TensorFlowTrainer(base_trainer.Trainer):
         if max_epochs and max_epochs < epochs:
             warnings.warn("Limiting epochs to %d" % max_epochs)
             epochs = max_epochs
-        # TODO: respect compiled trainable state
         self._eval_epoch_iterator = None
         if validation_split and validation_data is None:
             # Create the validation data using the training data. Only supported
@@ -466,7 +465,6 @@ class TensorFlowTrainer(base_trainer.Trainer):
         **kwargs,
     ):
         self._assert_compile_called("evaluate")
-        # TODO: respect compiled trainable state
         use_cached_eval_dataset = kwargs.pop("_use_cached_eval_dataset", False)
         if kwargs:
             raise ValueError(f"Arguments not recognized: {kwargs}")

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -1,3 +1,4 @@
+import contextlib
 import warnings
 
 import numpy as np
@@ -23,6 +24,22 @@ class TorchTrainer(base_trainer.Trainer):
         self.train_function = None
         self.test_function = None
         self.predict_function = None
+
+    def _sync_variable_trainable_state(self):
+        for v in self._trainable_variables_at_compile:
+            v.trainable = True
+        for v in self._non_trainable_variables_at_compile:
+            v.trainable = False
+
+    @contextlib.contextmanager
+    def _trainable_state_scope(self):
+        previous_states = [(v, v.trainable) for v in self.variables]
+        try:
+            self._sync_variable_trainable_state()
+            yield
+        finally:
+            for v, state in previous_states:
+                v.trainable = state
 
     def _should_torch_compile(self):
         # require torch>=2.1.0 to enable dynamo since it
@@ -64,12 +81,12 @@ class TorchTrainer(base_trainer.Trainer):
             loss = self.optimizer.scale_loss(loss)
 
         # Compute gradients
-        if self.trainable_weights:
+        if self._trainable_variables_at_compile:
             # Call torch.Tensor.backward() on the loss to compute gradients
             # for the weights.
             loss.backward()
 
-            trainable_weights = self.trainable_weights[:]
+            trainable_weights = self._trainable_variables_at_compile[:]
             gradients = [v.value.grad for v in trainable_weights]
 
             # Update weights
@@ -201,7 +218,6 @@ class TorchTrainer(base_trainer.Trainer):
             warnings.warn("Limiting epochs to %d" % max_epochs)
             epochs = max_epochs
 
-        # TODO: respect compiled trainable state
         self._eval_epoch_iterator = None
         if validation_split and validation_data is None:
             # Create the validation data using the training data. Only supported
@@ -249,71 +265,70 @@ class TorchTrainer(base_trainer.Trainer):
             )
 
         self.stop_training = False
-        training_logs = {}
         self.make_train_function()
         callbacks.on_train_begin()
         initial_epoch = self._initial_epoch or initial_epoch
-        for epoch in range(initial_epoch, epochs):
-            self.reset_metrics()
-            callbacks.on_epoch_begin(epoch)
+        with self._trainable_state_scope():
+            for epoch in range(initial_epoch, epochs):
+                self.reset_metrics()
+                callbacks.on_epoch_begin(epoch)
 
-            # Switch the torch Module to training mode. Inform torch layers to
-            # do training behavior in case the user did not use `self.training`
-            # when implementing a custom layer with torch layers.
-            self.train()
+                # Switch torch Module to training mode. Inform torch layers to
+                # do training behavior in case user did not use `self.training`
+                # when implementing custom layer with torch layers.
+                self.train()
 
-            logs = {}
-            for begin_step, end_step, data in epoch_iterator:
-                # Callbacks
-                callbacks.on_train_batch_begin(begin_step)
+                logs = {}
+                for begin_step, end_step, data in epoch_iterator:
+                    # Callbacks
+                    callbacks.on_train_batch_begin(begin_step)
 
-                logs = self.train_function(data)
+                    logs = self.train_function(data)
 
-                # Callbacks
-                callbacks.on_train_batch_end(end_step, logs)
-                if self.stop_training:
-                    break
+                    # Callbacks
+                    callbacks.on_train_batch_end(end_step, logs)
+                    if self.stop_training:
+                        break
 
-            # Override with model metrics instead of last step logs if needed.
-            epoch_logs = dict(self._get_metrics_result_or_logs(logs))
+                epoch_logs = dict(self._get_metrics_result_or_logs(logs))
 
-            # Switch the torch Module back to testing mode.
-            self.eval()
+                # Switch the torch Module back to testing mode.
+                self.eval()
 
-            # Run validation.
-            if validation_data is not None and self._should_eval(
-                epoch, validation_freq
-            ):
-                # Create TorchEpochIterator for evaluation and cache it.
-                if getattr(self, "_eval_epoch_iterator", None) is None:
-                    self._eval_epoch_iterator = TorchEpochIterator(
+                # Run validation.
+                if validation_data is not None and self._should_eval(
+                    epoch, validation_freq
+                ):
+                    # Create TorchEpochIterator for evaluation and cache it.
+                    if getattr(self, "_eval_epoch_iterator", None) is None:
+                        self._eval_epoch_iterator = TorchEpochIterator(
+                            x=val_x,
+                            y=val_y,
+                            sample_weight=val_sample_weight,
+                            batch_size=validation_batch_size or batch_size,
+                            steps_per_execution=self.steps_per_execution,
+                            steps_per_epoch=validation_steps,
+                            shuffle=False,
+                        )
+                    val_logs = self.evaluate(
                         x=val_x,
                         y=val_y,
                         sample_weight=val_sample_weight,
                         batch_size=validation_batch_size or batch_size,
-                        steps_per_execution=self.steps_per_execution,
-                        steps_per_epoch=validation_steps,
-                        shuffle=False,
+                        steps=validation_steps,
+                        callbacks=callbacks,
+                        return_dict=True,
+                        _use_cached_eval_dataset=True,
                     )
-                val_logs = self.evaluate(
-                    x=val_x,
-                    y=val_y,
-                    sample_weight=val_sample_weight,
-                    batch_size=validation_batch_size or batch_size,
-                    steps=validation_steps,
-                    callbacks=callbacks,
-                    return_dict=True,
-                    _use_cached_eval_dataset=True,
-                )
-                val_logs = {
-                    f"val_{name}": val for name, val in val_logs.items()
-                }
-                epoch_logs.update(val_logs)
+                    val_logs = {
+                        f"val_{name}": val for name, val in val_logs.items()
+                    }
+                    epoch_logs.update(val_logs)
 
-            callbacks.on_epoch_end(epoch, epoch_logs)
-            training_logs = epoch_logs
-            if self.stop_training:
-                break
+                callbacks.on_epoch_end(epoch, epoch_logs)
+                training_logs = epoch_logs
+                if self.stop_training:
+                    break
 
         if (
             isinstance(self.optimizer, optimizers_module.Optimizer)
@@ -340,7 +355,6 @@ class TorchTrainer(base_trainer.Trainer):
         return_dict=False,
         **kwargs,
     ):
-        # TODO: respect compiled trainable state
         use_cached_eval_dataset = kwargs.pop("_use_cached_eval_dataset", False)
         if kwargs:
             raise ValueError(f"Arguments not recognized: {kwargs}")
@@ -381,12 +395,13 @@ class TorchTrainer(base_trainer.Trainer):
         callbacks.on_test_begin()
         logs = {}
         self.reset_metrics()
-        for begin_step, end_step, data in epoch_iterator:
-            callbacks.on_test_batch_begin(begin_step)
-            logs = self.test_function(data)
-            callbacks.on_test_batch_end(end_step, logs)
-            if self.stop_evaluating:
-                break
+        with self._trainable_state_scope():
+            for begin_step, end_step, data in epoch_iterator:
+                callbacks.on_test_batch_begin(begin_step)
+                logs = self.test_function(data)
+                callbacks.on_test_batch_end(end_step, logs)
+                if self.stop_evaluating:
+                    break
         logs = pythonify_logs(self._get_metrics_result_or_logs(logs))
         callbacks.on_test_end(logs)
 
@@ -440,13 +455,16 @@ class TorchTrainer(base_trainer.Trainer):
         self.stop_predicting = False
         callbacks.on_predict_begin()
         outputs = None
-        for begin_step, end_step, data in epoch_iterator:
-            callbacks.on_predict_batch_begin(begin_step)
-            batch_outputs = self.predict_function(data)
-            outputs = append_to_outputs(batch_outputs, outputs)
-            callbacks.on_predict_batch_end(end_step, {"outputs": batch_outputs})
-            if self.stop_predicting:
-                break
+        with self._trainable_state_scope():
+            for begin_step, end_step, data in epoch_iterator:
+                callbacks.on_predict_batch_begin(begin_step)
+                batch_outputs = self.predict_function(data)
+                outputs = append_to_outputs(batch_outputs, outputs)
+                callbacks.on_predict_batch_end(
+                    end_step, {"outputs": batch_outputs}
+                )
+                if self.stop_predicting:
+                    break
         callbacks.on_predict_end()
         outputs = tree.map_structure(backend.convert_to_numpy, outputs)
         return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
@@ -479,7 +497,8 @@ class TorchTrainer(base_trainer.Trainer):
         self.make_train_function()
         self.reset_metrics()
 
-        logs = self.train_function([data])
+        with self._trainable_state_scope():
+            logs = self.train_function([data])
         logs = pythonify_logs(logs)
         if return_dict:
             return logs
@@ -501,7 +520,8 @@ class TorchTrainer(base_trainer.Trainer):
         self.make_test_function()
         self.reset_metrics()
 
-        logs = self.test_function([data])
+        with self._trainable_state_scope():
+            logs = self.test_function([data])
         logs = pythonify_logs(logs)
         if return_dict:
             return logs
@@ -509,7 +529,8 @@ class TorchTrainer(base_trainer.Trainer):
 
     def predict_on_batch(self, x):
         self.make_predict_function()
-        batch_outputs = self.predict_function([(x,)])
+        with self._trainable_state_scope():
+            batch_outputs = self.predict_function([(x,)])
         batch_outputs = tree.map_structure(
             backend.convert_to_numpy, batch_outputs
         )

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -210,6 +210,17 @@ class Trainer:
         self.test_function = None
         self.predict_function = None
 
+        if self.built:
+            self.__dict__["_compiled_trainable_variables"] = (
+                self.trainable_variables
+            )
+            self.__dict__["_compiled_non_trainable_variables"] = (
+                self.non_trainable_variables
+            )
+        else:
+            self.__dict__["_compiled_trainable_variables"] = None
+            self.__dict__["_compiled_non_trainable_variables"] = None
+
         self._compile_config = serialization_lib.SerializableDict(
             optimizer=optimizer,
             loss=loss,
@@ -422,6 +433,102 @@ class Trainer:
             loss = ops.cast(loss, dtype=backend.floatx())
         return ops.sum(loss)
 
+    @property
+    def _trainable_variables_at_compile(self):
+        if (
+            hasattr(self, "_compiled_trainable_variables")
+            and self._compiled_trainable_variables is not None
+        ):
+            return self._compiled_trainable_variables
+        return self.trainable_variables
+
+    @property
+    def _non_trainable_variables_at_compile(self):
+        if (
+            hasattr(self, "_compiled_non_trainable_variables")
+            and self._compiled_non_trainable_variables is not None
+        ):
+            return self._compiled_non_trainable_variables
+        return self.non_trainable_variables
+
+    def stateless_call(
+        self,
+        trainable_variables,
+        non_trainable_variables,
+        *args,
+        return_losses=False,
+        **kwargs,
+    ):
+        self._check_super_called()
+        if not self.built:
+            raise ValueError(
+                f"To call stateless_call, {self.__class__.__name__} must be "
+                "built (i.e. its variables must have been already created). "
+                "You can build it by calling it on some data."
+            )
+        if len(trainable_variables) != len(
+            self._trainable_variables_at_compile
+        ):
+            raise ValueError(
+                "Argument `trainable_variables` must be a list of tensors "
+                "corresponding 1:1 to "
+                f"{self.__class__.__name__}().trainable_variables. "
+                f"Received list with length {len(trainable_variables)}, "
+                f"but expected {len(self._trainable_variables_at_compile)} "
+                "variables."
+            )
+        if len(non_trainable_variables) != len(
+            self._non_trainable_variables_at_compile
+        ):
+            raise ValueError(
+                "Argument `non_trainable_variables` must be a list of tensors "
+                "corresponding 1:1 to "
+                f"{self.__class__.__name__}().non_trainable_variables. "
+                f"Received list with length {len(non_trainable_variables)}, "
+                f"but expected {len(self._non_trainable_variables_at_compile)} "
+                "variables."
+            )
+
+        # Gather variable mapping
+        trainable_mapping = zip(
+            self._trainable_variables_at_compile, trainable_variables
+        )
+        non_trainable_mapping = zip(
+            self._non_trainable_variables_at_compile, non_trainable_variables
+        )
+        mapping = list(trainable_mapping) + list(non_trainable_mapping)
+
+        # Call in stateless scope
+        losses = None
+        with backend.StatelessScope(
+            state_mapping=mapping, collect_losses=return_losses
+        ) as scope:
+            if self.dtype_policy.quantization_mode is not None:
+                if self._remat_mode is not None:
+                    outputs = self.rematerialized_call(
+                        self.quantized_call, *args, **kwargs
+                    )(*args, **kwargs)
+                else:
+                    outputs = self.quantized_call(*args, **kwargs)
+            elif self._remat_mode is not None:
+                outputs = self.rematerialized_call(self.call, *args, **kwargs)(
+                    *args, **kwargs
+                )
+            else:
+                outputs = self.call(*args, **kwargs)
+            if return_losses:
+                losses = self.losses
+
+        # Gather updated non-trainable variables
+        non_trainable_variables = []
+        for v in self._non_trainable_variables_at_compile:
+            new_v = scope.get_current_value(v)
+            non_trainable_variables.append(new_v)
+
+        if return_losses:
+            return outputs, non_trainable_variables, losses
+        return outputs, non_trainable_variables
+
     def stateless_compute_loss(
         self,
         trainable_variables,
@@ -433,9 +540,14 @@ class Trainer:
         sample_weight=None,
         training=True,
     ):
-        var_mapping = list(zip(self.trainable_variables, trainable_variables))
+        var_mapping = list(
+            zip(self._trainable_variables_at_compile, trainable_variables)
+        )
         var_mapping.extend(
-            zip(self.non_trainable_variables, non_trainable_variables)
+            zip(
+                self._non_trainable_variables_at_compile,
+                non_trainable_variables,
+            )
         )
         var_mapping.extend(zip(self.metrics_variables, metrics_variables))
         with backend.StatelessScope(state_mapping=var_mapping) as scope:
@@ -451,7 +563,7 @@ class Trainer:
 
         # Update non trainable vars (may have been updated in compute_loss)
         non_trainable_variables = []
-        for v in self.non_trainable_variables:
+        for v in self._non_trainable_variables_at_compile:
             new_v = scope.get_current_value(v)
             non_trainable_variables.append(new_v)
 
@@ -1003,7 +1115,7 @@ class Trainer:
         self.compile(**config)
         if hasattr(self, "optimizer") and self.built:
             # Create optimizer variables.
-            self.optimizer.build(self.trainable_variables)
+            self.optimizer.build(self._trainable_variables_at_compile)
 
     def _should_eval(self, epoch, validation_freq):
         epoch = epoch + 1  # one-index the user-facing epoch.
@@ -1156,9 +1268,16 @@ class Trainer:
                     sample_weight=sample_weight,
                     training=False,
                 )
+        if self._compiled_trainable_variables is None:
+            self.__dict__["_compiled_trainable_variables"] = (
+                self.trainable_variables
+            )
+            self.__dict__["_compiled_non_trainable_variables"] = (
+                self.non_trainable_variables
+            )
         if optimizer_unbuilt:
             # Build optimizer
-            self.optimizer.build(self.trainable_variables)
+            self.optimizer.build(self._trainable_variables_at_compile)
         self._post_build()
 
 

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -472,7 +472,8 @@ class Trainer:
             raise ValueError(
                 "Argument `trainable_variables` must be a list of tensors "
                 "corresponding 1:1 to "
-                f"{self.__class__.__name__}().trainable_variables. "
+                f"{self.__class__.__name__}().trainable_variables at compile "
+                "time. "
                 f"Received list with length {len(trainable_variables)}, "
                 f"but expected {len(self._trainable_variables_at_compile)} "
                 "variables."
@@ -483,7 +484,8 @@ class Trainer:
             raise ValueError(
                 "Argument `non_trainable_variables` must be a list of tensors "
                 "corresponding 1:1 to "
-                f"{self.__class__.__name__}().non_trainable_variables. "
+                f"{self.__class__.__name__}().non_trainable_variables at "
+                "compile time. "
                 f"Received list with length {len(non_trainable_variables)}, "
                 f"but expected {len(self._non_trainable_variables_at_compile)} "
                 "variables."
@@ -540,6 +542,46 @@ class Trainer:
         sample_weight=None,
         training=True,
     ):
+        self._check_super_called()
+        if not self.built:
+            raise ValueError(
+                f"To call stateless_compute_loss, {self.__class__.__name__} "
+                "must be built (i.e. its variables must have been already "
+                "created). You can build it by calling it on some data."
+            )
+        if len(trainable_variables) != len(
+            self._trainable_variables_at_compile
+        ):
+            raise ValueError(
+                "Argument `trainable_variables` must be a list of tensors "
+                "corresponding 1:1 to "
+                f"{self.__class__.__name__}().trainable_variables at compile "
+                "time. "
+                f"Received list with length {len(trainable_variables)}, "
+                f"but expected {len(self._trainable_variables_at_compile)} "
+                "variables."
+            )
+        if len(non_trainable_variables) != len(
+            self._non_trainable_variables_at_compile
+        ):
+            raise ValueError(
+                "Argument `non_trainable_variables` must be a list of tensors "
+                "corresponding 1:1 to "
+                f"{self.__class__.__name__}().non_trainable_variables at "
+                "compile time. "
+                f"Received list with length {len(non_trainable_variables)}, "
+                f"but expected {len(self._non_trainable_variables_at_compile)} "
+                "variables."
+            )
+        if len(metrics_variables) != len(self.metrics_variables):
+            raise ValueError(
+                "Argument `metrics_variables` must be a list of tensors "
+                "corresponding 1:1 to "
+                f"{self.__class__.__name__}().metrics_variables. "
+                f"Received list with length {len(metrics_variables)}, "
+                f"but expected {len(self.metrics_variables)} "
+                "variables."
+            )
         var_mapping = list(
             zip(self._trainable_variables_at_compile, trainable_variables)
         )
@@ -1268,7 +1310,10 @@ class Trainer:
                     sample_weight=sample_weight,
                     training=False,
                 )
-        if self._compiled_trainable_variables is None:
+        if (
+            self.compiled
+            and getattr(self, "_compiled_trainable_variables", None) is None
+        ):
             self.__dict__["_compiled_trainable_variables"] = (
                 self.trainable_variables
             )

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -373,7 +373,7 @@ class TestTrainer(testing.TestCase):
 
         final_weights = model.get_weights()[0]
 
-        # Weights SHOULD change because it was trainable at compile time.
+        # Weights should change because it was trainable at compile time.
         self.assertNotAllClose(initial_weights, final_weights)
 
         # Re-compile should freeze it.

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -349,6 +349,41 @@ class StepCount(Callback):
 
 class TestTrainer(testing.TestCase):
     @pytest.mark.requires_trainable_backend
+    def test_trainable_respect_compile(self):
+        model = models.Sequential(
+            [
+                layers.Dense(
+                    1,
+                    input_shape=(10,),
+                    use_bias=False,
+                    kernel_initializer="ones",
+                )
+            ]
+        )
+        model.compile(optimizer="sgd", loss="mse")
+
+        initial_weights = model.get_weights()[0].copy()
+
+        # Change trainable to False AFTER compile.
+        model.layers[0].trainable = False
+
+        x = np.ones((1, 10))
+        y = np.zeros((1, 1))
+        model.fit(x, y, epochs=1, verbose=0)
+
+        final_weights = model.get_weights()[0]
+
+        # Weights SHOULD change because it was trainable at compile time.
+        self.assertNotAllClose(initial_weights, final_weights)
+
+        # Re-compile should freeze it.
+        model.compile(optimizer="sgd", loss="mse")
+        initial_weights = model.get_weights()[0].copy()
+        model.fit(x, y, epochs=1, verbose=0)
+        final_weights = model.get_weights()[0]
+        self.assertAllClose(initial_weights, final_weights)
+
+    @pytest.mark.requires_trainable_backend
     def test_metric_tracking(self):
         class ModelWithMetric(Trainer, layers.Dense):
             def __init__(self, units):


### PR DESCRIPTION
## Description
This PR fixes a bug where changes to a layer's trainable property after model.compile() were immediately applied during training steps. According to Keras documentation and established workflows (such as transfer learning), the trainable state should be "frozen" at the time of compilation and only update upon a subsequent call to compile().

#### The Problem
Previously, backend trainers (JAX, TensorFlow, and PyTorch) were dynamically retrieving self.trainable_weights or self.trainable_variables during every train_step. This meant that setting layer.trainable = False after compilation would immediately exclude those weights from gradient updates, ignoring the configuration the optimizer was originally built with.

#### The Solution
This PR updates the base Trainer class to capture a snapshot of the model's trainable and non-trainable variables during compile() (or the first symbolic build()). The backend-specific trainers were then updated to use these "at-compile" lists during execution.

**Colab notebook: https://colab.research.google.com/drive/1ybm72E8ysqlabKti_lSFKyLB_N_KSNJT?usp=sharing**

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
