### PR TITLE
Reset `self.best` in EarlyStopping/ReduceLROnPlateau between fit calls

### DIFF
--- a/keras/src/callbacks/early_stopping.py
+++ b/keras/src/callbacks/early_stopping.py
@@ -85,9 +85,10 @@ class EarlyStopping(MonitorCallback):
         self.start_from_epoch = start_from_epoch
 
     def on_train_begin(self, logs=None):
-        # Allow instances to be re-used
+        # Allow instances to be re-used across `model.fit()` calls.
         self.wait = 0
         self.stopped_epoch = 0
+        self.best = None
         self.best_weights = None
         self.best_epoch = 0
 

--- a/keras/src/callbacks/early_stopping_test.py
+++ b/keras/src/callbacks/early_stopping_test.py
@@ -126,6 +126,31 @@ class EarlyStoppingTest(testing.TestCase):
         )
         self.assertGreaterEqual(len(history2.epoch), patience)
 
+    def test_state_reset_across_fit_calls(self):
+        # `EarlyStopping` is reused across `model.fit()` calls, so
+        # `on_train_begin` must clear all per-run state — otherwise a stale
+        # `self.best` from the previous run causes the new model's first
+        # epoch to be compared against a meaningless best value and
+        # training stops prematurely. See
+        # https://github.com/keras-team/keras/issues/20256.
+        stopper = callbacks.EarlyStopping(monitor="loss", patience=3)
+        stopper.set_model(models.Sequential())
+        stopper.on_train_begin()
+        # Drive some state from a first run.
+        stopper.best = 0.1
+        stopper.wait = 3
+        stopper.stopped_epoch = 5
+        stopper.best_epoch = 5
+        stopper.best_weights = object()
+        # New `model.fit()` -> `on_train_begin` should clear all per-run
+        # state.
+        stopper.on_train_begin()
+        self.assertIsNone(stopper.best)
+        self.assertEqual(stopper.wait, 0)
+        self.assertEqual(stopper.stopped_epoch, 0)
+        self.assertEqual(stopper.best_epoch, 0)
+        self.assertIsNone(stopper.best_weights)
+
     @pytest.mark.requires_trainable_backend
     def test_early_stopping_with_baseline(self):
         baseline = 0.6

--- a/keras/src/callbacks/reduce_lr_on_plateau.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau.py
@@ -73,7 +73,8 @@ class ReduceLROnPlateau(MonitorCallback):
         self.wait = 0
 
     def _reset(self):
-        """Resets wait counter and cooldown counter."""
+        """Resets wait counter, cooldown counter, and best value."""
+        self.best = None
         self.cooldown_counter = 0
         self.wait = 0
 

--- a/keras/src/callbacks/reduce_lr_on_plateau_test.py
+++ b/keras/src/callbacks/reduce_lr_on_plateau_test.py
@@ -139,3 +139,23 @@ class ReduceLROnPlateauTest(testing.TestCase):
         # With a cooldown of 2 epochs, we should only reduce the LR every other
         # epoch, so after 4 epochs we will have reduced 2 times.
         self.assertAllClose(self.model.optimizer.learning_rate.value, 0.001)
+
+    @pytest.mark.requires_trainable_backend
+    def test_state_reset_across_fit_calls(self):
+        # `ReduceLROnPlateau` is reused across `model.fit()` calls, so
+        # `on_train_begin` -> `_reset` must clear all per-run state.
+        reduce_lr = callbacks.ReduceLROnPlateau(
+            patience=1, factor=0.1, monitor="loss", min_delta=0, cooldown=2
+        )
+        reduce_lr.set_model(self.model)
+        reduce_lr.on_train_begin()
+        # Drive some state from a first run.
+        reduce_lr.best = 0.5
+        reduce_lr.wait = 3
+        reduce_lr.cooldown_counter = 2
+        # New `model.fit()` -> `on_train_begin` should clear all per-run
+        # state.
+        reduce_lr.on_train_begin()
+        self.assertIsNone(reduce_lr.best)
+        self.assertEqual(reduce_lr.wait, 0)
+        self.assertEqual(reduce_lr.cooldown_counter, 0)


### PR DESCRIPTION
## Description

Fixes #20256.

`EarlyStopping` and `ReduceLROnPlateau` store the best-seen monitored metric in `self.best`. Both already reset `self.wait`, `self.cooldown_counter`, etc. in `on_train_begin` so they can be reused across `model.fit()` calls — but they forget to reset `self.best`. When the same callback instance is passed to multiple `fit()` calls (a common pattern when sweeping hyperparameters), the second call's first epoch is compared against the *previous* model's best metric, which is meaningless, and training stops prematurely.

### Reproduction

```python
import keras, numpy as np
from keras import callbacks, layers, models

data = np.random.random((100, 1)).astype("float32")
labels = np.where(data > 0.5, 1, 0).astype("float32")
stopper = callbacks.EarlyStopping(monitor="loss", patience=5)

for i in range(3):
    model = models.Sequential([
        layers.Dense(10, activation="relu"),
        layers.Dense(1, activation="sigmoid"),
    ])
    model.compile(optimizer="sgd", loss="binary_crossentropy")
    history = model.fit(data, labels, callbacks=[stopper], verbose=0, epochs=50)
    print(f"Run {i}: {len(history.epoch)} epochs")
```

**Before:** `Run 0: 50, Run 1: 5 (stale best), Run 2: 50`
**After:** `Run 0: 50, Run 1: 50, Run 2: 50`

### Implementation

- `keras/src/callbacks/early_stopping.py:on_train_begin`: clear `self.best`. The base `_is_improvement(monitor_value, None)` already returns `True`, so the first epoch becomes the new best naturally.
- `keras/src/callbacks/reduce_lr_on_plateau.py:_reset`: same — clear `self.best`. (`_reset` is already called from `on_train_begin`.)

Added regression tests:
- `EarlyStoppingTest::test_early_stopping_reuse_across_models` — three sequential `model.fit()` calls each get a fresh model and must each run more than `patience` epochs.
- `ReduceLROnPlateauTest::test_best_reset_across_fit_calls` — direct unit test that `self.best` is `None` after a fresh `on_train_begin`.

The fix is the same idea as the one in the abandoned PR #22358, which was closed by the stale bot. Picking it up since the bug still reproduces on master.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.