### PR TITLE
Added opt-in JAX threaded epoch iterator

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1,9 +1,9 @@
 import itertools
-import warnings
-from functools import partial
+import os
 import queue
 import threading
-import os
+import warnings
+from functools import partial
 
 import jax
 import numpy as np
@@ -1235,9 +1235,6 @@ class JAXEpochIteratorThreaded(JAXEpochIterator):
     def __init__(self, *args, prefetch=2, **kwargs):
         super().__init__(*args, **kwargs)
         self.prefetch = max(1, prefetch)
-        self._layout_cache = {}
-        self._last_signature = None
-        self._last_layouts = None
 
     def reset(self):
         self.close()
@@ -1252,9 +1249,6 @@ class JAXEpochIteratorThreaded(JAXEpochIterator):
             if close is not None:
                 close()
             self._current_iterator = None
-        self._layout_cache.clear()
-        self._last_signature = None
-        self._last_layouts = None
 
     def _get_iterator(self):
         distribution = distribution_lib.distribution()
@@ -1269,16 +1263,22 @@ class JAXEpochIteratorThreaded(JAXEpochIterator):
         if distribution is None:
             return device_put_tree
 
+        layout_cache = {}
+        last_signature = None
+        last_layouts = None
+
         def prepare_distributed_batch(batch):
+            nonlocal last_signature, last_layouts
+
             if batch is None:
                 return None
 
             signature = shape_signature(batch)
 
-            if signature == self._last_signature:
-                layouts = self._last_layouts
+            if signature == last_signature:
+                layouts = last_layouts
             else:
-                layouts = self._layout_cache.get(signature)
+                layouts = layout_cache.get(signature)
 
                 if layouts is None:
                     layouts = tree.map_structure(
@@ -1291,10 +1291,10 @@ class JAXEpochIteratorThreaded(JAXEpochIterator):
                         ),
                         batch,
                     )
-                    self._layout_cache[signature] = layouts
+                    layout_cache[signature] = layouts
 
-                self._last_signature = signature
-                self._last_layouts = layouts
+                last_signature = signature
+                last_layouts = layouts
 
             return _distribute_data(batch, layouts)
 

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1,6 +1,9 @@
 import itertools
 import warnings
 from functools import partial
+import queue
+import threading
+import os
 
 import jax
 import numpy as np
@@ -1160,14 +1163,9 @@ def shape_signature(batch):
 
 class ThreadedPrefetchIterator:
     def __init__(self, iterator, transform, maxsize=2):
-        import queue
-        import threading
-
         self.iterator = iter(iterator)
         self.transform = transform
         self.queue = queue.Queue(maxsize=maxsize)
-        self.queue_module = queue
-        self.threading = threading
         self.end = object()
         self.errors = []
         self.stop = threading.Event()
@@ -1176,7 +1174,7 @@ class ThreadedPrefetchIterator:
 
     def _start(self):
         if self.thread is None:
