### PR TITLE
LossScaleOptimizer and Callback Support for MultiOptimizers.

### DIFF
--- a/keras/src/callbacks/learning_rate_scheduler.py
+++ b/keras/src/callbacks/learning_rate_scheduler.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from keras.src import backend
+from keras.src import optimizers
 from keras.src.api_export import keras_export
 from keras.src.callbacks.callback import Callback
 from keras.src.utils import io_utils
@@ -71,7 +72,9 @@ class LearningRateScheduler(Callback):
         return learning_rate
 
     def on_epoch_begin(self, epoch, logs=None):
-        if hasattr(self.model.optimizer, "optimizers"):
+        if isinstance(
+            self.model.optimizer, optimizers.MultiOptimizer
+        ) and hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
                 learning_rate = self._update_optimizer_lr(opt, epoch)
                 if self.verbose > 0:
@@ -91,7 +94,9 @@ class LearningRateScheduler(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        if hasattr(self.model.optimizer, "optimizers"):
+        if isinstance(
+            self.model.optimizer, optimizers.MultiOptimizer
+        ) and hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
                 logs[f"learning_rate_{opt.name}{idx}"] = float(
                     backend.convert_to_numpy(opt.learning_rate)

--- a/keras/src/callbacks/learning_rate_scheduler.py
+++ b/keras/src/callbacks/learning_rate_scheduler.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from keras.src import backend
-from keras.src import optimizers
 from keras.src.api_export import keras_export
 from keras.src.callbacks.callback import Callback
 from keras.src.utils import io_utils
@@ -72,15 +71,13 @@ class LearningRateScheduler(Callback):
         return learning_rate
 
     def on_epoch_begin(self, epoch, logs=None):
-        if isinstance(
-            self.model.optimizer, optimizers.MultiOptimizer
-        ) and hasattr(self.model.optimizer, "optimizers"):
+        if hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
                 learning_rate = self._update_optimizer_lr(opt, epoch)
                 if self.verbose > 0:
                     io_utils.print_msg(
                         f"\nEpoch {epoch + 1}: LearningRateScheduler setting "
-                        f"{opt.name}{idx} learning rate to {learning_rate}."
+                        f"{opt.name}_{idx} learning rate to {learning_rate}."
                     )
         else:
             learning_rate = self._update_optimizer_lr(
@@ -94,11 +91,9 @@ class LearningRateScheduler(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        if isinstance(
-            self.model.optimizer, optimizers.MultiOptimizer
-        ) and hasattr(self.model.optimizer, "optimizers"):
+        if hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
-                logs[f"learning_rate_{opt.name}{idx}"] = float(
+                logs[f"learning_rate_{opt.name}_{idx}"] = float(
                     backend.convert_to_numpy(opt.learning_rate)
                 )
         else:

--- a/keras/src/callbacks/learning_rate_scheduler.py
+++ b/keras/src/callbacks/learning_rate_scheduler.py
@@ -77,7 +77,7 @@ class LearningRateScheduler(Callback):
                 if self.verbose > 0:
                     io_utils.print_msg(
                         f"\nEpoch {epoch + 1}: LearningRateScheduler setting "
-                        f"{opt.name}_{idx} learning rate to {learning_rate}."
+                        f"{opt.name} learning rate to {learning_rate}."
                     )
         else:
             learning_rate = self._update_optimizer_lr(
@@ -93,7 +93,7 @@ class LearningRateScheduler(Callback):
         logs = logs or {}
         if hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
-                logs[f"learning_rate_{opt.name}_{idx}"] = float(
+                logs[f"learning_rate_{opt.name}"] = float(
                     backend.convert_to_numpy(opt.learning_rate)
                 )
         else:

--- a/keras/src/callbacks/learning_rate_scheduler.py
+++ b/keras/src/callbacks/learning_rate_scheduler.py
@@ -49,13 +49,13 @@ class LearningRateScheduler(Callback):
         self.schedule = schedule
         self.verbose = verbose
 
-    def on_epoch_begin(self, epoch, logs=None):
-        if not hasattr(self.model.optimizer, "learning_rate"):
+    def _update_optimizer_lr(self, optimizer, epoch):
+        if not hasattr(optimizer, "learning_rate"):
             raise ValueError('Optimizer must have a "learning_rate" attribute.')
 
         try:  # new API
             learning_rate = float(
-                backend.convert_to_numpy(self.model.optimizer.learning_rate)
+                backend.convert_to_numpy(optimizer.learning_rate)
             )
             learning_rate = self.schedule(epoch, learning_rate)
         except TypeError:  # Support for old API for backward compatibility
@@ -67,15 +67,36 @@ class LearningRateScheduler(Callback):
                 f"Got: {learning_rate}"
             )
 
-        self.model.optimizer.learning_rate = learning_rate
-        if self.verbose > 0:
-            io_utils.print_msg(
-                f"\nEpoch {epoch + 1}: LearningRateScheduler setting learning "
-                f"rate to {learning_rate}."
+        optimizer.learning_rate = learning_rate
+        return learning_rate
+
+    def on_epoch_begin(self, epoch, logs=None):
+        if hasattr(self.model.optimizer, "optimizers"):
+            for idx, opt in enumerate(self.model.optimizer.optimizers):
+                learning_rate = self._update_optimizer_lr(opt, epoch)
+            if self.verbose > 0:
+                io_utils.print_msg(
+                    f"\nEpoch {epoch + 1}: LearningRateScheduler setting "
+                    f"{opt.name}{idx} learning rate to {learning_rate}."
+                )
+        else:
+            learning_rate = self._update_optimizer_lr(
+                self.model.optimizer, epoch
             )
+            if self.verbose > 0:
+                io_utils.print_msg(
+                    f"\nEpoch {epoch + 1}: LearningRateScheduler setting "
+                    f"learning rate to {learning_rate}."
+                )
 
     def on_epoch_end(self, epoch, logs=None):
         logs = logs or {}
-        logs["learning_rate"] = float(
-            backend.convert_to_numpy(self.model.optimizer.learning_rate)
-        )
+        if hasattr(self.model.optimizer, "optimizers"):
+            for idx, opt in enumerate(self.model.optimizer.optimizers):
+                logs[f"learning_rate_{opt.name}{idx}"] = float(
+                    backend.convert_to_numpy(opt.learning_rate)
+                )
+        else:
+            logs["learning_rate"] = float(
+                backend.convert_to_numpy(self.model.optimizer.learning_rate)
+            )

--- a/keras/src/callbacks/learning_rate_scheduler.py
+++ b/keras/src/callbacks/learning_rate_scheduler.py
@@ -74,11 +74,11 @@ class LearningRateScheduler(Callback):
         if hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
                 learning_rate = self._update_optimizer_lr(opt, epoch)
-            if self.verbose > 0:
-                io_utils.print_msg(
-                    f"\nEpoch {epoch + 1}: LearningRateScheduler setting "
-                    f"{opt.name}{idx} learning rate to {learning_rate}."
-                )
+                if self.verbose > 0:
+                    io_utils.print_msg(
+                        f"\nEpoch {epoch + 1}: LearningRateScheduler setting "
+                        f"{opt.name}{idx} learning rate to {learning_rate}."
+                    )
         else:
             learning_rate = self._update_optimizer_lr(
                 self.model.optimizer, epoch

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -77,6 +77,21 @@ class ReduceLROnPlateau(MonitorCallback):
         self.cooldown_counter = 0
         self.wait = 0
 
+    def _reduce_optimizer_lr(self, optimizer, epoch, name_suffix=""):
+        old_lr = float(backend.convert_to_numpy(optimizer.learning_rate))
+        if old_lr > np.float32(self.min_lr):
+            new_lr = old_lr * self.factor
+            new_lr = max(new_lr, self.min_lr)
+            optimizer.learning_rate = new_lr
+            if self.verbose > 0:
+                name_str = f" {name_suffix}" if name_suffix else ""
+                io_utils.print_msg(
+                    f"\nEpoch {epoch + 1}: ReduceLROnPlateau reducing"
+                    f"{name_str} learning rate to {new_lr}."
+                )
+            return True
+        return False
+
     def on_train_begin(self, logs=None):
         self._reset()
 
@@ -114,44 +129,24 @@ class ReduceLROnPlateau(MonitorCallback):
             elif not self.in_cooldown():
                 self.wait += 1
                 if self.wait >= self.patience:
+                    reduced = False
                     if hasattr(self.model.optimizer, "optimizers"):
                         for idx, opt in enumerate(
                             self.model.optimizer.optimizers
                         ):
-                            old_lr = float(
-                                backend.convert_to_numpy(opt.learning_rate)
-                            )
-                            if old_lr > np.float32(self.min_lr):
-                                new_lr = old_lr * self.factor
-                                new_lr = max(new_lr, self.min_lr)
-                                opt.learning_rate = new_lr
-                                if self.verbose > 0:
-                                    io_utils.print_msg(
-                                        f"\nEpoch {epoch + 1}: "
-                                        "ReduceLROnPlateau reducing "
-                                        f"{opt.name}{idx} learning rate "
-                                        f"to {new_lr}."
-                                    )
-                                self.cooldown_counter = self.cooldown
-                                self.wait = 0
+                            if self._reduce_optimizer_lr(
+                                opt, epoch, f"{opt.name}{idx}"
+                            ):
+                                reduced = True
                     else:
-                        old_lr = float(
-                            backend.convert_to_numpy(
-                                self.model.optimizer.learning_rate
-                            )
-                        )
-                        if old_lr > np.float32(self.min_lr):
-                            new_lr = old_lr * self.factor
-                            new_lr = max(new_lr, self.min_lr)
-                            self.model.optimizer.learning_rate = new_lr
-                            if self.verbose > 0:
-                                io_utils.print_msg(
-                                    f"\nEpoch {epoch + 1}: "
-                                    "ReduceLROnPlateau reducing "
-                                    f"learning rate to {new_lr}."
-                                )
-                            self.cooldown_counter = self.cooldown
-                            self.wait = 0
+                        if self._reduce_optimizer_lr(
+                            self.model.optimizer, epoch
+                        ):
+                            reduced = True
+
+                    if reduced:
+                        self.cooldown_counter = self.cooldown
+                        self.wait = 0
 
     def in_cooldown(self):
         return self.cooldown_counter > 0

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -77,17 +77,16 @@ class ReduceLROnPlateau(MonitorCallback):
         self.cooldown_counter = 0
         self.wait = 0
 
-    def _reduce_optimizer_lr(self, optimizer, epoch, name_suffix=""):
+    def _reduce_optimizer_lr(self, optimizer, epoch, name=""):
         old_lr = float(backend.convert_to_numpy(optimizer.learning_rate))
         if old_lr > np.float32(self.min_lr):
             new_lr = old_lr * self.factor
             new_lr = max(new_lr, self.min_lr)
             optimizer.learning_rate = new_lr
             if self.verbose > 0:
-                name_str = f" {name_suffix}" if name_suffix else ""
                 io_utils.print_msg(
-                    f"\nEpoch {epoch + 1}: ReduceLROnPlateau reducing"
-                    f"{name_str} learning rate to {new_lr}."
+                    f"\nEpoch {epoch + 1}: ReduceLROnPlateau reducing "
+                    f"{name} learning rate to {new_lr}."
                 )
             return True
         return False
@@ -102,7 +101,7 @@ class ReduceLROnPlateau(MonitorCallback):
         logs = logs or {}
         if hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
-                logs[f"learning_rate_{opt.name}_{idx}"] = float(
+                logs[f"learning_rate_{opt.name}"] = float(
                     backend.convert_to_numpy(opt.learning_rate)
                 )
         else:
@@ -135,7 +134,7 @@ class ReduceLROnPlateau(MonitorCallback):
                             self.model.optimizer.optimizers
                         ):
                             if self._reduce_optimizer_lr(
-                                opt, epoch, f"{opt.name}_{idx}"
+                                opt, epoch, f"{opt.name}"
                             ):
                                 reduced = True
                     else:

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -84,9 +84,10 @@ class ReduceLROnPlateau(MonitorCallback):
             new_lr = max(new_lr, self.min_lr)
             optimizer.learning_rate = new_lr
             if self.verbose > 0:
+                name_str = f" {name}" if name else ""
                 io_utils.print_msg(
-                    f"\nEpoch {epoch + 1}: ReduceLROnPlateau reducing "
-                    f"{name} learning rate to {new_lr}."
+                    f"\nEpoch {epoch + 1}: ReduceLROnPlateau reducing"
+                    f"{name_str} learning rate to {new_lr}."
                 )
             return True
         return False

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 from keras.src import backend
+from keras.src import optimizers
 from keras.src.api_export import keras_export
 from keras.src.callbacks.monitor_callback import MonitorCallback
 from keras.src.utils import io_utils
@@ -100,7 +101,9 @@ class ReduceLROnPlateau(MonitorCallback):
             # Delay setup until the model's metrics are all built
             self._set_monitor_op()
         logs = logs or {}
-        if hasattr(self.model.optimizer, "optimizers"):
+        if isinstance(
+            self.model.optimizer, optimizers.MultiOptimizer
+        ) and hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
                 logs[f"learning_rate_{opt.name}{idx}"] = float(
                     backend.convert_to_numpy(opt.learning_rate)
@@ -130,7 +133,9 @@ class ReduceLROnPlateau(MonitorCallback):
                 self.wait += 1
                 if self.wait >= self.patience:
                     reduced = False
-                    if hasattr(self.model.optimizer, "optimizers"):
+                    if isinstance(
+                        self.model.optimizer, optimizers.MultiOptimizer
+                    ) and hasattr(self.model.optimizer, "optimizers"):
                         for idx, opt in enumerate(
                             self.model.optimizer.optimizers
                         ):

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -3,7 +3,6 @@ import warnings
 import numpy as np
 
 from keras.src import backend
-from keras.src import optimizers
 from keras.src.api_export import keras_export
 from keras.src.callbacks.monitor_callback import MonitorCallback
 from keras.src.utils import io_utils
@@ -101,11 +100,9 @@ class ReduceLROnPlateau(MonitorCallback):
             # Delay setup until the model's metrics are all built
             self._set_monitor_op()
         logs = logs or {}
-        if isinstance(
-            self.model.optimizer, optimizers.MultiOptimizer
-        ) and hasattr(self.model.optimizer, "optimizers"):
+        if hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
-                logs[f"learning_rate_{opt.name}{idx}"] = float(
+                logs[f"learning_rate_{opt.name}_{idx}"] = float(
                     backend.convert_to_numpy(opt.learning_rate)
                 )
         else:
@@ -133,14 +130,12 @@ class ReduceLROnPlateau(MonitorCallback):
                 self.wait += 1
                 if self.wait >= self.patience:
                     reduced = False
-                    if isinstance(
-                        self.model.optimizer, optimizers.MultiOptimizer
-                    ) and hasattr(self.model.optimizer, "optimizers"):
+                    if hasattr(self.model.optimizer, "optimizers"):
                         for idx, opt in enumerate(
                             self.model.optimizer.optimizers
                         ):
                             if self._reduce_optimizer_lr(
-                                opt, epoch, f"{opt.name}{idx}"
+                                opt, epoch, f"{opt.name}_{idx}"
                             ):
                                 reduced = True
                     else:

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -85,9 +85,15 @@ class ReduceLROnPlateau(MonitorCallback):
             # Delay setup until the model's metrics are all built
             self._set_monitor_op()
         logs = logs or {}
-        logs["learning_rate"] = float(
-            backend.convert_to_numpy(self.model.optimizer.learning_rate)
-        )
+        if hasattr(self.model.optimizer, "optimizers"):
+            for idx, opt in enumerate(self.model.optimizer.optimizers):
+                logs[f"learning_rate_{opt.name}{idx}"] = float(
+                    backend.convert_to_numpy(opt.learning_rate)
+                )
+        else:
+            logs["learning_rate"] = float(
+                backend.convert_to_numpy(self.model.optimizer.learning_rate)
+            )
         current = logs.get(self.monitor)
 
         if current is None:
@@ -108,23 +114,44 @@ class ReduceLROnPlateau(MonitorCallback):
             elif not self.in_cooldown():
                 self.wait += 1
                 if self.wait >= self.patience:
-                    old_lr = float(
-                        backend.convert_to_numpy(
-                            self.model.optimizer.learning_rate
-                        )
-                    )
-                    if old_lr > np.float32(self.min_lr):
-                        new_lr = old_lr * self.factor
-                        new_lr = max(new_lr, self.min_lr)
-                        self.model.optimizer.learning_rate = new_lr
-                        if self.verbose > 0:
-                            io_utils.print_msg(
-                                f"\nEpoch {epoch + 1}: "
-                                "ReduceLROnPlateau reducing "
-                                f"learning rate to {new_lr}."
+                    if hasattr(self.model.optimizer, "optimizers"):
+                        for idx, opt in enumerate(
+                            self.model.optimizer.optimizers
+                        ):
+                            old_lr = float(
+                                backend.convert_to_numpy(opt.learning_rate)
                             )
-                        self.cooldown_counter = self.cooldown
-                        self.wait = 0
+                            if old_lr > np.float32(self.min_lr):
+                                new_lr = old_lr * self.factor
+                                new_lr = max(new_lr, self.min_lr)
+                                opt.learning_rate = new_lr
+                                if self.verbose > 0:
+                                    io_utils.print_msg(
+                                        f"\nEpoch {epoch + 1}: "
+                                        "ReduceLROnPlateau reducing "
+                                        f"{opt.name}{idx} learning rate "
+                                        f"to {new_lr}."
+                                    )
+                                self.cooldown_counter = self.cooldown
+                                self.wait = 0
+                    else:
+                        old_lr = float(
+                            backend.convert_to_numpy(
+                                self.model.optimizer.learning_rate
+                            )
+                        )
+                        if old_lr > np.float32(self.min_lr):
+                            new_lr = old_lr * self.factor
+                            new_lr = max(new_lr, self.min_lr)
+                            self.model.optimizer.learning_rate = new_lr
+                            if self.verbose > 0:
+                                io_utils.print_msg(
+                                    f"\nEpoch {epoch + 1}: "
+                                    "ReduceLROnPlateau reducing "
+                                    f"learning rate to {new_lr}."
+                                )
+                            self.cooldown_counter = self.cooldown
+                            self.wait = 0
 
     def in_cooldown(self):
         return self.cooldown_counter > 0

--- a/keras/src/callbacks/swap_ema_weights.py
+++ b/keras/src/callbacks/swap_ema_weights.py
@@ -1,5 +1,6 @@
 from keras.src import backend
 from keras.src import ops
+from keras.src import optimizers
 from keras.src.api_export import keras_export
 from keras.src.callbacks.callback import Callback
 
@@ -52,7 +53,8 @@ class SwapEMAWeights(Callback):
 
         self._ema_weights_in_model = False
 
-    def _tf_swap_variables(self, variables, optimizer):
+    def _tf_swap_variables(self, optimizer):
+        variables = optimizer._trainable_variables
         for var, average_var in zip(
             variables,
             optimizer._model_variables_moving_average,
@@ -78,7 +80,8 @@ class SwapEMAWeights(Callback):
                 args=(average_var,),
             )
 
-    def _backend_swap_variables(self, variables, optimizer):
+    def _backend_swap_variables(self, optimizer):
+        variables = optimizer._trainable_variables
         for var, average_var in zip(
             variables,
             optimizer._model_variables_moving_average,
@@ -87,7 +90,8 @@ class SwapEMAWeights(Callback):
             var.assign(average_var)
             average_var.assign(temporary_variable)
 
-    def _tf_finalize_ema_values(self, variables, optimizer):
+    def _tf_finalize_ema_values(self, optimizer):
+        variables = optimizer._trainable_variables
         for var, average_var in zip(
             variables,
             optimizer._model_variables_moving_average,
@@ -102,7 +106,8 @@ class SwapEMAWeights(Callback):
                 args=(var,),
             )
 
-    def _backend_finalize_ema_values(self, variables, optimizer):
+    def _backend_finalize_ema_values(self, optimizer):
+        variables = optimizer._trainable_variables
         for var, average_var in zip(
             variables,
             optimizer._model_variables_moving_average,
@@ -116,7 +121,9 @@ class SwapEMAWeights(Callback):
         else:
             optimizer = self.model.optimizer
 
-        if hasattr(optimizer, "optimizers"):
+        if isinstance(optimizer, optimizers.MultiOptimizer) and hasattr(
+            optimizer, "optimizers"
+        ):
             has_ema = any(
                 getattr(opt, "use_ema", False) for opt in optimizer.optimizers
             )
@@ -135,11 +142,10 @@ class SwapEMAWeights(Callback):
                             "`use_ema=True` is set on the optimizer. "
                             f"Received: use_ema={opt.use_ema}"
                         )
-                    vars_to_swap = opt._trainable_variables
                     if backend.backend() == "tensorflow":
-                        self._tf_swap_variables(vars_to_swap, opt)
+                        self._tf_swap_variables(opt)
                     else:
-                        self._backend_swap_variables(vars_to_swap, opt)
+                        self._backend_swap_variables(opt)
         else:
             if not hasattr(optimizer, "_model_variables_moving_average"):
                 raise ValueError(
@@ -147,11 +153,10 @@ class SwapEMAWeights(Callback):
                     "`use_ema=True` is set on the optimizer. "
                     f"Received: use_ema={optimizer.use_ema}"
                 )
-            vars_to_swap = self.model.trainable_variables
             if backend.backend() == "tensorflow":
-                self._tf_swap_variables(vars_to_swap, optimizer)
+                self._tf_swap_variables(optimizer)
             else:
-                self._backend_swap_variables(vars_to_swap, optimizer)
+                self._backend_swap_variables(optimizer)
 
     def _finalize_ema_values(self):
         if hasattr(self.model.optimizer, "inner_optimizer"):
@@ -160,7 +165,9 @@ class SwapEMAWeights(Callback):
         else:
             optimizer = self.model.optimizer
 
-        if hasattr(optimizer, "optimizers"):
+        if isinstance(optimizer, optimizers.MultiOptimizer) and hasattr(
+            optimizer, "optimizers"
+        ):
             has_ema = any(
                 getattr(opt, "use_ema", False) for opt in optimizer.optimizers
             )
@@ -179,11 +186,10 @@ class SwapEMAWeights(Callback):
                             "`use_ema=True` is set on the optimizer. "
                             f"Received: use_ema={opt.use_ema}"
                         )
-                    vars_to_finalize = opt._trainable_variables
                     if backend.backend() == "tensorflow":
-                        self._tf_finalize_ema_values(vars_to_finalize, opt)
+                        self._tf_finalize_ema_values(opt)
                     else:
-                        self._backend_finalize_ema_values(vars_to_finalize, opt)
+                        self._backend_finalize_ema_values(opt)
         else:
             if not hasattr(optimizer, "_model_variables_moving_average"):
                 raise ValueError(
@@ -191,11 +197,10 @@ class SwapEMAWeights(Callback):
                     "`use_ema=True` is set on the optimizer. "
                     f"Received: use_ema={optimizer.use_ema}"
                 )
-            vars_to_finalize = self.model.trainable_variables
             if backend.backend() == "tensorflow":
-                self._tf_finalize_ema_values(vars_to_finalize, optimizer)
+                self._tf_finalize_ema_values(optimizer)
             else:
-                self._backend_finalize_ema_values(vars_to_finalize, optimizer)
+                self._backend_finalize_ema_values(optimizer)
 
     def on_epoch_begin(self, epoch, logs=None):
         if self.swap_on_epoch and self._ema_weights_in_model:

--- a/keras/src/callbacks/swap_ema_weights.py
+++ b/keras/src/callbacks/swap_ema_weights.py
@@ -52,9 +52,9 @@ class SwapEMAWeights(Callback):
 
         self._ema_weights_in_model = False
 
-    def _tf_swap_variables(self, optimizer):
+    def _tf_swap_variables(self, variables, optimizer):
         for var, average_var in zip(
-            self.model.trainable_variables,
+            variables,
             optimizer._model_variables_moving_average,
         ):
             if isinstance(var, backend.Variable):
@@ -78,18 +78,18 @@ class SwapEMAWeights(Callback):
                 args=(average_var,),
             )
 
-    def _backend_swap_variables(self, optimizer):
+    def _backend_swap_variables(self, variables, optimizer):
         for var, average_var in zip(
-            self.model.trainable_variables,
+            variables,
             optimizer._model_variables_moving_average,
         ):
             temporary_variable = ops.convert_to_numpy(var)
             var.assign(average_var)
             average_var.assign(temporary_variable)
 
-    def _tf_finalize_ema_values(self, optimizer):
+    def _tf_finalize_ema_values(self, variables, optimizer):
         for var, average_var in zip(
-            self.model.trainable_variables,
+            variables,
             optimizer._model_variables_moving_average,
         ):
             if isinstance(var, backend.Variable):
@@ -102,9 +102,9 @@ class SwapEMAWeights(Callback):
                 args=(var,),
             )
 
-    def _backend_finalize_ema_values(self, optimizer):
+    def _backend_finalize_ema_values(self, variables, optimizer):
         for var, average_var in zip(
-            self.model.trainable_variables,
+            variables,
             optimizer._model_variables_moving_average,
         ):
             average_var.assign(var)
@@ -115,16 +115,43 @@ class SwapEMAWeights(Callback):
             optimizer = self.model.optimizer.inner_optimizer
         else:
             optimizer = self.model.optimizer
-        if not hasattr(optimizer, "_model_variables_moving_average"):
-            raise ValueError(
-                "SwapEMAWeights must be used when "
-                "`use_ema=True` is set on the optimizer. "
-                f"Received: use_ema={optimizer.use_ema}"
+
+        if hasattr(optimizer, "optimizers"):
+            has_ema = any(
+                getattr(opt, "use_ema", False) for opt in optimizer.optimizers
             )
-        if backend.backend() == "tensorflow":
-            self._tf_swap_variables(optimizer)
+            if not has_ema:
+                raise ValueError(
+                    "SwapEMAWeights must be used when at least one inner "
+                    "optimizer has `use_ema=True` set. Received a "
+                    "MultiOptimizer with all inner optimizers having "
+                    "`use_ema=False`."
+                )
+            for opt in optimizer.optimizers:
+                if getattr(opt, "use_ema", False):
+                    if not hasattr(opt, "_model_variables_moving_average"):
+                        raise ValueError(
+                            "SwapEMAWeights must be used when "
+                            "`use_ema=True` is set on the optimizer. "
+                            f"Received: use_ema={opt.use_ema}"
+                        )
+                    vars_to_swap = opt._trainable_variables
+                    if backend.backend() == "tensorflow":
+                        self._tf_swap_variables(vars_to_swap, opt)
+                    else:
+                        self._backend_swap_variables(vars_to_swap, opt)
         else:
-            self._backend_swap_variables(optimizer)
+            if not hasattr(optimizer, "_model_variables_moving_average"):
+                raise ValueError(
+                    "SwapEMAWeights must be used when "
+                    "`use_ema=True` is set on the optimizer. "
+                    f"Received: use_ema={optimizer.use_ema}"
+                )
+            vars_to_swap = self.model.trainable_variables
+            if backend.backend() == "tensorflow":
+                self._tf_swap_variables(vars_to_swap, optimizer)
+            else:
+                self._backend_swap_variables(vars_to_swap, optimizer)
 
     def _finalize_ema_values(self):
         if hasattr(self.model.optimizer, "inner_optimizer"):
@@ -132,16 +159,43 @@ class SwapEMAWeights(Callback):
             optimizer = self.model.optimizer.inner_optimizer
         else:
             optimizer = self.model.optimizer
-        if not hasattr(optimizer, "_model_variables_moving_average"):
-            raise ValueError(
-                "SwapEMAWeights must be used when "
-                "`use_ema=True` is set on the optimizer. "
-                f"Received: use_ema={optimizer.use_ema}"
+
+        if hasattr(optimizer, "optimizers"):
+            has_ema = any(
+                getattr(opt, "use_ema", False) for opt in optimizer.optimizers
             )
-        if backend.backend() == "tensorflow":
-            self._tf_finalize_ema_values(optimizer)
+            if not has_ema:
+                raise ValueError(
+                    "SwapEMAWeights must be used when at least one inner "
+                    "optimizer has `use_ema=True` set. Received a "
+                    "MultiOptimizer with all inner optimizers having "
+                    "`use_ema=False`."
+                )
+            for opt in optimizer.optimizers:
+                if getattr(opt, "use_ema", False):
+                    if not hasattr(opt, "_model_variables_moving_average"):
+                        raise ValueError(
+                            "SwapEMAWeights must be used when "
+                            "`use_ema=True` is set on the optimizer. "
+                            f"Received: use_ema={opt.use_ema}"
+                        )
+                    vars_to_finalize = opt._trainable_variables
+                    if backend.backend() == "tensorflow":
+                        self._tf_finalize_ema_values(vars_to_finalize, opt)
+                    else:
+                        self._backend_finalize_ema_values(vars_to_finalize, opt)
         else:
-            self._backend_finalize_ema_values(optimizer)
+            if not hasattr(optimizer, "_model_variables_moving_average"):
+                raise ValueError(
+                    "SwapEMAWeights must be used when "
+                    "`use_ema=True` is set on the optimizer. "
+                    f"Received: use_ema={optimizer.use_ema}"
+                )
+            vars_to_finalize = self.model.trainable_variables
+            if backend.backend() == "tensorflow":
+                self._tf_finalize_ema_values(vars_to_finalize, optimizer)
+            else:
+                self._backend_finalize_ema_values(vars_to_finalize, optimizer)
 
     def on_epoch_begin(self, epoch, logs=None):
         if self.swap_on_epoch and self._ema_weights_in_model:

--- a/keras/src/callbacks/swap_ema_weights.py
+++ b/keras/src/callbacks/swap_ema_weights.py
@@ -1,6 +1,5 @@
 from keras.src import backend
 from keras.src import ops
-from keras.src import optimizers
 from keras.src.api_export import keras_export
 from keras.src.callbacks.callback import Callback
 
@@ -114,16 +113,14 @@ class SwapEMAWeights(Callback):
         ):
             average_var.assign(var)
 
-    def _swap_variables(self):
+    def _apply_to_ema_optimizers(self, tf_fn, backend_fn):
         if hasattr(self.model.optimizer, "inner_optimizer"):
             # LossScaleOptimizer
             optimizer = self.model.optimizer.inner_optimizer
         else:
             optimizer = self.model.optimizer
 
-        if isinstance(optimizer, optimizers.MultiOptimizer) and hasattr(
-            optimizer, "optimizers"
-        ):
+        if hasattr(optimizer, "optimizers"):
             has_ema = any(
                 getattr(opt, "use_ema", False) for opt in optimizer.optimizers
             )
@@ -143,9 +140,9 @@ class SwapEMAWeights(Callback):
                             f"Received: use_ema={opt.use_ema}"
                         )
                     if backend.backend() == "tensorflow":
-                        self._tf_swap_variables(opt)
+                        tf_fn(opt)
                     else:
-                        self._backend_swap_variables(opt)
+                        backend_fn(opt)
         else:
             if not hasattr(optimizer, "_model_variables_moving_average"):
                 raise ValueError(
@@ -154,53 +151,19 @@ class SwapEMAWeights(Callback):
                     f"Received: use_ema={optimizer.use_ema}"
                 )
             if backend.backend() == "tensorflow":
-                self._tf_swap_variables(optimizer)
+                tf_fn(optimizer)
             else:
-                self._backend_swap_variables(optimizer)
+                backend_fn(optimizer)
+
+    def _swap_variables(self):
+        self._apply_to_ema_optimizers(
+            self._tf_swap_variables, self._backend_swap_variables
+        )
 
     def _finalize_ema_values(self):
-        if hasattr(self.model.optimizer, "inner_optimizer"):
-            # LossScaleOptimizer
-            optimizer = self.model.optimizer.inner_optimizer
-        else:
-            optimizer = self.model.optimizer
-
-        if isinstance(optimizer, optimizers.MultiOptimizer) and hasattr(
-            optimizer, "optimizers"
-        ):
-            has_ema = any(
-                getattr(opt, "use_ema", False) for opt in optimizer.optimizers
-            )
-            if not has_ema:
-                raise ValueError(
-                    "SwapEMAWeights must be used when at least one inner "
-                    "optimizer has `use_ema=True` set. Received a "
-                    "MultiOptimizer with all inner optimizers having "
-                    "`use_ema=False`."
-                )
-            for opt in optimizer.optimizers:
-                if getattr(opt, "use_ema", False):
-                    if not hasattr(opt, "_model_variables_moving_average"):
-                        raise ValueError(
-                            "SwapEMAWeights must be used when "
-                            "`use_ema=True` is set on the optimizer. "
-                            f"Received: use_ema={opt.use_ema}"
-                        )
-                    if backend.backend() == "tensorflow":
-                        self._tf_finalize_ema_values(opt)
-                    else:
-                        self._backend_finalize_ema_values(opt)
-        else:
-            if not hasattr(optimizer, "_model_variables_moving_average"):
-                raise ValueError(
-                    "SwapEMAWeights must be used when "
-                    "`use_ema=True` is set on the optimizer. "
-                    f"Received: use_ema={optimizer.use_ema}"
-                )
-            if backend.backend() == "tensorflow":
-                self._tf_finalize_ema_values(optimizer)
-            else:
-                self._backend_finalize_ema_values(optimizer)
+        self._apply_to_ema_optimizers(
+            self._tf_finalize_ema_values, self._backend_finalize_ema_values
+        )
 
     def on_epoch_begin(self, epoch, logs=None):
         if self.swap_on_epoch and self._ema_weights_in_model:

--- a/keras/src/callbacks/tensorboard.py
+++ b/keras/src/callbacks/tensorboard.py
@@ -512,7 +512,7 @@ class TensorBoard(Callback):
     def _collect_learning_rate(self, logs):
         if hasattr(self.model.optimizer, "optimizers"):
             for idx, opt in enumerate(self.model.optimizer.optimizers):
-                logs[f"learning_rate_{opt.name}{idx}"] = float(
+                logs[f"learning_rate_{opt.name}_{idx}"] = float(
                     ops.convert_to_numpy(opt.learning_rate)
                 )
         elif isinstance(self.model.optimizer, Optimizer):

--- a/keras/src/callbacks/tensorboard.py
+++ b/keras/src/callbacks/tensorboard.py
@@ -517,7 +517,7 @@ class TensorBoard(Callback):
 
         if hasattr(optimizer, "optimizers"):
             for idx, opt in enumerate(optimizer.optimizers):
-                logs[f"learning_rate_{opt.name}_{idx}"] = float(
+                logs[f"learning_rate_{opt.name}"] = float(
                     ops.convert_to_numpy(opt.learning_rate)
                 )
         elif isinstance(optimizer, Optimizer):

--- a/keras/src/callbacks/tensorboard.py
+++ b/keras/src/callbacks/tensorboard.py
@@ -510,7 +510,12 @@ class TensorBoard(Callback):
         self._is_tracing = False
 
     def _collect_learning_rate(self, logs):
-        if isinstance(self.model.optimizer, Optimizer):
+        if hasattr(self.model.optimizer, "optimizers"):
+            for idx, opt in enumerate(self.model.optimizer.optimizers):
+                logs[f"learning_rate_{opt.name}{idx}"] = float(
+                    ops.convert_to_numpy(opt.learning_rate)
+                )
+        elif isinstance(self.model.optimizer, Optimizer):
             logs["learning_rate"] = float(
                 ops.convert_to_numpy(self.model.optimizer.learning_rate)
             )

--- a/keras/src/callbacks/tensorboard.py
+++ b/keras/src/callbacks/tensorboard.py
@@ -510,14 +510,19 @@ class TensorBoard(Callback):
         self._is_tracing = False
 
     def _collect_learning_rate(self, logs):
-        if hasattr(self.model.optimizer, "optimizers"):
-            for idx, opt in enumerate(self.model.optimizer.optimizers):
+        optimizer = self.model.optimizer
+        # Handles the case when the optimizer is wrapped by LossScaleOptimizer
+        if hasattr(optimizer, "inner_optimizer"):
+            optimizer = optimizer.inner_optimizer
+
+        if hasattr(optimizer, "optimizers"):
+            for idx, opt in enumerate(optimizer.optimizers):
                 logs[f"learning_rate_{opt.name}_{idx}"] = float(
                     ops.convert_to_numpy(opt.learning_rate)
                 )
-        elif isinstance(self.model.optimizer, Optimizer):
+        elif isinstance(optimizer, Optimizer):
             logs["learning_rate"] = float(
-                ops.convert_to_numpy(self.model.optimizer.learning_rate)
+                ops.convert_to_numpy(optimizer.learning_rate)
             )
         return logs
 

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import MutableMapping
 
 from keras.src.api_export import keras_export
+from keras.src.optimizers.loss_scale_optimizer import LossScaleOptimizer
 from keras.src.optimizers.optimizer import Optimizer
 from keras.src.saving import serialization_lib
 
@@ -117,10 +118,10 @@ class OptimizerMap(MutableMapping):
                 f"optimizer must be a Keras Optimizer instance. "
                 f"Received: {optimizer}"
             )
+        if isinstance(optimizer, LossScaleOptimizer):
+            raise ValueError("optimizer cannot be LossScaleOptimizer.")
         if isinstance(optimizer, MultiOptimizer):
-            raise ValueError(
-                "MultiOptimizer cannot be nested inside an OptimizerMap."
-            )
+            raise ValueError("optimizer cannot be MultiOptimizer.")
         self._optimizer_map[key] = optimizer
 
     def __delitem__(self, key):
@@ -257,6 +258,15 @@ class MultiOptimizer(Optimizer):
                     f"Optimizer for variable {var} is not "
                     "an Optimizer instance."
                 )
+            if isinstance(opt, LossScaleOptimizer):
+                raise ValueError(
+                    "LossScaleOptimizer cannot be used inside an "
+                    "MultiOptimizer."
+                )
+            if isinstance(opt, MultiOptimizer):
+                raise ValueError(
+                    "MultiOptimizer cannot be nested inside an MultiOptimizer."
+                )
             if opt not in self._inner_optimizers:
                 opt.loss_scale_factor = self.loss_scale_factor
                 self._inner_optimizers.append(opt)
@@ -299,6 +309,17 @@ class MultiOptimizer(Optimizer):
             "Learning rate cannot be set on a MultiOptimizer. "
             "Set the learning rate on the individual sub-optimizers instead."
         )
+
+    @property
+    def loss_scale_factor(self):
+        return getattr(self, "_loss_scale_factor", None)
+
+    @loss_scale_factor.setter
+    def loss_scale_factor(self, value):
+        self._loss_scale_factor = value
+        if hasattr(self, "_inner_optimizers"):
+            for opt in self._inner_optimizers:
+                opt.loss_scale_factor = value
 
     @property
     def iterations(self):

--- a/keras/src/optimizers/multi_optimizer.py
+++ b/keras/src/optimizers/multi_optimizer.py
@@ -265,7 +265,7 @@ class MultiOptimizer(Optimizer):
                 )
             if isinstance(opt, MultiOptimizer):
                 raise ValueError(
-                    "MultiOptimizer cannot be nested inside an MultiOptimizer."
+                    "MultiOptimizer cannot be used inside an MultiOptimizer."
                 )
             if opt not in self._inner_optimizers:
                 opt.loss_scale_factor = self.loss_scale_factor

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -439,9 +439,10 @@ class MultiOptimizerTest(testing.TestCase):
         """
         import tempfile
 
-        opt_1 = optimizers.SGD(learning_rate=0.1, name="sgd")
-        opt_2 = optimizers.SGD(learning_rate=0.01, name="sgd")
-
+        opt_1 = optimizers.SGD(learning_rate=0.1, name="SGD")
+        opt_2 = optimizers.SGD(learning_rate=0.01, name="SGD_1")
+        print(opt_1.name)
+        print(opt_2.name)
         optimizer = optimizers.MultiOptimizer(
             optimizers.OptimizerMap(
                 default_optimizer=opt_2,
@@ -470,10 +471,10 @@ class MultiOptimizerTest(testing.TestCase):
             logs = {}
             updated_logs = tb_callback._collect_learning_rate(logs)
 
-            self.assertIn("learning_rate_sgd_0", updated_logs)
-            self.assertIn("learning_rate_sgd_1", updated_logs)
-            self.assertAllClose(updated_logs["learning_rate_sgd_0"], 0.1)
-            self.assertAllClose(updated_logs["learning_rate_sgd_1"], 0.01)
+            self.assertIn("learning_rate_SGD", updated_logs)
+            self.assertIn("learning_rate_SGD_1", updated_logs)
+            self.assertAllClose(updated_logs["learning_rate_SGD"], 0.1)
+            self.assertAllClose(updated_logs["learning_rate_SGD_1"], 0.01)
 
     @pytest.mark.requires_trainable_backend
     def test_swap_ema_weights_with_multi_optimizer(self):
@@ -633,12 +634,15 @@ class MultiOptimizerTest(testing.TestCase):
         self.assertAllClose(w2.numpy(), [[1.9, 1.9]])
 
     @pytest.mark.requires_trainable_backend
-    def test_multi_optimizer_blocks_inner_loss_scale_optimizer(self):
+    def test_multi_optimizer_blocks_nested_optimizers(self):
         """Verifies MultiOptimizer raises ValueError if
-        inner optimizer is LSO."""
+        inner optimizer is LSO or MultiOptimizer."""
         opt_sgd = optimizers.SGD(learning_rate=0.1)
         # Wrapping inner SGD in LSO
         opt_lso = optimizers.LossScaleOptimizer(opt_sgd)
+
+        # Wrapping inner SGD in MultiOptimizer
+        opt_multi = optimizers.MultiOptimizer(opt_sgd)
 
         # 1. Check error during OptimizerMap setitem
         opt_map = optimizers.OptimizerMap(default_optimizer=opt_sgd)
@@ -647,18 +651,34 @@ class MultiOptimizerTest(testing.TestCase):
         ):
             opt_map[".*"] = opt_lso
 
+        with self.assertRaisesRegex(
+            ValueError, "optimizer cannot be MultiOptimizer."
+        ):
+            opt_map[".*"] = opt_multi
+
         # 2. Check error during build (in case it bypassed
         #  setitem via constructor dict)
         opt_map_direct = optimizers.OptimizerMap(default_optimizer=opt_sgd)
-        opt_map_direct._optimizer_map = {".*dense_1/.*": opt_lso}
+        opt_map_direct._optimizer_map = {
+            ".*dense_1/.*": opt_lso,
+            ".*dense_2/.*": opt_multi,
+        }
 
         multi_opt = optimizers.MultiOptimizer(opt_map_direct)
 
         with backend.name_scope("dense_1"):
-            w = backend.Variable([[1.0]], name="kernel")
+            w1 = backend.Variable([[1.0]], name="kernel")
+        with backend.name_scope("dense_2"):
+            w2 = backend.Variable([[1.0]], name="kernel")
 
         with self.assertRaisesRegex(
             ValueError,
             "LossScaleOptimizer cannot be used inside an MultiOptimizer.",
         ):
-            multi_opt.build([w])
+            multi_opt.build([w1])
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "MultiOptimizer cannot be used inside an MultiOptimizer.",
+        ):
+            multi_opt.build([w2])

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -470,10 +470,10 @@ class MultiOptimizerTest(testing.TestCase):
             logs = {}
             updated_logs = tb_callback._collect_learning_rate(logs)
 
-            self.assertIn("learning_rate_sgd0", updated_logs)
-            self.assertIn("learning_rate_sgd1", updated_logs)
-            self.assertAllClose(updated_logs["learning_rate_sgd0"], 0.1)
-            self.assertAllClose(updated_logs["learning_rate_sgd1"], 0.01)
+            self.assertIn("learning_rate_sgd_0", updated_logs)
+            self.assertIn("learning_rate_sgd_1", updated_logs)
+            self.assertAllClose(updated_logs["learning_rate_sgd_0"], 0.1)
+            self.assertAllClose(updated_logs["learning_rate_sgd_1"], 0.01)
 
     @pytest.mark.requires_trainable_backend
     def test_swap_ema_weights_with_multi_optimizer(self):
@@ -570,3 +570,95 @@ class MultiOptimizerTest(testing.TestCase):
             opt_1._model_variables_moving_average[0]
         )
         self.assertAllClose(opt_1_ema_after, w_dense_1_ema)
+
+    @pytest.mark.requires_trainable_backend
+    def test_multi_optimizer_wrapped_in_loss_scale_optimizer(self):
+        """Verifies wrapping MultiOptimizer inside LossScaleOptimizer works."""
+        opt_1 = optimizers.SGD(learning_rate=0.1)
+        opt_2 = optimizers.SGD(learning_rate=0.1)
+
+        # MultiOptimizer with initial loss scale 5.0
+        multi_opt = optimizers.MultiOptimizer(
+            optimizers.OptimizerMap(
+                default_optimizer=opt_2,
+                optimizer_map={
+                    ".*dense_1/.*": opt_1,
+                },
+            ),
+            loss_scale_factor=5.0,
+        )
+
+        # Wrap in LossScaleOptimizer with dynamic scaling (initial scale 10.0)
+        lso_opt = optimizers.LossScaleOptimizer(
+            multi_opt, initial_scale=10.0, dynamic_growth_steps=1000
+        )
+
+        with backend.name_scope("dense_1"):
+            w1 = backend.Variable([[2.0, 2.0]], name="kernel")
+        with backend.name_scope("dense_2"):
+            w2 = backend.Variable([[2.0, 2.0]], name="kernel")
+
+        lso_opt.build([w1, w2])
+
+        # 1. Verify that LSO set MultiOptimizer.loss_scale_factor to None
+        # and that it successfully propagated to sub-optimizers!
+        self.assertIsNone(multi_opt.loss_scale_factor)
+        self.assertIsNone(opt_1.loss_scale_factor)
+        self.assertIsNone(opt_2.loss_scale_factor)
+
+        # 2. Verify scale_loss uses LSO's dynamic scale (10.0)
+        loss = backend.convert_to_tensor(2.0)
+        self.assertAllClose(lso_opt.scale_loss(loss), 20.0)
+
+        # 3. Verify gradient unscaling and application
+        grads = [
+            backend.convert_to_tensor([[10.0, 10.0]]),  # for w1
+            backend.convert_to_tensor([[10.0, 10.0]]),  # for w2
+        ]
+
+        # Expected unscaled grads: 10.0 / 10.0 = 1.0
+        # Expected updates: 2.0 - lr * 1.0 = 2.0 - 0.1 * 1.0 = 1.9
+        if backend.backend() == "jax":
+            new_trainable, _ = lso_opt.stateless_apply(
+                [v.value for v in lso_opt.variables],
+                grads,
+                [w1.value, w2.value],
+            )
+            w1.assign(new_trainable[0])
+            w2.assign(new_trainable[1])
+        else:
+            lso_opt.apply(grads, [w1, w2])
+
+        self.assertAllClose(w1.numpy(), [[1.9, 1.9]])
+        self.assertAllClose(w2.numpy(), [[1.9, 1.9]])
+
+    @pytest.mark.requires_trainable_backend
+    def test_multi_optimizer_blocks_inner_loss_scale_optimizer(self):
+        """Verifies MultiOptimizer raises ValueError if
+        inner optimizer is LSO."""
+        opt_sgd = optimizers.SGD(learning_rate=0.1)
+        # Wrapping inner SGD in LSO
+        opt_lso = optimizers.LossScaleOptimizer(opt_sgd)
+
+        # 1. Check error during OptimizerMap setitem
+        opt_map = optimizers.OptimizerMap(default_optimizer=opt_sgd)
+        with self.assertRaisesRegex(
+            ValueError, "optimizer cannot be LossScaleOptimizer."
+        ):
+            opt_map[".*"] = opt_lso
+
+        # 2. Check error during build (in case it bypassed
+        #  setitem via constructor dict)
+        opt_map_direct = optimizers.OptimizerMap(default_optimizer=opt_sgd)
+        opt_map_direct._optimizer_map = {".*dense_1/.*": opt_lso}
+
+        multi_opt = optimizers.MultiOptimizer(opt_map_direct)
+
+        with backend.name_scope("dense_1"):
+            w = backend.Variable([[1.0]], name="kernel")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "LossScaleOptimizer cannot be used inside an MultiOptimizer.",
+        ):
+            multi_opt.build([w])

--- a/keras/src/optimizers/multi_optimizer_test.py
+++ b/keras/src/optimizers/multi_optimizer_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from keras.src import backend
+from keras.src import callbacks
 from keras.src import layers
 from keras.src import models
 from keras.src import optimizers
@@ -327,3 +328,245 @@ class MultiOptimizerTest(testing.TestCase):
         # other two optimizer iteration must be 2
         self.assertEqual(int(optimizer.optimizers[0].iterations), 1)
         self.assertEqual(int(optimizer.optimizers[1].iterations), 1)
+
+    @pytest.mark.requires_trainable_backend
+    def test_learning_rate_scheduler_with_multi_optimizer(self):
+        """Verifies LearningRateScheduler with MultiOptimizer.
+
+        This test ensures that when using a MultiOptimizer, the
+        LearningRateScheduler callback correctly updates the learning rate
+        of each individual sub-optimizer according to the schedule. It
+        verifies that non-linear scheduling is correctly applied to each
+        sub-optimizer's unique learning rate.
+        """
+        opt_1 = optimizers.SGD(learning_rate=0.1)
+        opt_2 = optimizers.SGD(learning_rate=0.01)
+
+        optimizer = optimizers.MultiOptimizer(
+            optimizers.OptimizerMap(
+                default_optimizer=opt_2,
+                optimizer_map={
+                    ".*dense_1/.*": opt_1,
+                },
+            )
+        )
+
+        model = models.Sequential(
+            [
+                layers.Dense(
+                    2, kernel_initializer="ones", use_bias=False, name="dense_1"
+                ),
+                layers.Dense(
+                    1, kernel_initializer="ones", use_bias=False, name="dense_2"
+                ),
+            ]
+        )
+        model.compile(loss="mse", optimizer=optimizer)
+
+        def schedule(epoch, lr):
+            return lr * 0.5
+
+        lr_scheduler = callbacks.LearningRateScheduler(schedule)
+        lr_scheduler.set_model(model)
+        lr_scheduler.on_epoch_begin(epoch=1)
+
+        self.assertAllClose(backend.convert_to_numpy(opt_1.learning_rate), 0.05)
+        self.assertAllClose(
+            backend.convert_to_numpy(opt_2.learning_rate), 0.005
+        )
+
+    @pytest.mark.requires_trainable_backend
+    def test_reduce_lr_on_plateau_with_multi_optimizer(self):
+        """Verifies ReduceLROnPlateau with MultiOptimizer.
+
+        This test ensures that when using a MultiOptimizer, the
+        ReduceLROnPlateau callback triggers learning rate reduction on all
+        sub-optimizers. It verifies that the reduction factor is applied to
+        each sub-optimizer's learning rate proportionally, while the state
+        machine (patience, cooldown) is only evaluated once per epoch.
+        """
+        opt_1 = optimizers.SGD(learning_rate=0.1)
+        opt_2 = optimizers.SGD(learning_rate=0.01)
+
+        optimizer = optimizers.MultiOptimizer(
+            optimizers.OptimizerMap(
+                default_optimizer=opt_2,
+                optimizer_map={
+                    ".*dense_1/.*": opt_1,
+                },
+            )
+        )
+
+        model = models.Sequential(
+            [
+                layers.Dense(
+                    2, kernel_initializer="ones", use_bias=False, name="dense_1"
+                ),
+                layers.Dense(
+                    1, kernel_initializer="ones", use_bias=False, name="dense_2"
+                ),
+            ]
+        )
+        model.compile(loss="mse", optimizer=optimizer)
+
+        reduce_lr = callbacks.ReduceLROnPlateau(
+            monitor="val_loss", factor=0.5, patience=1
+        )
+        reduce_lr.set_model(model)
+        reduce_lr.on_train_begin()
+
+        # First epoch: set a baseline val_loss
+        reduce_lr.on_epoch_end(epoch=0, logs={"val_loss": 1.0})
+        self.assertAllClose(backend.convert_to_numpy(opt_1.learning_rate), 0.1)
+        self.assertAllClose(backend.convert_to_numpy(opt_2.learning_rate), 0.01)
+
+        # Second epoch: val_loss does not improve (plateau), exceeds patience=1
+        reduce_lr.on_epoch_end(epoch=1, logs={"val_loss": 1.0})
+        self.assertAllClose(backend.convert_to_numpy(opt_1.learning_rate), 0.05)
+        self.assertAllClose(
+            backend.convert_to_numpy(opt_2.learning_rate), 0.005
+        )
+
+    @pytest.mark.requires_trainable_backend
+    def test_tensorboard_logging_with_multi_optimizer(self):
+        """Verifies TensorBoard learning rate logging with MultiOptimizer.
+
+        This test ensures that the TensorBoard callback correctly collects
+        and logs the learning rate of each sub-optimizer in a MultiOptimizer
+        setup. It verifies that learning rates are logged under unique keys
+        like 'learning_rate_{opt_name}' and that duplicate optimizer names
+        are handled by appending a suffix.
+        """
+        import tempfile
+
+        opt_1 = optimizers.SGD(learning_rate=0.1, name="sgd")
+        opt_2 = optimizers.SGD(learning_rate=0.01, name="sgd")
+
+        optimizer = optimizers.MultiOptimizer(
+            optimizers.OptimizerMap(
+                default_optimizer=opt_2,
+                optimizer_map={
+                    ".*dense_1/.*": opt_1,
+                },
+            )
+        )
+
+        model = models.Sequential(
+            [
+                layers.Dense(
+                    2, kernel_initializer="ones", use_bias=False, name="dense_1"
+                ),
+                layers.Dense(
+                    1, kernel_initializer="ones", use_bias=False, name="dense_2"
+                ),
+            ]
+        )
+        model.compile(loss="mse", optimizer=optimizer)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tb_callback = callbacks.TensorBoard(log_dir=temp_dir)
+            tb_callback.set_model(model)
+
+            logs = {}
+            updated_logs = tb_callback._collect_learning_rate(logs)
+
+            self.assertIn("learning_rate_sgd0", updated_logs)
+            self.assertIn("learning_rate_sgd1", updated_logs)
+            self.assertAllClose(updated_logs["learning_rate_sgd0"], 0.1)
+            self.assertAllClose(updated_logs["learning_rate_sgd1"], 0.01)
+
+    @pytest.mark.requires_trainable_backend
+    def test_swap_ema_weights_with_multi_optimizer(self):
+        """Verifies SwapEMAWeights callback works with MultiOptimizer.
+
+        This test ensures that when SwapEMAWeights is used with
+        a MultiOptimizer, it correctly identifies which sub-optimizers
+        have EMA enabled, and correctly swaps only the sub-variables
+        mapped to those sub-optimizers with their respective EMA weights
+        during evaluation, restoring them afterwards.
+        """
+        opt_1 = optimizers.SGD(
+            learning_rate=0.1, use_ema=True, ema_momentum=0.9
+        )
+        opt_2 = optimizers.SGD(learning_rate=0.1, use_ema=False)
+
+        optimizer = optimizers.MultiOptimizer(
+            optimizers.OptimizerMap(
+                default_optimizer=opt_2,
+                optimizer_map={
+                    ".*dense_1/.*": opt_1,
+                },
+            )
+        )
+
+        model = models.Sequential(
+            [
+                layers.Dense(
+                    2, kernel_initializer="ones", use_bias=False, name="dense_1"
+                ),
+                layers.Dense(
+                    1, kernel_initializer="ones", use_bias=False, name="dense_2"
+                ),
+            ]
+        )
+        model.compile(loss="mse", optimizer=optimizer)
+
+        # Build variables
+        x = np.ones((1, 1)).astype("float32")
+        y = np.ones((1, 1)).astype("float32")
+        model.train_on_batch(x, y)
+
+        # Now manually set model weights to known values
+        w_dense_1_initial = np.array([[2.0, 2.0]], dtype="float32")
+        w_dense_2_initial = np.array([[3.0], [3.0]], dtype="float32")
+
+        model.layers[0].kernel.assign(w_dense_1_initial)
+        model.layers[1].kernel.assign(w_dense_2_initial)
+
+        # Set EMA weights to a different known value
+        w_dense_1_ema = np.array([[9.0, 9.0]], dtype="float32")
+        opt_1._model_variables_moving_average[0].assign(w_dense_1_ema)
+
+        # Track dense_2 weights (should not change because use_ema=False)
+        dense_2_weights_before = backend.convert_to_numpy(
+            model.layers[1].kernel
+        )
+
+        swap_callback = callbacks.SwapEMAWeights()
+        swap_callback.set_model(model)
+
+        # 1. Simulate evaluation start
+        swap_callback.on_test_begin()
+
+        # Assert dense_1 weights are swapped with EMA weights
+        dense_1_weights_during = backend.convert_to_numpy(
+            model.layers[0].kernel
+        )
+        self.assertAllClose(dense_1_weights_during, w_dense_1_ema)
+
+        # Assert opt_1 EMA variable now holds the initial model weights
+        opt_1_ema_during = backend.convert_to_numpy(
+            opt_1._model_variables_moving_average[0]
+        )
+        self.assertAllClose(opt_1_ema_during, w_dense_1_initial)
+
+        # Assert dense_2 weights are NOT swapped
+        dense_2_weights_during = backend.convert_to_numpy(
+            model.layers[1].kernel
+        )
+        self.assertAllClose(dense_2_weights_during, dense_2_weights_before)
+
+        # 2. Simulate evaluation end
+        swap_callback.on_test_end()
+
+        # Assert weights are restored
+        dense_1_weights_after = backend.convert_to_numpy(model.layers[0].kernel)
+        dense_2_weights_after = backend.convert_to_numpy(model.layers[1].kernel)
+        self.assertAllClose(dense_1_weights_after, w_dense_1_initial)
+        self.assertAllClose(dense_2_weights_after, dense_2_weights_before)
+
+        # Assert EMA weights are restored
+        opt_1_ema_after = backend.convert_to_numpy(
+            opt_1._model_variables_moving_average[0]
+        )
+        self.assertAllClose(opt_1_ema_after, w_dense_1_ema)


### PR DESCRIPTION
## Description
`MultiOptimizer` initial implementation did not support dynamic scaling, tracking Exponential Moving Average (EMA) variables, support for standard Keras callbacks (`ReduceLROnPlateau`, `LearningRateScheduler`, `SwapEMAWeights`, and `TensorBoard`). This PR enables MultiOptimizer support for dynamic gradient scaling using existing `LossScaleOptimizer`. It also adds support for Callback Level Dispatching modifying the callback classes themselves to be aware of the composite optimizers.

Added 6 robust test cases in `multi_optimizer_test.py` to test each modification:

- `test_learning_rate_scheduler`:
  - Verifies LearningRateScheduler correctly updates each sub-optimizer with a custom non-linear schedule function.
- `test_reduce_lr_on_plateau`:
  - Verifies ReduceLROnPlateau triggers properly and reduces the learning rates of all sub-optimizers proportionally once patience is exceeded.
- `test_tensorboard_logging`:
  - Verifies TensorBoard correctly collects and logs each sub-optimizer's learning rate as learning_rate_{opt_name} (and handles duplicates gracefully).
- `test_swap_ema_weights`:
  - Verifies SwapEMAWeights successfully swaps model sub-variables with their corresponding EMA weights.
- `test_multi_optimizer_blocks_inner_loss_scale_optimizer`
  - Verfies Verifies MultiOptimizer raises ValueError if inner optimizer is LSO.
- `test_multi_optimizer_wrapped_in_loss_scale_optimizer`
  - Verifies wrapping MultiOptimizer inside LossScaleOptimizer works as expected. 



## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
