### PR TITLE
Validate scalar args in GroupNormalization and MultiHeadAttention

### DIFF
--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -134,6 +134,24 @@ class MultiHeadAttention(Layer):
         seed=None,
         **kwargs,
     ):
+        if not isinstance(num_heads, int) or num_heads <= 0:
+            raise ValueError(
+                "Received an invalid value for argument `num_heads`, "
+                f"expected a positive integer. Received: num_heads={num_heads}"
+            )
+        if not isinstance(key_dim, int) or key_dim <= 0:
+            raise ValueError(
+                "Received an invalid value for argument `key_dim`, expected "
+                f"a positive integer. Received: key_dim={key_dim}"
+            )
+        if value_dim is not None and (
+            not isinstance(value_dim, int) or value_dim <= 0
+        ):
+            raise ValueError(
+                "Received an invalid value for argument `value_dim`, "
+                "expected a positive integer or `None`. Received: "
+                f"value_dim={value_dim}"
+            )
         super().__init__(**kwargs)
         self.supports_masking = True
         self._num_heads = num_heads

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -394,6 +394,17 @@ class MultiHeadAttentionTest(testing.TestCase):
                 np.ones(query_shape), np.ones(value_shape), np.ones(key_shape)
             )
 
+    def test_invalid_scalar_args_rejected(self):
+        for bad in (0, -2, 1.5):
+            with self.assertRaisesRegex(ValueError, "argument `num_heads`"):
+                layers.MultiHeadAttention(num_heads=bad, key_dim=4)
+            with self.assertRaisesRegex(ValueError, "argument `key_dim`"):
+                layers.MultiHeadAttention(num_heads=4, key_dim=bad)
+            with self.assertRaisesRegex(ValueError, "argument `value_dim`"):
+                layers.MultiHeadAttention(num_heads=4, key_dim=4, value_dim=bad)
+        # `value_dim=None` is the documented default (mirror `key_dim`).
+        layers.MultiHeadAttention(num_heads=4, key_dim=4, value_dim=None)
+
     def test_initializer(self):
         # Test with a specified initializer.
         layer = layers.MultiHeadAttention(

--- a/keras/src/layers/normalization/group_normalization.py
+++ b/keras/src/layers/normalization/group_normalization.py
@@ -83,6 +83,12 @@ class GroupNormalization(Layer):
         gamma_constraint=None,
         **kwargs,
     ):
+        if not isinstance(groups, int) or (groups <= 0 and groups != -1):
+            raise ValueError(
+                "Received an invalid value for argument `groups`, expected "
+                "a positive integer (or `-1` for instance normalization). "
+                f"Received: groups={groups}"
+            )
         super().__init__(**kwargs)
         self.supports_masking = True
         self.groups = groups

--- a/keras/src/layers/normalization/group_normalization_test.py
+++ b/keras/src/layers/normalization/group_normalization_test.py
@@ -72,6 +72,13 @@ class GroupNormalizationTest(testing.TestCase):
         ):
             _ = layer(inputs)
 
+    def test_groups_rejects_invalid_values(self):
+        for bad in (0, -2, 1.5, "32"):
+            with self.assertRaisesRegex(ValueError, "argument `groups`"):
+                layers.GroupNormalization(groups=bad)
+        # `-1` is the documented sentinel for instance normalization.
+        layers.GroupNormalization(groups=-1)
+
     def test_groups_instance_norm(self):
         # GroupNormalization with groups=-1 will become InstanceNormalization
         instance_norm_layer_1 = layers.GroupNormalization(


### PR DESCRIPTION
## Description

Fixes #22965.

Two layers accept clearly-invalid scalar arguments without a construction-time error. The user only finds out at build/call time, where the failure surfaces as `ZeroDivisionError` or a backend-specific low-level error — or, worse, the layer silently builds and runs.

Sibling layers (`SimpleRNN`, `LSTM`, `Dense`, `Conv2D`, `Embedding`, …) already validate their own positive-integer args at `__init__`. These two were missed.

### Before

```python
import keras

keras.layers.GroupNormalization(groups=0).build((None, 32))
# ZeroDivisionError: integer modulo by zero

keras.layers.MultiHeadAttention(num_heads=0, key_dim=4)
# silently constructs; eager call later fails with:
#   InvalidArgumentError: Biases must be 1D: [0,4]

keras.layers.MultiHeadAttention(num_heads=4, key_dim=0)
# ZeroDivisionError: float division by zero
```

### After

```
ValueError: Received an invalid value for argument `groups`, expected a positive
integer (or `-1` for instance normalization). Received: groups=0
```

```
ValueError: Received an invalid value for argument `num_heads`, expected a
positive integer. Received: num_heads=0
```

### Scope

Construction-time only — `__init__` runs once per layer, never on the data path. Same pattern as the existing `Dense.units` / `SimpleRNN.units` checks. No hot-path validation added.

Note: `GroupNormalization(groups=-1)` is intentionally allowed — it's the documented sentinel for instance normalization (see line 32 of `group_normalization.py`).

### Implementation

- `keras/src/layers/normalization/group_normalization.py:GroupNormalization.__init__`: reject `groups` unless it's a positive integer or the sentinel `-1`.
- `keras/src/layers/attention/multi_head_attention.py:MultiHeadAttention.__init__`: reject `num_heads`, `key_dim`, and `value_dim` (when not `None`) unless they're positive integers.
- Tests: `test_groups_rejects_invalid_values` (covers `0`, `-2`, `1.5`, `"32"`; confirms `-1` is still accepted) and `test_invalid_scalar_args_rejected` (covers `num_heads`, `key_dim`, `value_dim`; confirms `value_dim=None` still accepted).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.