### PR TITLE
Fix int8 quantization test with MultiHeadAttention on JAX on GPU.

### DIFF
--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -15,6 +15,7 @@ from keras.src import ops
 from keras.src import random
 from keras.src import saving
 from keras.src import testing
+from keras.src import utils
 from keras.src.backend.config import disable_flash_attention
 from keras.src.backend.config import enable_flash_attention
 from keras.src.backend.config import is_flash_attention_enabled
@@ -830,6 +831,8 @@ class MultiHeadAttentionTest(testing.TestCase):
             layers.MultiHeadAttention(num_heads=2, key_dim=16, output_shape=8.0)
 
     def test_quantize_int8(self):
+        utils.set_random_seed(1347)
+
         query = np.array([[[1.0, 0.0], [0.0, 1.0]]])
         key = np.array([[[0.0, 1.0], [1.0, 0.0]]])
         value = np.array([[[1.0, 2.0], [3.0, 4.0]]])


### PR DESCRIPTION
https://github.com/keras-team/keras/pull/22970 was not enough to fix the test for JAX on GPU.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
