### PR TITLE
Fix: reject hard-link tar members whose name escapes the extraction directory

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -66,8 +66,16 @@ def resolve_sub_path(base_dir, relative_path):
 
 def is_link_in_dir(info, base_dir):
     if info.islnk():
-        # Hard links resolve relative to the root.
-        return resolve_sub_path(base_dir, info.linkname) is not None
+        # Hard links resolve relative to the root. Both the link's own
+        # location (`info.name`) and its target (`info.linkname`) must stay
+        # within `base_dir`. The `info.name` check matches the validation
+        # already applied to regular files and symbolic links; without it a
+        # hard-link member with a traversing or absolute name is materialized
+        # outside the extraction directory.
+        return (
+            resolve_sub_path(base_dir, info.name) is not None
+            and resolve_sub_path(base_dir, info.linkname) is not None
+        )
 
     # Symlinks resolve relative to the directory of their destination.
     destination = resolve_sub_path(base_dir, info.name)

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -66,12 +66,8 @@ def resolve_sub_path(base_dir, relative_path):
 
 def is_link_in_dir(info, base_dir):
     if info.islnk():
-        # Hard links resolve relative to the root. Both the link's own
-        # location (`info.name`) and its target (`info.linkname`) must stay
-        # within `base_dir`. The `info.name` check matches the validation
-        # already applied to regular files and symbolic links; without it a
-        # hard-link member with a traversing or absolute name is materialized
-        # outside the extraction directory.
+        # Hard links resolve relative to the root. Verify both the link
+        # location and target location.
         return (
             resolve_sub_path(base_dir, info.name) is not None
             and resolve_sub_path(base_dir, info.linkname) is not None

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -216,22 +216,6 @@ class FilterSafePathsTest(test_case.TestCase):
                 members[0].issym()
             )  # Explicitly assert it's a symbolic link.
 
-    def test_hardlink_name_traversal_skipped(self):
-        """A hard link whose own name escapes base_dir is skipped."""
-        with tarfile.open(self.tar_path, "w") as tar:
-            tar.add(self.target_path, arcname="payload.txt")
-            link = tarfile.TarInfo("../../escaped_hardlink.txt")
-            link.type = tarfile.LNKTYPE
-            link.linkname = "payload.txt"
-            tar.addfile(link)
-        with tarfile.open(self.tar_path, "r") as tar:
-            members = list(
-                file_utils.filter_safe_tarinfos(tar.getmembers(), self.base_dir)
-            )
-            names = [m.name for m in members]
-            self.assertIn("payload.txt", names)
-            self.assertNotIn("../../escaped_hardlink.txt", names)
-
 
 class ExtractArchiveTest(test_case.TestCase):
     def setUp(self):

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -89,15 +89,22 @@ class IsLinkInDirTest(test_case.TestCase):
             {
                 "testcase_name": "hardlink_in",
                 "is_symlink": False,
-                "name": None,
+                "name": "file.txt",
                 "linkname": "file.txt",
                 "expected": True,
             },
             {
-                "testcase_name": "hardlink_out",
+                "testcase_name": "hardlink_target_out",
                 "is_symlink": False,
-                "name": None,
+                "name": "file.txt",
                 "linkname": "../file.txt",
+                "expected": False,
+            },
+            {
+                "testcase_name": "hardlink_name_out",
+                "is_symlink": False,
+                "name": "../file.txt",
+                "linkname": "file.txt",
                 "expected": False,
             },
             {
@@ -208,6 +215,22 @@ class FilterSafePathsTest(test_case.TestCase):
             self.assertTrue(
                 members[0].issym()
             )  # Explicitly assert it's a symbolic link.
+
+    def test_hardlink_name_traversal_skipped(self):
+        """A hard link whose own name escapes base_dir is skipped."""
+        with tarfile.open(self.tar_path, "w") as tar:
+            tar.add(self.target_path, arcname="payload.txt")
+            link = tarfile.TarInfo("../../escaped_hardlink.txt")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "payload.txt"
+            tar.addfile(link)
+        with tarfile.open(self.tar_path, "r") as tar:
+            members = list(
+                file_utils.filter_safe_tarinfos(tar.getmembers(), self.base_dir)
+            )
+            names = [m.name for m in members]
+            self.assertIn("payload.txt", names)
+            self.assertNotIn("../../escaped_hardlink.txt", names)
 
 
 class ExtractArchiveTest(test_case.TestCase):


### PR DESCRIPTION
## Summary

`keras.utils.get_file(extract=True)` (and `untar=True`) and
`keras.utils.extract_archive` extract tar archives through
`extract_open_archive` → `filter_safe_tarinfos`, which is meant to drop any
member that would be written outside the destination directory.

For **hard-link** members the filter only validated the link *target*
(`info.linkname`) and never the link's own *destination* (`info.name`). A
crafted tar whose hard-link member has a `name` that is an absolute path or
contains `../` therefore passed the filter, and `tarfile.extractall`
materialized it outside the extraction directory — writing (or overwriting) an
attacker-controlled file at an arbitrary location.

On Python < 3.12 `filter_safe_tarinfos` is the only protection
(`extract_open_archive` adds `filter="data"` only for Python 3.12–3.13), so the
bypass is directly exploitable there. Keras declares `requires-python >= 3.11`,
so the minimum supported interpreter is affected.

## Relationship to CVE-2025-12060

CVE-2025-12060 / GHSA-hjqc-jx6g-rwp9 addressed tar directory traversal in
`get_file`/`extract_archive` by adding `filter="data"` and a custom path filter
that validates symbolic-link names and targets. That work did not validate the
**name** of hard-link members, so the same write-outside-the-directory primitive
remained reachable through hard links. This PR completes that hardening.

## Fix

- `keras/src/utils/file_utils.py` — in `is_link_in_dir`, validate `info.name`
  for hard links (it must resolve within `base_dir`) in addition to the
  existing `info.linkname` check. This mirrors the validation already applied to
  regular files and symbolic links.

## Test plan

`keras/src/utils/file_utils_test.py`:

- Updated the parameterized `IsLinkInDirTest` hard-link cases to set a real
  `name` (previously `None`, since `name` was unused) and added
  `hardlink_name_out` (name `../file.txt`, target `file.txt` → rejected).
- Added `FilterSafePathsTest.test_hardlink_name_traversal_skipped`: a tar with a
  hard-link member named `../../escaped_hardlink.txt` is dropped by
  `filter_safe_tarinfos` while the in-directory payload is kept.
- Existing `IsLinkInDirTest`, `FilterSafePathsTest`, and `ExtractArchiveTest`
  cases still pass; `ruff check` and `ruff format` are clean on the changed
  files.

```
$ pytest keras/src/utils/file_utils_test.py -k "IsLinkInDir or FilterSafePaths or ExtractArchive"
18 passed
```

Verified that a malicious archive that previously wrote a file outside the
extraction directory via a hard-link member is now skipped, while legitimate
hard links inside the directory continue to extract.

## Disclosure

Reported via huntr (incomplete fix of CVE-2025-12060 / GHSA-hjqc-jx6g-rwp9).
<!-- huntr bounty link: add here -->

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
