### PR TITLE
Validate positive integer size in RepeatVector and UpSampling1D

### DIFF
--- a/keras/src/layers/reshaping/repeat_vector.py
+++ b/keras/src/layers/reshaping/repeat_vector.py
@@ -27,11 +27,15 @@ class RepeatVector(Layer):
 
     def __init__(self, n, **kwargs):
         super().__init__(**kwargs)
-        self.n = n
-        if not isinstance(n, int):
+        if not isinstance(n, int) or isinstance(n, bool):
             raise TypeError(
                 f"Expected an integer value for `n`, got {type(n)}."
             )
+        if n <= 0:
+            raise ValueError(
+                f"Argument `n` should be a positive integer. Received: n={n}"
+            )
+        self.n = n
         self.input_spec = InputSpec(ndim=2)
 
     def compute_output_shape(self, input_shape):

--- a/keras/src/layers/reshaping/repeat_vector_test.py
+++ b/keras/src/layers/reshaping/repeat_vector_test.py
@@ -43,3 +43,10 @@ class FlattenTest(testing.TestCase):
             TypeError, "Expected an integer value for `n`"
         ):
             layers.RepeatVector(n=[3])
+
+    def test_repeat_vector_with_non_positive_n(self):
+        for n in (0, -3):
+            with self.assertRaisesRegex(
+                ValueError, "should be a positive integer"
+            ):
+                layers.RepeatVector(n=n)

--- a/keras/src/layers/reshaping/up_sampling1d.py
+++ b/keras/src/layers/reshaping/up_sampling1d.py
@@ -42,12 +42,16 @@ class UpSampling1D(Layer):
 
     def __init__(self, size=2, **kwargs):
         super().__init__(**kwargs)
-        if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+        if not isinstance(size, int) or isinstance(size, bool):
+            raise TypeError(
+                f"Expected an integer value for `size`, got {type(size)}."
+            )
+        if size <= 0:
             raise ValueError(
                 "Argument `size` should be a positive integer. "
                 f"Received: size={size}"
             )
-        self.size = int(size)
+        self.size = size
         self.input_spec = InputSpec(ndim=3)
 
     def compute_output_shape(self, input_shape):

--- a/keras/src/layers/reshaping/up_sampling1d.py
+++ b/keras/src/layers/reshaping/up_sampling1d.py
@@ -42,6 +42,11 @@ class UpSampling1D(Layer):
 
     def __init__(self, size=2, **kwargs):
         super().__init__(**kwargs)
+        if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+            raise ValueError(
+                "Argument `size` should be a positive integer. "
+                f"Received: size={size}"
+            )
         self.size = int(size)
         self.input_spec = InputSpec(ndim=3)
 

--- a/keras/src/layers/reshaping/up_sampling1d_test.py
+++ b/keras/src/layers/reshaping/up_sampling1d_test.py
@@ -63,8 +63,13 @@ class UpSamplingTest(testing.TestCase):
     def test_upsampling_1d_with_invalid_size(self):
         # `UpSampling2D` / `UpSampling3D` already reject these; `UpSampling1D`
         # should be consistent.
-        for size in (0, -2, 2.5):
+        for size in (0, -2):
             with self.assertRaisesRegex(
                 ValueError, "should be a positive integer"
+            ):
+                layers.UpSampling1D(size=size)
+        for size in (2.5, "2", True):
+            with self.assertRaisesRegex(
+                TypeError, "Expected an integer value for `size`"
             ):
                 layers.UpSampling1D(size=size)

--- a/keras/src/layers/reshaping/up_sampling1d_test.py
+++ b/keras/src/layers/reshaping/up_sampling1d_test.py
@@ -59,3 +59,12 @@ class UpSamplingTest(testing.TestCase):
         z = KerasTensor([2, 3, None])
         self.assertEqual(layers.UpSampling1D(size=2)(z).shape, (2, 6, None))
         self.assertEqual(layers.UpSampling1D(size=4)(z).shape, (2, 12, None))
+
+    def test_upsampling_1d_with_invalid_size(self):
+        # `UpSampling2D` / `UpSampling3D` already reject these; `UpSampling1D`
+        # should be consistent.
+        for size in (0, -2, 2.5):
+            with self.assertRaisesRegex(
+                ValueError, "should be a positive integer"
+            ):
+                layers.UpSampling1D(size=size)


### PR DESCRIPTION
## Description

Fixes #22986.

`RepeatVector` and `UpSampling1D` accept zero/negative (and, for `UpSampling1D`, non-integer) size arguments at construction without raising. The mistake only surfaces later as a degenerate `0`-sized output or a cryptic backend error. Their 2D/3D counterparts (`UpSampling2D`, `UpSampling3D`) already validate this.

### Before

```python
import keras

keras.layers.RepeatVector(n=0)(keras.Input(shape=(5,))).shape  # (None, 0, 5)
keras.layers.RepeatVector(n=-3)                                # accepted
keras.layers.UpSampling1D(size=0)                              # accepted -> (None, 0, 3)
keras.layers.UpSampling1D(size=2.5)                            # silently truncated to 2
```

### After

```
ValueError: Argument `n` should be a positive integer. Received: n=0
ValueError: Argument `size` should be a positive integer. Received: size=0
```

Matches the existing behavior of `UpSampling2D` / `UpSampling3D` and the positive-integer checks on `Dense.units`, `GroupNormalization.groups`, `MultiHeadAttention.num_heads`.

### Implementation

- `keras/src/layers/reshaping/repeat_vector.py`: keep the existing int-type `TypeError`, and add a `ValueError` when `n <= 0`. Also reject `bool` (a subclass of `int`) since a boolean repetition factor is clearly a mistake.
- `keras/src/layers/reshaping/up_sampling1d.py`: reject non-int and `size <= 0` before the existing `int(size)` (which previously truncated floats and accepted non-positive values).
- Tests: `test_repeat_vector_with_non_positive_n` and `test_upsampling_1d_with_invalid_size`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.