### PR TITLE
Keras subclass optimizers default name to None

### DIFF
--- a/keras/src/backend/torch/optimizers/torch_optimizer.py
+++ b/keras/src/backend/torch/optimizers/torch_optimizer.py
@@ -31,7 +31,7 @@ class TorchOptimizer(BaseOptimizer):
         }
 
         if cls in OPTIMIZERS:
-            return OPTIMIZERS[cls](*args, **kwargs)
+            return super().__new__(OPTIMIZERS[cls])
         return super().__new__(cls)
 
     @torch_utils.no_grad

--- a/keras/src/models/variable_mapping_test.py
+++ b/keras/src/models/variable_mapping_test.py
@@ -19,7 +19,7 @@ class VariableMappingTest(testing.TestCase):
         model.optimizer.build(model.trainable_variables)
         variable_map = model._get_variable_map()
         self.assertIn("sequential/dense_1/bias", variable_map)
-        self.assertIn("adam/learning_rate", variable_map)
+        self.assertIn("adam_1/learning_rate", variable_map)
 
         model = saving_lib_test._get_subclassed_model()
         model(np.ones((1, 1)))
@@ -30,4 +30,4 @@ class VariableMappingTest(testing.TestCase):
         self.assertIn(
             "custom_model_x/my_dense_1/my_additional_weight", variable_map
         )
-        self.assertIn("adam/learning_rate", variable_map)
+        self.assertIn("adam_2/learning_rate", variable_map)

--- a/keras/src/optimizers/adadelta.py
+++ b/keras/src/optimizers/adadelta.py
@@ -51,7 +51,7 @@ class Adadelta(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="adadelta",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/adafactor.py
+++ b/keras/src/optimizers/adafactor.py
@@ -58,7 +58,7 @@ class Adafactor(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="adafactor",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/adagrad.py
+++ b/keras/src/optimizers/adagrad.py
@@ -46,7 +46,7 @@ class Adagrad(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="adagrad",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/adam.py
+++ b/keras/src/optimizers/adam.py
@@ -56,7 +56,7 @@ class Adam(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="adam",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/adamax.py
+++ b/keras/src/optimizers/adamax.py
@@ -65,7 +65,7 @@ class Adamax(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="adamax",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/adamw.py
+++ b/keras/src/optimizers/adamw.py
@@ -66,7 +66,7 @@ class AdamW(adam.Adam):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="adamw",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/ftrl.py
+++ b/keras/src/optimizers/ftrl.py
@@ -93,7 +93,7 @@ class Ftrl(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="ftrl",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/lamb.py
+++ b/keras/src/optimizers/lamb.py
@@ -50,7 +50,7 @@ class Lamb(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="lamb",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/lion.py
+++ b/keras/src/optimizers/lion.py
@@ -55,7 +55,7 @@ class Lion(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="lion",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/muon.py
+++ b/keras/src/optimizers/muon.py
@@ -96,7 +96,7 @@ class Muon(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="muon",
+        name=None,
         exclude_layers=None,
         exclude_embeddings=True,
         muon_a=3.4445,

--- a/keras/src/optimizers/nadam.py
+++ b/keras/src/optimizers/nadam.py
@@ -51,7 +51,7 @@ class Nadam(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="nadam",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/optimizer_test.py
+++ b/keras/src/optimizers/optimizer_test.py
@@ -429,11 +429,15 @@ class OptimizerTest(testing.TestCase):
         adam_2 = optimizers.Adam()
         sgd_1 = optimizers.SGD()
         sgd_2 = optimizers.SGD()
+        adamw_1 = optimizers.AdamW()
+        adamw_2 = optimizers.AdamW()
 
         self.assertEqual(adam_1.name, "adam")
         self.assertEqual(adam_2.name, "adam_1")
         self.assertEqual(sgd_1.name, "sgd")
         self.assertEqual(sgd_2.name, "sgd_1")
+        self.assertEqual(adamw_1.name, "adam_w")
+        self.assertEqual(adamw_2.name, "adam_w_1")
 
         # Test explicit naming
         custom_adam = optimizers.Adam(name="my_adam")

--- a/keras/src/optimizers/optimizer_test.py
+++ b/keras/src/optimizers/optimizer_test.py
@@ -423,3 +423,27 @@ class OptimizerTest(testing.TestCase):
         ):
             optimizer.apply_gradients([(grads, v), (None, tf_v)])
             self.assertAllClose(optimizer.iterations, 2)
+
+    def test_optimizer_auto_naming(self):
+        adam_1 = optimizers.Adam()
+        adam_2 = optimizers.Adam()
+        sgd_1 = optimizers.SGD()
+        sgd_2 = optimizers.SGD()
+
+        self.assertEqual(adam_1.name, "adam")
+        self.assertEqual(adam_2.name, "adam_1")
+        self.assertEqual(sgd_1.name, "sgd")
+        self.assertEqual(sgd_2.name, "sgd_1")
+
+        # Test explicit naming
+        custom_adam = optimizers.Adam(name="my_adam")
+        self.assertEqual(custom_adam.name, "my_adam")
+
+        # Test serialization and deserialization preserves name
+        config_adam_2 = optimizers.serialize(adam_2)
+        reloaded_adam_2 = optimizers.deserialize(config_adam_2)
+        self.assertEqual(reloaded_adam_2.name, "adam_1")
+
+        config_custom = optimizers.serialize(custom_adam)
+        reloaded_custom = optimizers.deserialize(config_custom)
+        self.assertEqual(reloaded_custom.name, "my_adam")

--- a/keras/src/optimizers/rmsprop.py
+++ b/keras/src/optimizers/rmsprop.py
@@ -66,7 +66,7 @@ class RMSprop(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="rmsprop",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/schedule_free_adamw.py
+++ b/keras/src/optimizers/schedule_free_adamw.py
@@ -69,7 +69,7 @@ class ScheduleFreeAdamW(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="schedule_free_adamw",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/optimizers/sgd.py
+++ b/keras/src/optimizers/sgd.py
@@ -54,7 +54,7 @@ class SGD(optimizer.Optimizer):
         ema_overwrite_frequency=None,
         loss_scale_factor=None,
         gradient_accumulation_steps=None,
-        name="SGD",
+        name=None,
         **kwargs,
     ):
         super().__init__(

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -360,11 +360,15 @@ class SavingTest(testing.TestCase):
         self.assertEqual(
             config_dict["registered_name"], "my_custom_package>CustomModelX"
         )
+        # exclude optimizer name
+        del config_dict["compile_config"]["optimizer"]["config"]["name"]
+        expected_config = keras.src.saving.serialize_keras_object(
+            keras.src.optimizers.get("adam")
+        )
+        del expected_config["config"]["name"]
         self.assertEqual(
             config_dict["compile_config"]["optimizer"],
-            keras.src.saving.serialize_keras_object(
-                keras.src.optimizers.get("adam")
-            ),
+            expected_config,
         )
         self.assertEqual(
             config_dict["compile_config"]["loss"]["config"],


### PR DESCRIPTION
## Description
Currently, Keras subclass optimizers (e.g., Adam, SGD, Adagrad, RMSprop, etc.) explicitly define a default string value for the keyword argument name in their respective constructors (for example, name="adam" for Adam). To resolve this, we will change the default value of name to None in all subclass optimizer constructors.

Testing: 
`test_optimizer_auto_naming` verifies auto_name functionality, by creating multi optimizers and validating their names.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
