### PR TITLE
Drop temp dim from matmul output shape for 1-D operands

### DIFF
--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -659,6 +659,24 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         y = KerasTensor((3, 2))
         self.assertEqual(knp.matmul(x, y).shape, (2, 2))
 
+        # 1-D operands: the temporary prepended/appended dim must be dropped
+        # from the output, matching `np.matmul`.
+        self.assertEqual(
+            knp.matmul(KerasTensor((4,)), KerasTensor((4,))).shape, ()
+        )
+        self.assertEqual(
+            knp.matmul(KerasTensor((4,)), KerasTensor((4, 5))).shape, (5,)
+        )
+        self.assertEqual(
+            knp.matmul(KerasTensor((3, 4)), KerasTensor((4,))).shape, (3,)
+        )
+        self.assertEqual(
+            knp.matmul(KerasTensor((4,)), KerasTensor((2, 4, 5))).shape, (2, 5)
+        )
+        self.assertEqual(
+            knp.matmul(KerasTensor((2, 3, 4)), KerasTensor((4,))).shape, (2, 3)
+        )
+
         with self.assertRaises(ValueError):
             x = KerasTensor((3, 4))
             y = KerasTensor((2, 3, 4))

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -261,9 +261,14 @@ def compute_matmul_output_shape(shape1, shape2):
     Returns:
         Tuple of ints: The output shape for the `matmul` operation.
     """
-    if len(shape1) == 1:
+    # Track whether each operand was 1-D before it gets promoted to 2-D
+    # below; the temporary dimension is removed from the output afterwards
+    # (matching `np.matmul`).
+    x1_is_1d = len(shape1) == 1
+    x2_is_1d = len(shape2) == 1
+    if x1_is_1d:
         shape1 = (1, shape1[0])
-    if len(shape2) == 1:
+    if x2_is_1d:
         shape2 = (shape2[0], 1)
     if (
         shape1[-1] is not None
@@ -279,9 +284,9 @@ def compute_matmul_output_shape(shape1, shape2):
     leading_shape = broadcast_shapes(shape1[:-2], shape2[:-2])
     last_2_dims_shape = [shape1[-2], shape2[-1]]
     output_shape = leading_shape + last_2_dims_shape
-    if len(shape1) == 1:
+    if x1_is_1d:
         del output_shape[-2]
-    if len(shape2) == 1:
+    if x2_is_1d:
         del output_shape[-1]
     return tuple(output_shape)
 


### PR DESCRIPTION
## Description

Fixes #22993.

`keras.ops.matmul` produced an incorrect symbolic output shape whenever an operand was 1-D. `np.matmul` promotes a 1-D operand to a matrix (prepend a `1` for the first arg, append a `1` for the second), multiplies, then removes that temporary dimension. Keras' symbolic shape inference did the promotion but never removed the temporary dim, so symbolic and eager shapes disagreed.

### Before

```python
import keras, keras.ops as ops
K = keras.KerasTensor

ops.matmul(K((4,)), K((4,))).shape       # (1, 1)   -> should be ()
ops.matmul(K((4,)), K((4, 5))).shape     # (1, 5)   -> should be (5,)
ops.matmul(K((3, 4)), K((4,))).shape     # (3, 1)   -> should be (3,)
ops.matmul(K((2, 3, 4)), K((4,))).shape  # (2, 3, 1)-> should be (2, 3)
```

### Root cause

In `compute_matmul_output_shape`, the operands are promoted to 2-D, then the code tries to undo it:

```python
if len(shape1) == 1:
    shape1 = (1, shape1[0])   # shape1 is now a 2-tuple
...
if len(shape1) == 1:          # always False — shape1 was reassigned
    del output_shape[-2]
```

The cleanup guards check the already-promoted shapes, so they never fire.

### Fix

Capture `x1_is_1d` / `x2_is_1d` **before** promoting, and use those flags for the post-multiply dimension removal. Output now matches `np.matmul` for all combinations (1-D @ 1-D, 1-D @ N-D, N-D @ 1-D, including batched).

Added 1-D coverage to the static-shape `test_matmul`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.