### PR TITLE
 Implement sparse outputs test 

### DIFF
--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -346,6 +346,7 @@ class IndexLookupLayerTest(testing.TestCase):
         backend.backend() != "tensorflow",
         reason="Sparse outputs are only supported with TensorFlow backend.",
     )
+
     def test_sparse_outputs(self):
         layer = layers.IntegerLookup(
             vocabulary=[1, 2, 3],

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -346,7 +346,6 @@ class IndexLookupLayerTest(testing.TestCase):
         backend.backend() != "tensorflow",
         reason="Sparse outputs are only supported with TensorFlow backend.",
     )
-
     def test_sparse_outputs(self):
         layer = layers.IntegerLookup(
             vocabulary=[1, 2, 3],

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -342,7 +342,7 @@ class IndexLookupLayerTest(testing.TestCase):
         self.assertEqual(output_spec.shape, (None, 3, 4, 4))
         self.assertEqual(output_spec.dtype, backend.floatx())
 
-    pytest.mark.skipif(
+    @pytest.mark.skipif(
         backend.backend() != "tensorflow",
         reason="Sparse outputs are only supported with TensorFlow backend.",
     )

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -342,6 +342,10 @@ class IndexLookupLayerTest(testing.TestCase):
         self.assertEqual(output_spec.shape, (None, 3, 4, 4))
         self.assertEqual(output_spec.dtype, backend.floatx())
 
+    pytest.mark.skipif(
+        backend.backend() != "tensorflow",
+        reason="Sparse outputs are only supported with TensorFlow backend.",
+    )
     def test_sparse_outputs(self):
         layer = layers.IntegerLookup(
             vocabulary=[1, 2, 3],

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -343,8 +343,13 @@ class IndexLookupLayerTest(testing.TestCase):
         self.assertEqual(output_spec.dtype, backend.floatx())
 
     def test_sparse_outputs(self):
-        # TODO
-        pass
+        layer = layers.IntegerLookup(
+            vocabulary=[1, 2, 3],
+            output_mode="multi_hot",
+            sparse=True,
+        )
+        output = layer([[1, 2], [3, 4]])
+        self.assertEqual(backend.is_tensor(output), True)
 
     def test_adapt_tf_idf(self):
         # Case: unbatched data

--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import pytest
+import tensorflow as tf
 from tensorflow import data as tf_data
 
 from keras.src import backend
@@ -354,6 +355,10 @@ class IndexLookupLayerTest(testing.TestCase):
         )
         output = layer([[1, 2], [3, 4]])
         self.assertEqual(backend.is_tensor(output), True)
+        self.assertIsInstance(output, tf.SparseTensor)
+        self.assertAllClose(
+            tf.sparse.to_dense(output), np.array([[0, 1, 1, 0], [1, 0, 0, 1]])
+        )
 
     def test_adapt_tf_idf(self):
         # Case: unbatched data


### PR DESCRIPTION


## Description
<!-- Describe your changes here -->
Implemented the missing `test_sparse_outputs` in `keras/src/layers/preprocessing/index_lookup_test.py` based on a TODO comment. The new test verifies that the `IntegerLookup` layer with `sparse=True` and `output_mode='multi_hot'` runs successfully and correctly returns a tensor.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
