### PR TITLE
Make EinsumDense.compute_output_shape work before build

### DIFF
--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -303,8 +303,16 @@ class EinsumDense(Layer):
 
         return kernel
 
-    def compute_output_shape(self, _):
-        return self.full_output_shape
+    def compute_output_shape(self, input_shape):
+        # Derive the output shape from `input_shape` so this works before the
+        # layer is built (`self.full_output_shape` is only set in `build`).
+        _, _, full_output_shape, _, _ = _analyze_einsum_string(
+            self.equation,
+            self.bias_axes,
+            input_shape,
+            self.partial_output_shape,
+        )
+        return tuple(full_output_shape)
 
     def call(self, inputs, training=None):
         x = ops.einsum(self.equation, inputs, self.kernel)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -184,10 +184,7 @@ class EinsumDense(Layer):
             input_shape,
             self.partial_output_shape,
         )
-        kernel_shape, bias_shape, full_output_shape, input_axes, output_axes = (
-            shape_data
-        )
-        self.full_output_shape = tuple(full_output_shape)
+        kernel_shape, bias_shape, _, input_axes, output_axes = shape_data
         self.input_spec = InputSpec(ndim=len(input_shape))
 
         kernel_initializer = self.kernel_initializer
@@ -304,8 +301,6 @@ class EinsumDense(Layer):
         return kernel
 
     def compute_output_shape(self, input_shape):
-        # Derive the output shape from `input_shape` so this works before the
-        # layer is built (`self.full_output_shape` is only set in `build`).
         _, _, full_output_shape, _, _ = _analyze_einsum_string(
             self.equation,
             self.bias_axes,

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -349,6 +349,26 @@ class EinsumDenseTest(testing.TestCase):
         if expected_bias_shape is not None:
             self.assertEqual(layer.bias.shape, expected_bias_shape)
 
+    def test_compute_output_shape_before_build(self):
+        # `compute_output_shape` must work without the layer being built
+        # first (it previously read `self.full_output_shape`, which only
+        # exists after `build`, and raised `AttributeError`).
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=(7,))
+        self.assertEqual(layer.compute_output_shape((None, 5)), (None, 7))
+        # And it stays consistent after the layer is built.
+        layer.build((None, 5))
+        self.assertEqual(layer.compute_output_shape((None, 5)), (None, 7))
+
+        # A higher-rank equation with an explicitly-unknown output axis;
+        # `compute_output_shape` must agree with the actual call.
+        layer = layers.EinsumDense(
+            "abc,cd->abd", output_shape=(None, 4), bias_axes="d"
+        )
+        x = layers.Input(shape=(3, 8))
+        self.assertEqual(
+            layer.compute_output_shape((None, 3, 8)), tuple(layer(x).shape)
+        )
+
     def test_einsum_dense_constraints(self):
         layer = layers.EinsumDense(
             "abc,cde->abde", (1, 3, 4), kernel_constraint="non_neg"

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -350,9 +350,7 @@ class EinsumDenseTest(testing.TestCase):
             self.assertEqual(layer.bias.shape, expected_bias_shape)
 
     def test_compute_output_shape_before_build(self):
-        # `compute_output_shape` must work without the layer being built
-        # first (it previously read `self.full_output_shape`, which only
-        # exists after `build`, and raised `AttributeError`).
+        # `compute_output_shape` must work without the layer being built first.
         layer = layers.EinsumDense("ab,bc->ac", output_shape=(7,))
         self.assertEqual(layer.compute_output_shape((None, 5)), (None, 7))
         # And it stays consistent after the layer is built.


### PR DESCRIPTION
## Description

Fixes #22999.

`EinsumDense.compute_output_shape` raised `AttributeError: 'EinsumDense' object has no attribute 'full_output_shape'` when called before the layer was built, because it returned the cached `self.full_output_shape` (only set in `build()`) and ignored its `input_shape` argument.

### Before

```python
import keras
from keras import layers

layer = layers.EinsumDense("ab,bc->ac", output_shape=(7,))
layer.compute_output_shape((None, 5))
# AttributeError: 'EinsumDense' object has no attribute 'full_output_shape'
```

### After

```python
layer.compute_output_shape((None, 5))   # (None, 7)
```

### Fix

`compute_output_shape` now derives the result from its `input_shape` argument via the same `_analyze_einsum_string` helper that `build()` uses, so it works whether or not the layer is built and stays consistent with the actual call (verified, including equations with an explicitly-unknown output axis).

Added `test_compute_output_shape_before_build`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.