### PR TITLE
Fix data distribution for model training in Jax Training

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1104,12 +1104,13 @@ class JAXEpochIterator(EpochIterator):
         layouts = None
         for data in self.data_adapter.get_jax_iterator():
             if layouts is None:
-                layouts = tree.map_structure(
-                    lambda d: (
-                        distribution.get_data_layout(d.shape).backend_layout
-                    ),
-                    data,
-                )
+
+                def get_layout(d):
+                    if d is None:
+                        return None
+                    return distribution.get_data_layout(d.shape).backend_layout
+
+                layouts = tree.map_structure(get_layout, data)
             yield _distribute_data(data, layouts)
 
     def _one_batch_ahead_iterator(self, numpy_iterator):

--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1068,10 +1068,13 @@ def _distribute_data(data, layouts=None):
 
     if distribution is not None:
         if layouts is None:
-            layouts = tree.map_structure(
-                lambda d: distribution.get_data_layout(d.shape),
-                data,
-            )
+
+            def get_layout(d):
+                if d is None:
+                    return None
+                return distribution.get_data_layout(d.shape)
+
+            layouts = tree.map_structure(get_layout, data)
         jax_dist_data_input = partial(
             jax_distribution_lib.distribute_data_input,
             batch_dim_name=distribution.batch_dim_name,

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -106,38 +106,6 @@ class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
         {"testcase_name": "DataParallel", "dist_type": "data_parallel"},
         {"testcase_name": "ModelParallel", "dist_type": "model_parallel"},
     )
-    def test_no_warning_when_model_built_inside_scope(self, dist_type):
-        """Model built inside distribution scope -> no warning."""
-        n = len(backend_dlib.list_devices())
-        units = n * max(1, 4 // n)
-        dist = self._make_distribution(dist_type)
-
-        # Model created inside scope — weights get proper sharding.
-        with dist.scope():
-            model = models.Sequential([layers.Dense(units, input_shape=(16,))])
-
-        inputs = np.random.normal(size=(8, 16)).astype("float32")
-        labels = np.random.normal(size=(8, units)).astype("float32")
-
-        with dist.scope():
-            model.compile(loss="mse", optimizer="adam")
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                model._symbolic_build(data_batch=(inputs[:2], labels[:2]))
-                model._get_state_sharding_spec()
-
-            mixed = [w for w in caught if "mix of local" in str(w.message)]
-            self.assertEqual(
-                len(mixed),
-                0,
-                "Unexpected mixed-sharding warning when model is "
-                "built inside scope",
-            )
-
-    @parameterized.named_parameters(
-        {"testcase_name": "DataParallel", "dist_type": "data_parallel"},
-        {"testcase_name": "ModelParallel", "dist_type": "model_parallel"},
-    )
     def test_train_on_batch(self, dist_type):
         n = len(backend_dlib.list_devices())
         units = n * max(1, 4 // n)
@@ -159,3 +127,5 @@ class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
             model.train_on_batch(x=inputs, y=labels)
             model.test_on_batch(x=inputs, y=labels)
             model.predict_on_batch(x=inputs)
+            model.fit(x=inputs, y=labels, epochs=1, verbose=0)
+            model.evaluate(x=inputs, y=labels, verbose=0)

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -10,6 +10,7 @@ from keras.src import layers
 from keras.src import models
 from keras.src import testing
 from keras.src.backend import distribution_lib as backend_dlib
+from keras.src.backend.jax import trainer as jax_trainer
 from keras.src.distribution import distribution_lib
 
 
@@ -129,3 +130,26 @@ class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
             model.predict_on_batch(x=inputs)
             model.fit(x=inputs, y=labels, epochs=1, verbose=0)
             model.evaluate(x=inputs, y=labels, verbose=0)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "DataParallel", "dist_type": "data_parallel"},
+        {"testcase_name": "ModelParallel", "dist_type": "model_parallel"},
+    )
+    def test_jax_epoch_iterator_with_none_elements(self, dist_type):
+        class MockDataAdapter:
+            def __init__(self):
+                self.num_batches = 1
+
+            def get_jax_iterator(self):
+                # test for None in data
+                yield (np.ones((2, 4)), None)
+
+        with self._make_distribution(dist_type).scope():
+            iterator = jax_trainer.JAXEpochIterator(x=np.ones((2, 4)))
+            iterator.data_adapter = MockDataAdapter()
+
+            epoch_iter = iterator._get_iterator()
+            batch = next(epoch_iter)
+
+        self.assertIsNone(batch[1])
+        self.assertIsNotNone(batch[0])

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -101,3 +101,61 @@ class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
                 "Unexpected mixed-sharding warning when model is "
                 "built inside scope",
             )
