### PR TITLE
Fix torch backend SymInt handling in convert_to_tensor and slice

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -219,6 +219,10 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
         else:
             dt = torch.complex64
         return torch.as_tensor(x, dtype=dt, device=get_device())
+    if isinstance(x, (torch.SymInt, torch.SymFloat)):
+        # Scalar symbolic values from torch.export can't go through numpy.
+        dt = to_torch_dtype(dtype) if dtype is not None else None
+        return torch.as_tensor(x, dtype=dt, device=get_device())
 
     # Convert to np in case of any array-like that is not list or tuple.
     # Skip scalar Python values to avoid np.array(float) -> float64, which
@@ -228,6 +232,14 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
         if len(x) > 0 and any(isinstance(x1, torch.Tensor) for x1 in x):
             # Handle list or tuple of torch tensors
             return torch.stack([convert_to_tensor(x1) for x1 in x])
+        if len(x) > 0 and any(
+            isinstance(x1, (torch.SymInt, torch.SymFloat))
+            for x1 in tree.flatten(x)
+        ):
+            # Symbolic shape values from torch.export can't go through numpy
+            # and don't have a .dtype attribute. Use torch.as_tensor directly.
+            dt = to_torch_dtype(dtype) if dtype is not None else None
+            return torch.as_tensor(x, dtype=dt, device=get_device())
     elif not isinstance(x, (bool, int, float)):
         x = np.array(x)
     if isinstance(x, np.ndarray):
@@ -630,9 +642,9 @@ def slice(inputs, start_indices, shape):
     if isinstance(start_indices, (list, tuple)) and isinstance(
         shape, (list, tuple)
     ):
-        if all(isinstance(s, int) for s in start_indices) and all(
-            isinstance(s, int) for s in shape
-        ):
+        if all(
+            isinstance(s, (int, torch.SymInt)) for s in start_indices
+        ) and all(isinstance(s, (int, torch.SymInt)) for s in shape):
             slices = [
                 builtins.slice(start_index, start_index + length)
                 for start_index, length in zip(start_indices, shape)

--- a/keras/src/backend/torch/core_test.py
+++ b/keras/src/backend/torch/core_test.py
@@ -1,0 +1,106 @@
+"""Tests for PyTorch backend core utilities."""
+
+import pytest
+import torch
+
+from keras.src import backend
+from keras.src import testing
+from keras.src.backend.torch.core import convert_to_tensor
+from keras.src.backend.torch.core import slice as torch_slice
+
+
+def _get_backed_symint(hint=2):
+    """Create a backed SymInt via torch.export dynamic shapes."""
+
+    class _M(torch.nn.Module):
+        def forward(self, x):
+            return x + x.shape[0]
+
+    ep = torch.export.export(
+        _M(),
+        (torch.randn(hint, 3),),
+        dynamic_shapes={"x": {0: torch.export.Dim("batch")}},
+    )
+    for node in ep.graph.nodes:
+        if node.op == "placeholder":
+            return node.meta["val"].shape[0]
+    raise RuntimeError("Could not extract SymInt from exported program")
+
+
+def _get_backed_symfloat(hint=2):
+    """Create a backed SymFloat from a backed SymInt."""
+    return torch.sym_float(_get_backed_symint(hint))
+
+
+@pytest.mark.skipif(
+    backend.backend() != "torch", reason="Requires torch backend"
+)
+class TorchCoreTest(testing.TestCase):
+    def _assert_sym_convert(
+        self,
+        value,
+        expected_dtype,
+        expected_item=None,
+        expected_shape=None,
+        expected_values=None,
+        dtype=None,
+    ):
+        result = convert_to_tensor(value, dtype=dtype)
+        self.assertIsInstance(result, torch.Tensor)
+        self.assertEqual(result.dtype, expected_dtype)
+        if expected_item is not None:
+            self.assertEqual(result.item(), expected_item)
+        if expected_shape is not None:
+            self.assertEqual(tuple(result.shape), expected_shape)
+        if expected_values is not None:
+            self.assertListEqual(result.tolist(), expected_values)
+
+    def test_convert_to_tensor_symint_scalar(self):
+        self._assert_sym_convert(
+            _get_backed_symint(5), torch.int64, expected_item=5
+        )
+
+    def test_convert_to_tensor_symfloat_scalar(self):
+        self._assert_sym_convert(
+            _get_backed_symfloat(5), torch.float32, expected_item=5.0
+        )
+
+    def test_convert_to_tensor_list_of_symint(self):
+        self._assert_sym_convert(
+            [_get_backed_symint(3), _get_backed_symint(4)],
+            torch.int64,
+            expected_shape=(2,),
+            expected_values=[3, 4],
+        )
+
+    def test_convert_to_tensor_tuple_of_symfloat(self):
+        self._assert_sym_convert(
+            (_get_backed_symfloat(3), _get_backed_symfloat(4)),
+            torch.float32,
+            expected_shape=(2,),
+            expected_values=[3.0, 4.0],
+        )
+
+    def test_convert_to_tensor_nested_list_of_symint(self):
+        self._assert_sym_convert(
+            [[_get_backed_symint(3), _get_backed_symint(4)]],
+            torch.int64,
+            expected_shape=(1, 2),
+            expected_values=[[3, 4]],
+        )
+
+    def test_convert_to_tensor_explicit_dtype_for_symint(self):
+        self._assert_sym_convert(
+            _get_backed_symint(5),
+            torch.float32,
+            dtype="float32",
+        )
+
+    def test_slice_fast_path_accepts_symint(self):
+        """slice fast path should accept SymInt without crashing."""
+        x = torch.arange(24).reshape(2, 3, 4)
+        batch = _get_backed_symint(2)
+        start_indices = [0, 0, 0]
+        shape = [batch, 2, 2]
+        result = torch_slice(x, start_indices, shape)
+        self.assertEqual(tuple(result.shape), (2, 2, 2))


### PR DESCRIPTION
This PR extracts the torch backend SymInt fixes from #22893 into a focused, minimal change.

## What it does

- **convert_to_tensor**: Handles scalar `torch.SymInt` / `torch.SymFloat` directly via `torch.as_tensor`, avoiding the numpy path that fails with symbolic types during `torch.export` tracing.
- **convert_to_tensor**: Handles list/tuple containing `SymInt` / `SymFloat` by using `torch.as_tensor` directly.
- **slice**: Allows `torch.SymInt` in `start_indices` and `shape` for the Python slicing fast path, enabling proper dynamic shape tracing in `torch.export`.

## What's NOT included (compared to #22893)

- No `_maybe_build()` modifications
- No `_build_shapes_dict` updates
- No shape merge logic in `get_input_signature()`
- No hot-path performance regressions

## Tests

Adds `keras/src/backend/torch/core_test.py` with 6 focused unit tests:
- `test_convert_to_tensor_symint_scalar`
- `test_convert_to_tensor_symfloat_scalar`
- `test_convert_to_tensor_list_of_symint`
- `test_convert_to_tensor_tuple_of_symfloat`
- `test_convert_to_tensor_explicit_dtype_for_symint`
- `test_slice_fast_path_accepts_symint`

All tests pass with `KERAS_BACKEND=torch pytest keras/src/backend/torch/core_test.py -v`.

## Related

- #22893 — the original PR this was split from
- #22996 — documents why dynamic shapes still can't work end-to-end (JAX bridge limitation in litert-torch, not a Keras bug)

- [x]  I am a human, and not a bot.
- [x]  I will be responsible for responding to review comments in a timely manner.
- [x]  I will work with the maintainers to push this PR forward until submission.

