### PR TITLE
Implement Hashing.compute_output_shape

### DIFF
--- a/keras/src/layers/preprocessing/hashing.py
+++ b/keras/src/layers/preprocessing/hashing.py
@@ -209,6 +209,15 @@ class Hashing(Layer):
         self._allow_non_tensor_positional_args = True
         self.supports_jit = False
 
+    def compute_output_shape(self, input_shape):
+        if self.output_mode == "int":
+            return tuple(input_shape)
+        # `one_hot`, `multi_hot` and `count` encode the last (sample) axis
+        # into a `num_bins`-sized axis.
+        if len(input_shape) == 0:
+            return (self.num_bins,)
+        return tuple(input_shape[:-1]) + (self.num_bins,)
+
     def call(self, inputs):
         from keras.src.backend import tensorflow as tf_backend
 

--- a/keras/src/layers/preprocessing/hashing_test.py
+++ b/keras/src/layers/preprocessing/hashing_test.py
@@ -10,6 +10,7 @@ from keras.src import layers
 from keras.src import models
 from keras.src import testing
 from keras.src.saving import load_model
+from keras.src.testing.test_utils import named_product
 
 
 class ArrayLike:
@@ -249,15 +250,19 @@ class HashingTest(testing.TestCase):
         ):
             _ = layers.Hashing(num_bins=1, salt=[133, 137, 177])
 
-    def test_compute_output_shape(self):
+    @parameterized.named_parameters(
+        named_product(
+            mode=("int", "one_hot", "multi_hot", "count"),
+            input_shape=((4,), (4, 1), (3, 4)),
+        )
+    )
+    def test_compute_output_shape(self, mode, input_shape):
         # `compute_output_shape` must work without building the layer first
         # and agree with the actual call for every output mode.
-        for mode in ("int", "one_hot", "multi_hot", "count"):
-            for ishape in [(4,), (4, 1), (3, 4)]:
-                layer = layers.Hashing(num_bins=5, output_mode=mode)
-                cos = tuple(layer.compute_output_shape((None,) + ishape))
-                actual = tuple(layer(layers.Input(shape=ishape)).shape)
-                self.assertEqual(cos, actual)
+        layer = layers.Hashing(num_bins=5, output_mode=mode)
+        cos = tuple(layer.compute_output_shape((None,) + input_shape))
+        actual = tuple(layer(layers.Input(shape=input_shape)).shape)
+        self.assertEqual(cos, actual)
 
     def test_one_hot_output(self):
         input_array = np.array([0, 1, 2, 3, 4])

--- a/keras/src/layers/preprocessing/hashing_test.py
+++ b/keras/src/layers/preprocessing/hashing_test.py
@@ -249,6 +249,16 @@ class HashingTest(testing.TestCase):
         ):
             _ = layers.Hashing(num_bins=1, salt=[133, 137, 177])
 
+    def test_compute_output_shape(self):
+        # `compute_output_shape` must work without building the layer first
+        # and agree with the actual call for every output mode.
+        for mode in ("int", "one_hot", "multi_hot", "count"):
+            for ishape in [(4,), (4, 1), (3, 4)]:
+                layer = layers.Hashing(num_bins=5, output_mode=mode)
+                cos = tuple(layer.compute_output_shape((None,) + ishape))
+                actual = tuple(layer(layers.Input(shape=ishape)).shape)
+                self.assertEqual(cos, actual)
+
     def test_one_hot_output(self):
         input_array = np.array([0, 1, 2, 3, 4])
 


### PR DESCRIPTION
## Description

Fixes #23001.

`keras.layers.Hashing` didn't implement `compute_output_shape`, so calling it raised `NotImplementedError` even though the output shape is deterministic. Sibling preprocessing layers (`CategoryEncoding`, `IntegerLookup`, `Discretization`) all implement it.

### Before

```python
import keras
from keras import layers

layers.Hashing(num_bins=3).compute_output_shape((None, 4))
# NotImplementedError: Layer Hashing does not have a `compute_output_shape` ...
```

### After

```python
layers.Hashing(num_bins=3).compute_output_shape((None, 4))   # (None, 4)
```

### Implementation

Added `compute_output_shape`:
- `output_mode="int"`: returns `input_shape` unchanged.
- `output_mode in {"one_hot", "multi_hot", "count"}`: encodes the last (sample) axis into a `num_bins` axis -> `input_shape[:-1] + (num_bins,)`.

Verified against the actual call for every output mode across input ranks `(4,)`, `(4, 1)`, `(3, 4)` — all match. Added `test_compute_output_shape`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.