+
+    @parameterized.named_parameters(
+        {"testcase_name": "DataParallel", "dist_type": "data_parallel"},
+        {"testcase_name": "ModelParallel", "dist_type": "model_parallel"},
+    )
+    def test_no_warning_when_model_built_inside_scope(self, dist_type):
+        """Model built inside distribution scope -> no warning."""
+        n = len(backend_dlib.list_devices())
+        units = n * max(1, 4 // n)
+        dist = self._make_distribution(dist_type)
+
+        # Model created inside scope — weights get proper sharding.
+        with dist.scope():
+            model = models.Sequential([layers.Dense(units, input_shape=(16,))])
+
+        inputs = np.random.normal(size=(8, 16)).astype("float32")
+        labels = np.random.normal(size=(8, units)).astype("float32")
+
+        with dist.scope():
+            model.compile(loss="mse", optimizer="adam")
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                model._symbolic_build(data_batch=(inputs[:2], labels[:2]))
+                model._get_state_sharding_spec()
+
+            mixed = [w for w in caught if "mix of local" in str(w.message)]
+            self.assertEqual(
+                len(mixed),
+                0,
+                "Unexpected mixed-sharding warning when model is "
+                "built inside scope",
+            )
+
+    @parameterized.named_parameters(
+        {"testcase_name": "DataParallel", "dist_type": "data_parallel"},
+        {"testcase_name": "ModelParallel", "dist_type": "model_parallel"},
+    )
+    def test_train_on_batch(self, dist_type):
+        n = len(backend_dlib.list_devices())
+        units = n * max(1, 4 // n)
+        dist = self._make_distribution(dist_type)
+
+        with dist.scope():
+            model = models.Sequential([layers.Dense(units, input_shape=(16,))])
+            model.compile(loss="mse", optimizer="adam")
+
+            inputs = np.random.normal(size=(8, 16)).astype("float32")
+            labels = np.random.normal(size=(8, units)).astype("float32")
+            sw = np.random.uniform(size=(8,)).astype("float32")
+
+            # With sample weight.
+            model.train_on_batch(x=inputs, y=labels, sample_weight=sw)
+            model.test_on_batch(x=inputs, y=labels, sample_weight=sw)
+
+            # Without sample weight.
+            model.train_on_batch(x=inputs, y=labels)
+            model.test_on_batch(x=inputs, y=labels)
+            model.predict_on_batch(x=inputs)

--- a/keras/src/backend/jax/trainer_test.py
+++ b/keras/src/backend/jax/trainer_test.py
@@ -136,17 +136,13 @@ class JAXTrainerTest(testing.TestCase, parameterized.TestCase):
         {"testcase_name": "ModelParallel", "dist_type": "model_parallel"},
     )
     def test_jax_epoch_iterator_with_none_elements(self, dist_type):
-        class MockDataAdapter:
-            def __init__(self):
-                self.num_batches = 1
-
-            def get_jax_iterator(self):
-                # test for None in data
-                yield (np.ones((2, 4)), None)
+        def generator():
+            yield (np.ones((16, 32)), None)
 
         with self._make_distribution(dist_type).scope():
-            iterator = jax_trainer.JAXEpochIterator(x=np.ones((2, 4)))
-            iterator.data_adapter = MockDataAdapter()
+            iterator = jax_trainer.JAXEpochIterator(
+                x=generator(), steps_per_epoch=1
+            )
 
             epoch_iter = iterator._get_iterator()
             batch = next(epoch_iter)


### PR DESCRIPTION
## Description

The logic for ditributing tensors in `JaxTrainer` doesn't take this into consideration `None`, which might happen when `sample_weight = None` in `train_on_batch`. This CL fixes that


### Failure log on the added test, w/o fix:

```
    def test_train_on_batch(self, dist_type):
        n = len(backend_dlib.list_devices())
        units = n * max(1, 4 // n)
        dist = self._make_distribution(dist_type)
    
        with dist.scope():
            model = models.Sequential([layers.Dense(units, input_shape=(16,))])
            model.compile(loss="mse", optimizer="adam")
    
            inputs = np.random.normal(size=(8, 16)).astype("float32")
            labels = np.random.normal(size=(8, units)).astype("float32")
            sw = np.random.uniform(size=(8,)).astype("float32")
    
            # With sample weight.
            model.train_on_batch(x=inputs, y=labels, sample_weight=sw)
            model.test_on_batch(x=inputs, y=labels, sample_weight=sw)
    
            # Without sample weight.
>           model.train_on_batch(x=inputs, y=labels)

src/backend/jax/trainer_test.py:127: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
....
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

d = None

>       lambda d: distribution.get_data_layout(d.shape),
        data,
    )
E   AttributeError: 'NoneType' object has no attribute 'shape'

src/backend/jax/trainer.py:1072: AttributeError
```

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
