### PR TITLE
Document static input signature requirement for LiteRT PyTorch export

### DIFF
--- a/keras/src/export/litert.py
+++ b/keras/src/export/litert.py
@@ -26,6 +26,12 @@ def export_litert(
         filepath: The path to save the exported artifact.
         input_signature: Optional input signature specification. If
             `None`, it will be inferred.
+            Note: With the PyTorch backend, dynamic input shapes are not
+            supported. Any dynamic dimensions (represented as `None`) will
+            be automatically replaced with `1` during export, which may
+            cause runtime failures for other shapes. You must explicitly
+            pass a fixed static `input_signature` matching your maximum
+            runtime shape.
         **kwargs: Additional keyword arguments passed to the exporter.
     """
     filepath = str(filepath)

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -675,6 +675,12 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                 `tf.TensorSpec`, `backend.KerasTensor`, or backend tensor. If
                 not provided, it will be automatically computed. Defaults to
                 `None`.
+                Note: With `format="litert"` and the PyTorch backend, dynamic
+                input shapes are not supported. Any dynamic dimensions (i.e.,
+                `None` in input shapes) will be automatically replaced with `1`
+                during export, which may cause runtime failures for other
+                shapes. You must explicitly pass a fixed static
+                `input_signature` matching your maximum runtime shape.
             **kwargs: Additional keyword arguments.
                 - `is_static`: Optional `bool`. Specific to the JAX backend and
                     `format="tf_saved_model"`. Indicates whether `fn` is static.
@@ -697,8 +703,9 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                     `allow_custom_ops`, `enable_select_tf_ops`, etc. On the
                     PyTorch backend, LiteRT export accepts `optimizations`
                     plus the installed `litert_torch.convert()` keyword
-                    arguments such as `strict_export`, `dynamic_shapes`,
-                    `lightweight_conversion`, `enable_x64`,
+                    arguments such as `strict_export`, `dynamic_shapes` (note
+                    that standard ops do not support dynamic shapes, as noted
+                    below), `lightweight_conversion`, `enable_x64`,
                     `runtime_constant_folding`, and `quant_config`.
                 - PyTorch export options: Optional keyword arguments specific
                     to `format="torch"`. These are passed directly to
@@ -706,6 +713,15 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                     `dynamic_shapes`,
                     `prefer_deferred_runtime_asserts_over_guards`, and
                     `preserve_module_call_signature`.
+
+        **Note on LiteRT (TFLite) Export with PyTorch Backend:**
+        With the PyTorch backend, LiteRT export (`format="litert"`) does not
+        support dynamic input shapes. If no static signature is provided,
+        any dynamic dimensions (represented as `None`) are automatically
+        replaced with `1` during export. This can lead to runtime failures
+        for other shapes. You must explicitly specify a fixed static
+        `input_signature` (matching your maximum runtime dimensions) and pad
+        your inputs to this static shape at runtime.
 
         **Note:** This feature is currently supported only with TensorFlow, JAX
         and Torch backends.


### PR DESCRIPTION
Addressing issue #22996 by documenting that dynamic shapes are not supported in LiteRT with the PyTorch backend and that users must explicitly specify a fixed static input signature.

- [x]  I am a human, and not a bot.
- [x]  I will be responsible for responding to review comments in a timely manner.
- [x]  I will work with the maintainers to push this PR forward until submission.