### PR TITLE
Fix: KerasFileEditor reject HDF5 virtual datasets

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -528,6 +528,11 @@ class KerasFileEditor:
                     f"{value.external}"
                 )
 
+            # Reject HDF5 virtual datasets, which read through to other files
+            # on access. Mirrors `saving_lib.safe_get_h5_dataset`.
+            if value.is_virtual:
+                raise ValueError("Not allowed: H5 file with virtual Dataset")
+
             shape = value.shape
             dtype = value.dtype
 

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -528,10 +528,11 @@ class KerasFileEditor:
                     f"{value.external}"
                 )
 
-            # Reject HDF5 virtual datasets, which read through to other files
-            # on access. Mirrors `saving_lib.safe_get_h5_dataset`.
             if value.is_virtual:
-                raise ValueError("Not allowed: H5 file with virtual Dataset")
+                raise ValueError(
+                    "Not allowed: H5 file with virtual Dataset at "
+                    f"{current_inner_path}"
+                )
 
             shape = value.shape
             dtype = value.dtype

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -141,3 +141,26 @@ class SavingTest(testing.TestCase):
 
         with self.assertRaisesRegex(ValueError, "SoftLink"):
             KerasFileEditor(attacker_fpath)
+
+    def test_rejects_virtual_dataset(self):
+        target_fpath = os.path.join(
+            self.get_temp_dir(), "victim_private.weights.h5"
+        )
+        with h5py.File(target_fpath, "w") as f:
+            f.create_dataset("s", data=np.arange(5, dtype="float32"))
+
+        attacker_fpath = os.path.join(
+            self.get_temp_dir(), "vds_payload.weights.h5"
+        )
+        with h5py.File(attacker_fpath, "w") as f:
+            vars_group = (
+                f.create_group("layers")
+                .create_group("dense")
+                .create_group("vars")
+            )
+            layout = h5py.VirtualLayout(shape=(5,), dtype="float32")
+            layout[:] = h5py.VirtualSource(target_fpath, "s", shape=(5,))
+            vars_group.create_virtual_dataset("0", layout)
+
+        with self.assertRaisesRegex(ValueError, "virtual"):
+            KerasFileEditor(attacker_fpath)

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -143,24 +143,21 @@ class SavingTest(testing.TestCase):
             KerasFileEditor(attacker_fpath)
 
     def test_rejects_virtual_dataset(self):
-        target_fpath = os.path.join(
-            self.get_temp_dir(), "victim_private.weights.h5"
-        )
-        with h5py.File(target_fpath, "w") as f:
+        temp_dir = self.get_temp_dir()
+        other_fpath = os.path.join(temp_dir, "other.weights.h5")
+        with h5py.File(other_fpath, "w") as f:
             f.create_dataset("s", data=np.arange(5, dtype="float32"))
 
-        attacker_fpath = os.path.join(
-            self.get_temp_dir(), "vds_payload.weights.h5"
-        )
-        with h5py.File(attacker_fpath, "w") as f:
+        virtual_fpath = os.path.join(temp_dir, "virtual.weights.h5")
+        with h5py.File(virtual_fpath, "w") as f:
             vars_group = (
                 f.create_group("layers")
                 .create_group("dense")
                 .create_group("vars")
             )
             layout = h5py.VirtualLayout(shape=(5,), dtype="float32")
-            layout[:] = h5py.VirtualSource(target_fpath, "s", shape=(5,))
+            layout[:] = h5py.VirtualSource(other_fpath, "s", shape=(5,))
             vars_group.create_virtual_dataset("0", layout)
 
         with self.assertRaisesRegex(ValueError, "virtual"):
-            KerasFileEditor(attacker_fpath)
+            KerasFileEditor(virtual_fpath)


### PR DESCRIPTION
## Summary

`KerasFileEditor._extract_weights_from_store` walks the HDF5 tree and reads
each leaf dataset with a raw `value[()]`. PR #22899 added rejection of
group-level `ExternalLink`/`SoftLink`, and #22057 (the CVE-2026-1669 fix)
added a `Dataset.external` check to this same method — but neither rejects
**virtual datasets**. An HDF5 Virtual Dataset (VDS) presents as an
`h5py.HardLink` with `external == None`, so it passes both existing guards;
h5py then transparently resolves the VDS source mapping on `value[()]` and
returns bytes from another HDF5 file on the host.

A small attacker `.weights.h5` containing only a VDS leaf (under the usual
`<layer>/vars/<n>` structure the editor walks) therefore redirects the editor
into any HDF5 file the victim process can read. The leaked tensors appear in
`editor.weights_dict` / `weights_summary()`, and `editor.save(...)` re-emits
them as ordinary datasets — the same cross-file disclosure / exfiltration
channel as CVE-2026-1669, via virtual storage instead of links.

`safe_mode` is irrelevant here: the payload contains no Python and the editor
performs no object deserialization.

## Fix

`saving_lib.safe_get_h5_dataset` already rejects virtual datasets, but this
path does not route through it. Add the matching `value.is_virtual` check
inline, right after the existing `value.external` guard. Keras's own
`save_weights` never emits virtual datasets, so legitimate files are
unaffected.

## Test

`test_rejects_virtual_dataset` builds a VDS payload pointing at a separate
file and asserts `KerasFileEditor(...)` raises.

## References
- Prior CVE: CVE-2026-1669 / GHSA-3m4q-jmj6-r34q
- Prior fixes (incomplete): #22057 (Dataset.external), #22899 / GHSA-fx5g-469v-w8mc (Group-level ExternalLink/SoftLink)

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