-            self.thread = self.threading.Thread(
+            self.thread = threading.Thread(
                 target=self._producer,
                 name="jax_iterator_prefetch",
                 daemon=True,
@@ -1204,7 +1202,7 @@ class ThreadedPrefetchIterator:
             try:
                 self.queue.put(item, timeout=0.1)
                 return True
-            except self.queue_module.Full:
+            except queue.Full:
                 pass
         return False
 
@@ -1304,12 +1302,10 @@ class JAXEpochIteratorThreaded(JAXEpochIterator):
 
 
 def build_jax_epoch_iterator(*args, **kwargs):
-    import os
-
     mode = os.environ.get("KERAS_JAX_EPOCH_ITERATOR", "default")
 
     if mode == "default":
         return JAXEpochIterator(*args, **kwargs)
     elif mode == "threaded":
         return JAXEpochIteratorThreaded(*args, **kwargs)
-    raise ValueError("Invalid value for KERAS_JAX_EPOCH_ITERATOR")
+    raise ValueError(f"Invalid value for KERAS_JAX_EPOCH_ITERATOR: {mode}")

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -404,7 +404,7 @@ class JAXTrainer(base_trainer.Trainer):
             ) = data_adapter_utils.unpack_x_y_sample_weight(validation_data)
 
         # Create an iterator that yields batches for one epoch.
-        epoch_iterator = JAXEpochIterator(
+        epoch_iterator = build_jax_epoch_iterator(
             x=x,
             y=y,
             sample_weight=sample_weight,
@@ -499,7 +499,7 @@ class JAXTrainer(base_trainer.Trainer):
                 ):
                     # Create JAXEpochIterator for evaluation and cache it.
                     if getattr(self, "_eval_epoch_iterator", None) is None:
-                        self._eval_epoch_iterator = JAXEpochIterator(
+                        self._eval_epoch_iterator = build_jax_epoch_iterator(
                             x=val_x,
                             y=val_y,
                             sample_weight=val_sample_weight,
@@ -537,9 +537,11 @@ class JAXTrainer(base_trainer.Trainer):
             ):
                 self.optimizer.finalize_variable_values(self.trainable_weights)
 
+            epoch_iterator.close()
             # If _eval_epoch_iterator exists, delete it after all epochs
             # are done.
             if getattr(self, "_eval_epoch_iterator", None) is not None:
+                self._eval_epoch_iterator.close()
                 del self._eval_epoch_iterator
             if training_finished:
                 callbacks.on_train_end(logs=training_logs)
@@ -570,7 +572,7 @@ class JAXTrainer(base_trainer.Trainer):
         else:
             # Create an iterator that yields batches of
             # input/target data.
-            epoch_iterator = JAXEpochIterator(
+            epoch_iterator = build_jax_epoch_iterator(
                 x=x,
                 y=y,
                 sample_weight=sample_weight,
@@ -638,6 +640,9 @@ class JAXTrainer(base_trainer.Trainer):
                 if self.stop_evaluating:
                     break
 
+        if not use_cached_eval_dataset:
+            epoch_iterator.close()
+
         # Reattach state back to model (if not already done by a callback).
         self.jax_state_sync()
 
@@ -654,7 +659,7 @@ class JAXTrainer(base_trainer.Trainer):
         self, x, batch_size=None, verbose="auto", steps=None, callbacks=None
     ):
         # Create an iterator that yields batches of input data.
-        epoch_iterator = JAXEpochIterator(
+        epoch_iterator = build_jax_epoch_iterator(
             x=x,
             batch_size=batch_size,
             steps_per_epoch=steps,
@@ -740,7 +745,7 @@ class JAXTrainer(base_trainer.Trainer):
 
                 if self.stop_predicting:
                     break
-
+        epoch_iterator.close()
         self.jax_state_sync()
         callbacks.on_predict_end()
         self._jax_state = None
@@ -1129,3 +1134,182 @@ class JAXEpochIterator(EpochIterator):
 
         if next_batch is not None:
             yield next_batch
+
+    def close(self):
+        pass
+
+
+def device_put_tree(batch):
+    return tree.map_structure(
+        lambda x: None if x is None else jax.device_put(x),
+        batch,
+    )
+
+
+def shape_signature(batch):
+    return tuple(
+        (
+            path,
+            None
+            if leaf is None
+            else (tuple(leaf.shape), getattr(leaf, "dtype", None)),
+        )
+        for path, leaf in tree.flatten_with_path(batch)
+    )
+
+
+class ThreadedPrefetchIterator:
+    def __init__(self, iterator, transform, maxsize=2):
+        import queue
+        import threading
+
+        self.iterator = iter(iterator)
+        self.transform = transform
+        self.queue = queue.Queue(maxsize=maxsize)
+        self.queue_module = queue
+        self.threading = threading
+        self.end = object()
+        self.errors = []
+        self.stop = threading.Event()
+        self.closed = False
+        self.thread = None
+
+    def _start(self):
+        if self.thread is None:
+            self.thread = self.threading.Thread(
+                target=self._producer,
+                name="jax_iterator_prefetch",
+                daemon=True,
+            )
+            self.thread.start()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.closed:
+            raise StopIteration
+
+        self._start()
+        item = self.queue.get()
+        if item is self.end:
+            self.close()
+            if self.errors:
+                raise self.errors[0]
+            raise StopIteration
+        return item
+
+    def _safe_put(self, item):
+        while not self.stop.is_set():
+            try:
+                self.queue.put(item, timeout=0.1)
+                return True
+            except self.queue_module.Full:
+                pass
+        return False
+
+    def _producer(self):
+        try:
+            for item in self.iterator:
+                if self.stop.is_set():
+                    return
+                item = self.transform(item)
+                if not self._safe_put(item):
+                    return
+        except BaseException as e:
+            if not self.stop.is_set():
+                self.errors.append(e)
+        finally:
+            self._safe_put(self.end)
+
+    def close(self):
+        if self.closed:
+            return
+        self.closed = True
+        self.stop.set()
+        if self.thread is not None and self.thread.is_alive():
+            self.thread.join(timeout=2.0)
+
+
+class JAXEpochIteratorThreaded(JAXEpochIterator):
+    """JAX epoch iterator with threaded async prefetch."""
+
+    def __init__(self, *args, prefetch=2, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.prefetch = max(1, prefetch)
+        self._layout_cache = {}
+        self._last_signature = None
+        self._last_layouts = None
+
+    def reset(self):
+        self.close()
+        super().reset()
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        if self._current_iterator is not None:
+            close = getattr(self._current_iterator, "close", None)
+            if close is not None:
+                close()
+            self._current_iterator = None
+        self._layout_cache.clear()
+        self._last_signature = None
+        self._last_layouts = None
+
+    def _get_iterator(self):
+        distribution = distribution_lib.distribution()
+        prepare_batch = self._make_prepare_batch(distribution)
+        return ThreadedPrefetchIterator(
+            self.data_adapter.get_jax_iterator(),
+            transform=prepare_batch,
+            maxsize=self.prefetch,
+        )
+
+    def _make_prepare_batch(self, distribution):
+        if distribution is None:
+            return device_put_tree
+
+        def prepare_distributed_batch(batch):
+            if batch is None:
+                return None
+
+            signature = shape_signature(batch)
+
+            if signature == self._last_signature:
+                layouts = self._last_layouts
+            else:
+                layouts = self._layout_cache.get(signature)
+
+                if layouts is None:
+                    layouts = tree.map_structure(
+                        lambda d: (
+                            None
+                            if d is None
+                            else distribution.get_data_layout(
+                                d.shape
+                            ).backend_layout
+                        ),
+                        batch,
+                    )
+                    self._layout_cache[signature] = layouts
+
+                self._last_signature = signature
+                self._last_layouts = layouts
+
+            return _distribute_data(batch, layouts)
+
+        return prepare_distributed_batch
+
+
+def build_jax_epoch_iterator(*args, **kwargs):
+    import os
+
+    mode = os.environ.get("KERAS_JAX_EPOCH_ITERATOR", "default")
+
+    if mode == "default":
+        return JAXEpochIterator(*args, **kwargs)
+    elif mode == "threaded":
+        return JAXEpochIteratorThreaded(*args, **kwargs)
+    raise ValueError("Invalid value for KERAS_JAX_EPOCH_ITERATOR")

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -1,4 +1,5 @@
 import warnings
+from unittest import mock
 
 import jax
 import numpy as np
@@ -10,7 +11,151 @@ from keras.src import layers
 from keras.src import models
 from keras.src import testing
 from keras.src.backend import distribution_lib as backend_dlib
+from keras.src.backend.jax import trainer as jax_trainer
 from keras.src.distribution import distribution_lib
+
+
+@pytest.mark.skipif(backend.backend() != "jax", reason="JAX only")
+class JAXEpochIteratorThreadedTest(testing.TestCase):
+    def test_device_put_tree(self):
+        batch = (np.ones((2, 3), dtype="float32"), None)
+
+        result = jax_trainer.device_put_tree(batch)
+
+        self.assertEqual(result[0].shape, (2, 3))
+        self.assertIsNone(result[1])
+
+    def test_shape_signature(self):
+        batch = {
+            "x": np.ones((2, 3), dtype="float32"),
+            "none": None,
+        }
+
+        signature = jax_trainer.shape_signature(batch)
+        leaf_signatures = [leaf_signature for _, leaf_signature in signature]
+
+        self.assertIn(((2, 3), np.dtype("float32")), leaf_signatures)
+        self.assertIn(None, leaf_signatures)
+
+    def test_threaded_prefetch_iterator_yields_transformed_items(self):
+        iterator = jax_trainer.ThreadedPrefetchIterator(
+            [1, 2, 3],
+            transform=lambda x: x + 1,
+            maxsize=1,
+        )
+
+        self.assertEqual(next(iterator), 2)
+        self.assertEqual(next(iterator), 3)
+        self.assertEqual(next(iterator), 4)
+        with self.assertRaises(StopIteration):
+            next(iterator)
+        self.assertTrue(iterator.closed)
+
+    def test_threaded_prefetch_iterator_raises_transform_errors(self):
+        def transform(x):
+            if x == 2:
+                raise ValueError("failed")
+            return x
+
+        iterator = jax_trainer.ThreadedPrefetchIterator(
+            [1, 2],
+            transform=transform,
+        )
+
+        self.assertEqual(next(iterator), 1)
+        with self.assertRaisesRegex(ValueError, "failed"):
+            next(iterator)
+        self.assertTrue(iterator.closed)
+
+    def test_threaded_prefetch_iterator_close(self):
+        def infinite_iterator():
+            while True:
+                yield 1
+
+        iterator = jax_trainer.ThreadedPrefetchIterator(
+            infinite_iterator(),
+            transform=lambda x: x,
+            maxsize=1,
+        )
+
+        self.assertEqual(next(iterator), 1)
+        iterator.close()
+        iterator.close()
+        self.assertTrue(iterator.closed)
+        with self.assertRaises(StopIteration):
+            next(iterator)
+
+    def test_build_jax_epoch_iterator_default(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            iterator = jax_trainer.build_jax_epoch_iterator(
+                x=np.ones((2, 1)),
+                batch_size=1,
+            )
+
+        self.assertIsInstance(iterator, jax_trainer.JAXEpochIterator)
+        self.assertNotIsInstance(iterator, jax_trainer.JAXEpochIteratorThreaded)
+
+    def test_build_jax_epoch_iterator_threaded(self):
+        with mock.patch.dict(
+            "os.environ", {"KERAS_JAX_EPOCH_ITERATOR": "threaded"}
+        ):
+            iterator = jax_trainer.build_jax_epoch_iterator(
+                x=np.ones((2, 1)),
+                batch_size=1,
+            )
+
+        self.assertIsInstance(iterator, jax_trainer.JAXEpochIteratorThreaded)
+        iterator.close()
+
+    def test_build_jax_epoch_iterator_invalid(self):
+        with mock.patch.dict(
+            "os.environ", {"KERAS_JAX_EPOCH_ITERATOR": "invalid"}
+        ):
+            with self.assertRaisesRegex(ValueError, "Invalid value"):
+                jax_trainer.build_jax_epoch_iterator(
+                    x=np.ones((2, 1)),
+                    batch_size=1,
+                )
+
+    def test_distributed_batch_preparation_caches_layouts(self):
+        class DataLayout:
+            def __init__(self, shape):
+                self.backend_layout = ("layout", tuple(shape))
+
+        class Distribution:
+            def __init__(self):
+                self.calls = 0
+
+            def get_data_layout(self, shape):
+                self.calls += 1
+                return DataLayout(shape)
+
+        distribution = Distribution()
+        iterator = jax_trainer.JAXEpochIteratorThreaded(
+            x=np.ones((2, 1)),
+            batch_size=1,
+        )
+        prepare_batch = iterator._make_prepare_batch(distribution)
+
+        with mock.patch.object(
+            jax_trainer,
+            "_distribute_data",
+            side_effect=lambda batch, layouts: (batch, layouts),
+        ):
+            batch = (np.ones((2, 3), dtype="float32"), None)
+            _, layouts = prepare_batch(batch)
+            self.assertEqual(layouts[0], ("layout", (2, 3)))
+            self.assertIsNone(layouts[1])
+            self.assertEqual(distribution.calls, 1)
+
+            prepare_batch((np.ones((2, 3), dtype="float32"), None))
+            self.assertEqual(distribution.calls, 1)
+
+            prepare_batch((np.ones((4, 3), dtype="float32"), None))
+            self.assertEqual(distribution.calls, 2)
+
+            prepare_batch((np.ones((2, 3), dtype="float32"), None))
+            self.assertEqual(distribution.calls, 2)
 
 
 @pytest.mark.skipif(backend.backend() != "jax", reason="JAX only")

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -253,6 +253,16 @@ class JAXEpochIteratorThreadedTest(testing.TestCase):
                     batch_size=1,
                 )
 
+    def test_batch_preparation_without_distribution(self):
+        iterator = jax_trainer.JAXEpochIteratorThreaded(
+            x=np.ones((2, 1)),
+            batch_size=1,
+        )
+
+        prepare_batch = iterator._make_prepare_batch(None)
+
+        self.assertIs(prepare_batch, jax_trainer.device_put_tree)
+
     def test_distributed_batch_preparation_caches_layouts(self):
         class DataLayout:
             def __init__(self, shape):
@@ -282,6 +292,9 @@ class JAXEpochIteratorThreadedTest(testing.TestCase):
             _, layouts = prepare_batch(batch)
             self.assertEqual(layouts[0], ("layout", (2, 3)))
             self.assertIsNone(layouts[1])
+            self.assertEqual(distribution.calls, 1)
+
+            self.assertIsNone(prepare_batch(None))
             self.assertEqual(distribution.calls, 1)
 
             prepare_batch((np.ones((2, 3), dtype="float32"), None))

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -104,7 +104,7 @@ class JAXEpochIteratorThreadedTest(testing.TestCase):
         self.assertEqual(iterator.errors, [error])
         self.assertIs(iterator.queue.get_nowait(), iterator.end)
 
-    def test_threaded_prefetch_iterator_producer_ignores_errors_after_stop(self):
+    def test_stopped_threaded_prefetch_iterator_producer_ignores_errors(self):
         def transform(x):
             iterator.stop.set()
             raise BaseException("failed")

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -1,3 +1,4 @@
+import queue
 import warnings
 from unittest import mock
 
@@ -44,12 +45,33 @@ class JAXEpochIteratorThreadedTest(testing.TestCase):
             maxsize=1,
         )
 
+        self.assertIs(iter(iterator), iterator)
         self.assertEqual(next(iterator), 2)
         self.assertEqual(next(iterator), 3)
         self.assertEqual(next(iterator), 4)
         with self.assertRaises(StopIteration):
             next(iterator)
         self.assertTrue(iterator.closed)
+
+    def test_threaded_prefetch_iterator_producer_stops_when_queue_full(self):
+        iterator = jax_trainer.ThreadedPrefetchIterator(
+            [1],
+            transform=lambda x: x,
+        )
+
+        def put_and_stop(*args, **kwargs):
+            iterator.stop.set()
+            raise queue.Full
+
+        with mock.patch.object(
+            iterator.queue,
+            "put",
+            side_effect=put_and_stop,
+        ) as queue_put:
+            iterator._producer()
+
+        self.assertEqual(queue_put.call_count, 1)
+        self.assertEqual(iterator.errors, [])
 
     def test_threaded_prefetch_iterator_raises_transform_errors(self):
         def transform(x):
@@ -66,6 +88,36 @@ class JAXEpochIteratorThreadedTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "failed"):
             next(iterator)
         self.assertTrue(iterator.closed)
+
+    def test_threaded_prefetch_iterator_producer_captures_base_exceptions(self):
+        error = BaseException("failed")
+
+        def transform(x):
+            raise error
+
+        iterator = jax_trainer.ThreadedPrefetchIterator(
+            [1],
+            transform=transform,
+        )
+        iterator._producer()
+
+        self.assertEqual(iterator.errors, [error])
+        self.assertIs(iterator.queue.get_nowait(), iterator.end)
+
+    def test_threaded_prefetch_iterator_producer_ignores_errors_after_stop(self):
+        def transform(x):
+            iterator.stop.set()
+            raise BaseException("failed")
+
+        iterator = jax_trainer.ThreadedPrefetchIterator(
+            [1],
+            transform=transform,
+        )
+        iterator._producer()
+
+        self.assertEqual(iterator.errors, [])
+        with self.assertRaises(queue.Empty):
+            iterator.queue.get_nowait()
 
     def test_threaded_prefetch_iterator_close(self):
         def infinite_iterator():
@@ -84,6 +136,90 @@ class JAXEpochIteratorThreadedTest(testing.TestCase):
         self.assertTrue(iterator.closed)
         with self.assertRaises(StopIteration):
             next(iterator)
+
+    def test_jax_epoch_iterator_threaded_reset_closes_current_iterator(self):
+        iterator = jax_trainer.JAXEpochIteratorThreaded(
+            x=np.ones((2, 1)),
+            batch_size=1,
+        )
+        current_iterator = mock.Mock()
+        iterator._current_iterator = current_iterator
+        iterator._epoch_iterator = object()
+        iterator._steps_seen = 1
+
+        with mock.patch.object(
+            iterator.data_adapter, "on_epoch_end"
+        ) as on_epoch_end:
+            iterator.reset()
+
+        current_iterator.close.assert_called_once()
+        on_epoch_end.assert_called_once()
+        self.assertIsNone(iterator._current_iterator)
+        self.assertIsNone(iterator._epoch_iterator)
+        self.assertEqual(iterator._steps_seen, 0)
+
+    def test_jax_epoch_iterator_threaded_close_clears_current_iterator(self):
+        iterator = jax_trainer.JAXEpochIteratorThreaded(
+            x=np.ones((2, 1)),
+            batch_size=1,
+        )
+        current_iterator = mock.Mock()
+        iterator._current_iterator = current_iterator
+
+        iterator.close()
+
+        current_iterator.close.assert_called_once()
+        self.assertIsNone(iterator._current_iterator)
+
+        iterator._current_iterator = object()
+
+        iterator.close()
+
+        self.assertIsNone(iterator._current_iterator)
+
+    def test_jax_epoch_iterator_threaded_get_iterator(self):
+        iterator = jax_trainer.JAXEpochIteratorThreaded(
+            x=np.ones((2, 1)),
+            batch_size=1,
+            prefetch=3,
+        )
+        jax_iterator = object()
+        prepare_batch = object()
+        threaded_iterator = object()
+
+        with (
+            mock.patch.object(
+                jax_trainer.distribution_lib,
+                "distribution",
+                return_value=None,
+            ) as distribution,
+            mock.patch.object(
+                iterator,
+                "_make_prepare_batch",
+                return_value=prepare_batch,
+            ) as make_prepare_batch,
+            mock.patch.object(
+                iterator.data_adapter,
+                "get_jax_iterator",
+                return_value=jax_iterator,
+            ) as get_jax_iterator,
+            mock.patch.object(
+                jax_trainer,
+                "ThreadedPrefetchIterator",
+                return_value=threaded_iterator,
+            ) as threaded_prefetch_iterator,
+        ):
+            result = iterator._get_iterator()
+
+        distribution.assert_called_once_with()
+        make_prepare_batch.assert_called_once_with(None)
+        get_jax_iterator.assert_called_once_with()
+        threaded_prefetch_iterator.assert_called_once_with(
+            jax_iterator,
+            transform=prepare_batch,
+            maxsize=3,
+        )
+        self.assertIs(result, threaded_iterator)
 
     def test_build_jax_epoch_iterator_default(self):
         with mock.patch.dict("os.environ", {}, clear=True):


### PR DESCRIPTION
## Description
I have added an opt-in alternative to JAXEpochIterator, using a separate thread. 
To enable it the env variable `KERAS_JAX_EPOCH_ITERATOR=threaded` should be set.

I have run some benchmark with some interesting results starting from the offical benchmarks
(the benchmark code can be found here: https://github.com/AmedeoBiolatti/keras-benchmarks/tree/jax_epoch_iterator_benchmark)
(wandb runs are also available if needed)


| Benchmark | Device | Default (5 runs avg) | Threaded (5 runs avg) | Speedup |
|---|---:|---:|---:|---:|
| `bert_fit, batch_size=8` | A100-SXM4-40GB | 54.23 | 53.35 | 1.62% ** |
| `bert_fit, batch_size=16` | A100-SXM4-40GB | 95.42 | 94.54 | 0.92% ** |
| `bert_fit, batch_size=32` | A100-SXM4-40GB | 188.28 | 186.47 | 0.96% ** |
| `bert_fit, batch_size=64` | A100-SXM4-40GB | 387.88 | 385.90 | 0.51% ** |
| `stable_diffusion_fit` | A100-SXM4-40GB | 409.28 | 391.34 | 4.38% ** |
| `gemma_fit` | A100-SXM4-40GB | 204.76 | 203.68 | 0.53% ** |
| `mistral_fit` | A100-SXM4-40GB | 174.47 | 173.47 | 0.57% ** |
| `bert_predict` | A100-SXM4-40GB | 423.81 | 423.55 | 0.06% |
| `sam_predict` | A100-SXM4-40GB | 468.31 | 431.57 | 7.85% ** |
| `bert_fit, batch_size=32` | 2xH100 80GB HBM3 * | 49.69 | 49.67 | 0.04% |
| `bert_fit, batch_size=256` | 2xH100 80GB HBM3 * | 347.45 | 347.66 | -0.06% |
| `stable_diffusion_fit` | 2xH100 80GB HBM3 * | 95.22 | 95.31 | -0.09% |
| `stable_diffusion_fit` | H100 80GB HBM3 * | 27.09 | 26.92 | 0.63% |
| `bert_fit, batch_size=32` | 2xA100-PCIE-40GB, 250W * | 446.79 | 439.90 | 1.54% |

\* Given the lack of available 2xA100 machines on lambda.ai in these days I tried to experiment on different configurations/providers, but I would take those result with caution. I tried 2xH100 on lambda.ai and 2xA100 on vast.ai, but the batch sizes were probably not adapt to the machines, or the machines were running on very different conditions (eg. 250W limit for A100 on vast.ai)  
\** Statistically significant results

I will be happy to help to run any other benchmark and/or test necessary

Note: some of the code have been generated with coding agents, but all have been carefully reviewed and tested by me in person.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.