### PR TITLE
Respect axis when squeezing singleton class dim in sparse_categorical_crossentropy

### DIFF
--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -876,8 +876,8 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     target = convert_to_tensor(target, dtype=torch.long)
     output = convert_to_tensor(output)
 
-    if len(target.shape) == len(output.shape) and target.shape[-1] == 1:
-        target = torch.squeeze(target, dim=-1)
+    if len(target.shape) == len(output.shape) and target.shape[axis] == 1:
+        target = torch.squeeze(target, dim=axis)
 
     if len(output.shape) < 1:
         raise ValueError(

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2340,14 +2340,25 @@ def sparse_categorical_crossentropy(
     array([0.0513, 2.303], dtype=float32)
     """
 
-    if len(y_true.shape) == len(y_pred.shape) and y_true.shape[-1] == 1:
-        y_true = ops.squeeze(y_true, axis=-1)
+    # Squeeze a singleton class dim on `y_true` if present. This must use the
+    # caller's `axis` (not a hardcoded `-1`), so that channels-first inputs
+    # — e.g. `y_true.shape=(B, 1, H, W)` with `axis=1` on the Torch backend —
+    # also have the singleton dim removed before backend dispatch. See
+    # https://github.com/keras-team/keras/issues/21097.
+    if len(y_true.shape) == len(y_pred.shape) and y_true.shape[axis] == 1:
+        y_true = ops.squeeze(y_true, axis=axis)
 
     if ignore_class is not None:
-        res_shape = ops.shape(y_pred)[:-1]
+        # `res_shape` is the shape of the per-element loss: `y_pred.shape`
+        # with the class axis removed.
+        class_axis = axis % len(y_pred.shape)
+        y_pred_shape = ops.shape(y_pred)
+        res_shape = tuple(
+            d for i, d in enumerate(y_pred_shape) if i != class_axis
+        )
         valid_mask = ops.not_equal(y_true, ops.cast(ignore_class, y_pred.dtype))
         y_true = ops.where(valid_mask, y_true, 0)
-        y_pred = ops.where(ops.expand_dims(valid_mask, -1), y_pred, 0)
+        y_pred = ops.where(ops.expand_dims(valid_mask, axis), y_pred, 0)
 
     res = ops.sparse_categorical_crossentropy(
         y_true,

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -4,6 +4,7 @@ from keras.src import backend
 from keras.src import ops
 from keras.src import tree
 from keras.src.api_export import keras_export
+from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.losses.loss import Loss
 from keras.src.losses.loss import squeeze_or_expand_to_same_rank
 from keras.src.saving import serialization_lib
@@ -2340,18 +2341,13 @@ def sparse_categorical_crossentropy(
     array([0.0513, 2.303], dtype=float32)
     """
 
-    # Squeeze a singleton class dim on `y_true` if present. This must use the
-    # caller's `axis` (not a hardcoded `-1`), so that channels-first inputs
-    # — e.g. `y_true.shape=(B, 1, H, W)` with `axis=1` on the Torch backend —
-    # also have the singleton dim removed before backend dispatch. See
-    # https://github.com/keras-team/keras/issues/21097.
     if len(y_true.shape) == len(y_pred.shape) and y_true.shape[axis] == 1:
         y_true = ops.squeeze(y_true, axis=axis)
 
     if ignore_class is not None:
         # `res_shape` is the shape of the per-element loss: `y_pred.shape`
         # with the class axis removed.
-        class_axis = axis % len(y_pred.shape)
+        class_axis = canonicalize_axis(axis, len(y_pred.shape))
         y_pred_shape = ops.shape(y_pred)
         res_shape = tuple(
             d for i, d in enumerate(y_pred_shape) if i != class_axis

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1427,6 +1427,21 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             )
             self.assertAllClose(output, expected.sum() / 16.0)
 
+    def test_squeezes_singleton_class_dim_on_user_axis(self):
+        # Regression test for https://github.com/keras-team/keras/issues/21097.
+        # When `y_true` has a singleton class dim at the user-supplied `axis`
+        # (e.g. `(B, 1, H, W)` for channels-first with `axis=1`), it must be
+        # squeezed before backend dispatch — not just on the last axis.
+        if backend.backend() != "torch":
+            self.skipTest("Channels-first axis only supported on Torch.")
+        y_true = np.random.randint(0, 2, size=(2, 1, 4, 4)).astype("float32")
+        y_pred = np.random.random((2, 2, 4, 4)).astype("float32")
+        # Without `axis=1` this raises:
+        #   "Arguments `target` and `output` must have the same shape up
+        #    until the last dimension"
+        loss = losses.sparse_categorical_crossentropy(y_true, y_pred, axis=1)
+        self.assertEqual(loss.shape, (2, 4, 4))
+
     def test_multi_class_segmentation(self):
         y_true = np.array(
             [[0, 1, 2, 0], [1, 0, 1, 0], [0, 0, 1, 1], [1, 1, 0, 1]]

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1427,18 +1427,13 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
             )
             self.assertAllClose(output, expected.sum() / 16.0)
 
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="Channels-first axis only supported on Torch.",
+    )
     def test_squeezes_singleton_class_dim_on_user_axis(self):
-        # Regression test for https://github.com/keras-team/keras/issues/21097.
-        # When `y_true` has a singleton class dim at the user-supplied `axis`
-        # (e.g. `(B, 1, H, W)` for channels-first with `axis=1`), it must be
-        # squeezed before backend dispatch — not just on the last axis.
-        if backend.backend() != "torch":
-            self.skipTest("Channels-first axis only supported on Torch.")
         y_true = np.random.randint(0, 2, size=(2, 1, 4, 4)).astype("float32")
         y_pred = np.random.random((2, 2, 4, 4)).astype("float32")
-        # Without `axis=1` this raises:
-        #   "Arguments `target` and `output` must have the same shape up
-        #    until the last dimension"
         loss = losses.sparse_categorical_crossentropy(y_true, y_pred, axis=1)
         self.assertEqual(loss.shape, (2, 4, 4))
 


### PR DESCRIPTION
## Description

Fixes #21097.

`keras.losses.sparse_categorical_crossentropy` (and the underlying Torch backend) hardcoded the class axis as `-1` when squeezing a singleton dim on `y_true`. For channels-first segmentation models on the Torch backend — where the user passes `y_true` of shape `(B, 1, H, W)` and `y_pred` of shape `(B, C, H, W)` with `axis=1` — the singleton dim was never squeezed and the call failed with a confusing shape error:

```
ValueError: Arguments `target` and `output` must have the same shape up
until the last dimension: target.shape=torch.Size([16, 1, 224, 224]),
output.shape=torch.Size([16, 2, 224, 224])
```

Even passing `axis=1` explicitly didn't help — the pre-squeeze step in `losses.py` ignored `axis`.

### Before

```python
import os
os.environ["KERAS_BACKEND"] = "torch"
import keras, numpy as np

y_true = np.random.randint(0, 2, size=(16, 1, 224, 224)).astype("float32")
y_pred = np.random.random((16, 2, 224, 224)).astype("float32")

keras.losses.sparse_categorical_crossentropy(y_true, y_pred, axis=1)
# ValueError: target.shape=(16, 1, 224, 224), output.shape=(16, 2, 224, 224)
```

### After

```python
keras.losses.sparse_categorical_crossentropy(y_true, y_pred, axis=1).shape
# torch.Size([16, 224, 224])
```

### Implementation

- `keras/src/losses/losses.py:sparse_categorical_crossentropy`: squeeze the singleton dim at the caller-supplied `axis` rather than at the hardcoded last axis. Also fix the `ignore_class` branch to compute `res_shape` relative to the actual class axis (instead of always dropping `[:-1]`) and expand the validity mask at `axis`.
- `keras/src/backend/torch/nn.py:sparse_categorical_crossentropy`: same fix for the backend-level pre-squeeze.
- `keras/src/losses/losses_test.py`: regression test (`test_squeezes_singleton_class_dim_on_user_axis`).

Scope is intentionally narrow: only the pre-squeeze path. The default `axis=-1` path is unchanged, and the TF/JAX backends — which still only support `axis=-1` natively in their underlying ops — are not touched. The fix unblocks the Torch channels-first case that #21097 was originally filed about.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.