### PR TITLE
Fix: reject HDF5 shape-bomb datasets in the main load_model/load_weights path

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1094,6 +1094,17 @@ def safe_get_h5_group(parent, name):
     return group
 
 
+# Guard against HDF5 "shape bomb" datasets: a dataset can declare an enormous
+# shape while storing almost nothing on disk (e.g. chunked + gzip-compressed
+# with only a fill value), which forces a huge allocation when it is read into
+# memory (CWE-789 / CWE-409). For datasets whose declared in-memory size is
+# above this floor, we require it to stay within `_H5_DATASET_MAX_EXPANSION` of
+# the bytes actually stored on disk. Genuine arrays (even compressed) satisfy
+# this; shape/decompression bombs, which store next to nothing, do not.
+_H5_DATASET_BOMB_FLOOR_BYTES = 1 << 30  # 1 GiB
+_H5_DATASET_MAX_EXPANSION = 1000
+
+
 def safe_get_h5_dataset(group, name):
     """Retrieve a Dataset within a given Group.
 
@@ -1123,6 +1134,17 @@ def safe_get_h5_dataset(group, name):
         )
     if dataset.is_virtual:
         raise ValueError("Not allowed: H5 file with virtual Dataset")
+    declared_bytes = math.prod(dataset.shape) * dataset.dtype.itemsize
+    stored_bytes = dataset.id.get_storage_size()
+    if (
+        declared_bytes > _H5_DATASET_BOMB_FLOOR_BYTES
+        and declared_bytes > _H5_DATASET_MAX_EXPANSION * stored_bytes
+    ):
+        raise ValueError(
+            f"Not allowed: H5 dataset '{name}' declares {declared_bytes} "
+            f"bytes but only {stored_bytes} bytes are stored on disk; "
+            "refusing to load a potential decompression/shape bomb."
+        )
     return dataset
 
 

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1101,7 +1101,7 @@ def safe_get_h5_group(parent, name):
 # above this floor, we require it to stay within `_H5_DATASET_MAX_EXPANSION` of
 # the bytes actually stored on disk. Genuine arrays (even compressed) satisfy
 # this; shape/decompression bombs, which store next to nothing, do not.
-_H5_DATASET_BOMB_FLOOR_BYTES = 1 << 30  # 1 GiB
+_H5_DATASET_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
 _H5_DATASET_MAX_EXPANSION = 1000
 
 
@@ -1141,8 +1141,9 @@ def safe_get_h5_dataset(group, name):
         and declared_bytes > _H5_DATASET_MAX_EXPANSION * stored_bytes
     ):
         raise ValueError(
-            f"Not allowed: H5 dataset '{name}' declares {declared_bytes} "
-            f"bytes but only {stored_bytes} bytes are stored on disk; "
+            f"Not allowed: H5 dataset '{name}' declares "
+            f"{readable_memory_size(declared_bytes)} but only "
+            f"{readable_memory_size(stored_bytes)} are stored on disk; "
             "refusing to load a potential decompression/shape bomb."
         )
     return dataset

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from pathlib import Path
 from unittest import mock
 
+import h5py
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -1635,3 +1636,67 @@ class SavingH5IOStoreTest(testing.TestCase):
             del vars_store["abc"]
 
         store.close()
+
+
+class SafeGetH5DatasetTest(testing.TestCase):
+    def _shape_bomb_file(self):
+        """An HDF5 file with a dataset declaring ~8 PiB but storing ~nothing."""
+        path = os.path.join(self.get_temp_dir(), "bomb.h5")
+        with h5py.File(path, "w") as f:
+            f.create_dataset(
+                "d",
+                shape=(2**50,),
+                dtype="float64",
+                chunks=(1024,),
+                compression="gzip",
+                fillvalue=0.0,
+            )
+        return path
+
+    def test_rejects_shape_bomb(self):
+        path = self._shape_bomb_file()
+        self.assertLess(os.path.getsize(path), 1 << 20)  # tiny file on disk
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "shape bomb"):
+                saving_lib.safe_get_h5_dataset(f, "d")
+
+    def test_allows_regular_dataset(self):
+        path = os.path.join(self.get_temp_dir(), "ok.h5")
+        with h5py.File(path, "w") as f:
+            f.create_dataset("d", data=np.ones((128,), dtype="float32"))
+        with h5py.File(path, "r") as f:
+            dataset = saving_lib.safe_get_h5_dataset(f, "d")
+            self.assertEqual(dataset.shape, (128,))
+
+    def test_load_weights_rejects_shape_bomb(self):
+        model = keras.Sequential(
+            [keras.Input((4,)), keras.layers.Dense(3, name="d")]
+        )
+        good_path = os.path.join(self.get_temp_dir(), "good.weights.h5")
+        model.save_weights(good_path)
+
+        # Replace a real weight dataset with a shape bomb at the same path.
+        datasets = []
+        with h5py.File(good_path, "r") as f:
+
+            def collect(name, obj):
+                if isinstance(obj, h5py.Dataset) and "/vars/" in "/" + name:
+                    datasets.append(name)
+
+            f.visititems(collect)
+        with h5py.File(good_path, "r+") as f:
+            del f[datasets[0]]
+            f.create_dataset(
+                datasets[0],
+                shape=(2**50,),
+                dtype="float64",
+                chunks=(1024,),
+                compression="gzip",
+                fillvalue=0.0,
+            )
+
+        reloaded = keras.Sequential(
+            [keras.Input((4,)), keras.layers.Dense(3, name="d")]
+        )
+        with self.assertRaises(ValueError):
+            reloaded.load_weights(good_path)

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1660,14 +1660,6 @@ class SafeGetH5DatasetTest(testing.TestCase):
             with self.assertRaisesRegex(ValueError, "shape bomb"):
                 saving_lib.safe_get_h5_dataset(f, "d")
 
-    def test_allows_regular_dataset(self):
-        path = os.path.join(self.get_temp_dir(), "ok.h5")
-        with h5py.File(path, "w") as f:
-            f.create_dataset("d", data=np.ones((128,), dtype="float32"))
-        with h5py.File(path, "r") as f:
-            dataset = saving_lib.safe_get_h5_dataset(f, "d")
-            self.assertEqual(dataset.shape, (128,))
-
     def test_load_weights_rejects_shape_bomb(self):
         model = keras.Sequential(
             [keras.Input((4,)), keras.layers.Dense(3, name="d")]


### PR DESCRIPTION
## Summary

`safe_get_h5_dataset` is the shared guard the weights loaders
(`H5IOStore`, `ShardedH5IOStore`, and the legacy HDF5 loader) use before
materializing a dataset with `np.array(...)`. It rejected external/virtual
datasets and external/soft links, but never checked how large the dataset is
relative to what is actually stored on disk.

An HDF5 dataset can declare an enormous shape while storing almost nothing —
e.g. a chunked, gzip-compressed dataset with only a fill value. Reading it
allocates memory for the **declared** shape, not the stored bytes. A few-KB
`.weights.h5` / `.keras` can therefore declare a petabyte-scale array, so
`model.load_weights(...)` / `keras.saving.load_model(...)` attempts a huge
allocation and the process is OOM-killed (CWE-789 / CWE-409). A ~12 KB file is
enough to request an 8 PiB allocation.

## Relationship to CVE-2026-0897

CVE-2026-0897 / GHSA-mgx6-5cf9-rr43 fixed this "shape bomb" for
`KerasFileEditor` by adding a per-dataset size guard in
`file_editor.py::_extract_weights_from_store`. The main `load_model` /
`load_weights` path was not covered, so the same primitive remained reachable
through the standard loading APIs. This PR adds the guard to the shared
`safe_get_h5_dataset`, so every loader benefits.

## Fix

- `keras/src/saving/saving_lib.py` — in `safe_get_h5_dataset`, reject a dataset
  when its declared in-memory size both exceeds a floor (1 GiB) and exceeds the
  on-disk storage size (`dataset.id.get_storage_size()`) by a large factor
  (1000x). Genuine arrays — including compressed ones — keep these within a
  small factor; a fill/shape bomb stores next to nothing, so it is rejected
  before any allocation. The floor avoids touching small datasets, and the
  storage-ratio check (rather than a flat cap) means arbitrarily large
  *legitimate* models still load.

## Test plan

`keras/src/saving/saving_lib_test.py` — new `SafeGetH5DatasetTest`:

- `test_rejects_shape_bomb`: a tiny file declaring a ~8 PiB chunked/fill dataset
  is rejected by `safe_get_h5_dataset`.
- `test_allows_regular_dataset`: an ordinary dataset is returned unchanged.
- `test_load_weights_rejects_shape_bomb`: end-to-end, `model.load_weights` on a
  `.weights.h5` whose weight dataset was replaced with a shape bomb raises
  instead of attempting the allocation.

```
$ pytest keras/src/saving/saving_lib_test.py
66 passed
```

`ruff check` and `ruff format` pass on the changed files. Verified that the
malicious file is now rejected with a clear error
("...refusing to load a potential decompression/shape bomb") rather than
attempting the multi-petabyte allocation, while normal models load unchanged.

## Disclosure

Reported via huntr (incomplete fix of CVE-2026-0897 / GHSA-mgx6-5cf9-rr43).
<!-- huntr bounty link: add here -->

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
