### PR TITLE
Correct symbolic output shape of ops.inner for multi-dimensional inputs

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -8270,7 +8270,22 @@ class Inner(Operation):
             getattr(x1, "dtype", type(x1)),
             getattr(x2, "dtype", type(x2)),
         )
-        return KerasTensor([], dtype=dtype)
+        x1_shape = getattr(x1, "shape", ())
+        x2_shape = getattr(x2, "shape", ())
+        # `inner` sums over the last axis of each input, so the last
+        # dimensions must match. The output shape is the concatenation of
+        # the leading dimensions of both inputs.
+        if x1_shape and x2_shape:
+            d1 = x1_shape[-1]
+            d2 = x2_shape[-1]
+            if isinstance(d1, int) and isinstance(d2, int) and d1 != d2:
+                raise ValueError(
+                    "`inner` requires the last dimension of `x1` and `x2` "
+                    f"to match. Received: x1.shape={x1_shape}, "
+                    f"x2.shape={x2_shape}."
+                )
+        output_shape = tuple(x1_shape[:-1]) + tuple(x2_shape[:-1])
+        return KerasTensor(output_shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.inner", "keras.ops.numpy.inner"])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -8273,21 +8273,25 @@ class Inner(Operation):
             getattr(x1, "dtype", type(x1)),
             getattr(x2, "dtype", type(x2)),
         )
-        x1_shape = getattr(x1, "shape", ())
-        x2_shape = getattr(x2, "shape", ())
-        # `inner` sums over the last axis of each input, so the last
-        # dimensions must match. The output shape is the concatenation of
-        # the leading dimensions of both inputs.
-        if x1_shape and x2_shape:
-            d1 = x1_shape[-1]
-            d2 = x2_shape[-1]
+        x1_shape = tuple(getattr(x1, "shape", ()))
+        x2_shape = tuple(getattr(x2, "shape", ()))
+        # A scalar operand acts as scalar multiplication, yielding the other
+        # operand's full shape (matches `np.inner`).
+        if not x1_shape:
+            output_shape = x2_shape
+        elif not x2_shape:
+            output_shape = x1_shape
+        else:
+            # `inner` sums over the last axis, so the last dimensions must
+            # match; the output is x1.shape[:-1] + x2.shape[:-1].
+            d1, d2 = x1_shape[-1], x2_shape[-1]
             if isinstance(d1, int) and isinstance(d2, int) and d1 != d2:
                 raise ValueError(
                     "`inner` requires the last dimension of `x1` and `x2` "
                     f"to match. Received: x1.shape={x1_shape}, "
                     f"x2.shape={x2_shape}."
                 )
-        output_shape = tuple(x1_shape[:-1]) + tuple(x2_shape[:-1])
+            output_shape = x1_shape[:-1] + x2_shape[:-1]
         return KerasTensor(output_shape, dtype=dtype)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1209,7 +1209,15 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(
             knp.inner(KerasTensor((5, 3)), KerasTensor((3,))).shape, (5,)
         )
-        # Mismatched last dimension is rejected.
+        # Scalar input (empty shape) is treated as a vector by `np.inner`.
+        self.assertEqual(
+            knp.inner(KerasTensor(()), KerasTensor((3,))).shape, (3,)
+        )
+        # A dynamic last dimension skips the static match check.
+        self.assertEqual(
+            knp.inner(KerasTensor((5, None)), KerasTensor((4, 3))).shape, (5, 4)
+        )
+        # Mismatched (static) last dimension is rejected.
         with self.assertRaisesRegex(ValueError, "last dimension"):
             knp.inner(KerasTensor((5, 3)), KerasTensor((4,)))
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1198,9 +1198,20 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(knp.vdot(x, y).shape, ())
 
     def test_inner(self):
+        # `inner` sums over the last axis; output is x1.shape[:-1] +
+        # x2.shape[:-1] (matches `np.inner`), not a scalar.
         x = KerasTensor((2, 3))
         y = KerasTensor((2, 3))
-        self.assertEqual(knp.inner(x, y).shape, ())
+        self.assertEqual(knp.inner(x, y).shape, (2, 2))
+        self.assertEqual(
+            knp.inner(KerasTensor((4,)), KerasTensor((4,))).shape, ()
+        )
+        self.assertEqual(
+            knp.inner(KerasTensor((5, 3)), KerasTensor((3,))).shape, (5,)
+        )
+        # Mismatched last dimension is rejected.
+        with self.assertRaisesRegex(ValueError, "last dimension"):
+            knp.inner(KerasTensor((5, 3)), KerasTensor((4,)))
 
     def test_where(self):
         condition = KerasTensor((2, 3))
@@ -4713,6 +4724,13 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         y = np.array([4.0, 5.0, 6.0])
         self.assertAllClose(knp.inner(x, y), np.inner(x, y))
         self.assertAllClose(knp.Inner()(x, y), np.inner(x, y))
+
+        # Multi-dimensional inputs: sum over the last axis, output shape is
+        # x1.shape[:-1] + x2.shape[:-1].
+        x = np.arange(12.0).reshape(3, 4)
+        y = np.arange(20.0).reshape(5, 4)
+        self.assertAllClose(knp.inner(x, y), np.inner(x, y))
+        self.assertEqual(knp.inner(x, y).shape, (3, 5))
 
     def test_where(self):
         x = np.array([1, 2, 3])


### PR DESCRIPTION
## Description

Fixes #22988.

`keras.ops.inner` always reported a scalar (`()`) output shape during symbolic shape inference, regardless of input rank. For multi-dimensional inputs the eager result is `x1.shape[:-1] + x2.shape[:-1]` (matching `np.inner`), so symbolic and eager shapes disagreed — which breaks functional models that apply `ops.inner` to rank ≥ 2 tensors.

### Before

```python
import keras, keras.ops as ops, numpy as np

ops.inner(keras.KerasTensor((3, 4)), keras.KerasTensor((5, 4))).shape  # ()
np.inner(np.ones((3, 4)), np.ones((5, 4))).shape                       # (3, 5)
```

### After

| inputs | output shape |
|--------|--------------|
| `(3,4),(5,4)` | `(3,5)` |
| `(2,3,4),(5,4)` | `(2,3,5)` |
| `(3,4),(4,)` | `(3,)` |
| `(4,),(4,)` | `()` |

All match `np.inner`.

### Implementation

- `keras/src/ops/numpy.py:Inner.compute_output_spec`: compute `x1.shape[:-1] + x2.shape[:-1]` instead of returning a hardcoded scalar. Also validate that the last dimensions match (when both are concrete ints), raising a clear `ValueError` rather than letting the eager backend fail later.
- Updated the static-shape test (which had encoded the buggy `()` result for `(2,3),(2,3)`) to the correct `(2,2)`, and added eager + symbolic coverage for the multi-dimensional case.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.