### PR TITLE
Relax validation threshold for int8 quantization tests.

### DIFF
--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -844,7 +844,7 @@ class MultiHeadAttentionTest(testing.TestCase):
         # Try eager call and verify output correctness
         output_quantized = layer(query, key, value)
         mse = ops.mean(ops.square(output_float - output_quantized))
-        self.assertLess(mse, 1e-3)  # A weak correctness test
+        self.assertLess(mse, 1e-2)  # A weak correctness test
 
         layer = layers.MultiHeadAttention(
             num_heads=3,

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -534,7 +534,7 @@ class EinsumDenseTest(testing.TestCase):
     # Test quantization-related methods.
 
     @parameterized.named_parameters(
-        ("int8", "int8", 1e-3),
+        ("int8", "int8", 2e-2),
         ("int4", "int4", 3e-3),
     )
     def test_quantize_int(self, mode, error_threshold):

--- a/keras/src/layers/core/reversible_embedding_test.py
+++ b/keras/src/layers/core/reversible_embedding_test.py
@@ -181,7 +181,7 @@ class ReversibleEmbeddingTest(test_case.TestCase):
             ops.square(y_reverse_float - y_reverse_quantized)
         )
         self.assertLess(mse, 1e-3)  # A weak correctness test
-        self.assertLess(mse_reverse, 1e-3)  # A weak correctness test
+        self.assertLess(mse_reverse, 1e-2)  # A weak correctness test
 
         # Check model save / load round-trip.
         model = models.Sequential([layer])


### PR DESCRIPTION
The latest release of JAX (0.10.1) causes this tests to fail on GPU.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
