### PR TITLE
Validate Pipeline.from_config layers and avoid mutating input config

### DIFF
--- a/keras/src/layers/preprocessing/pipeline.py
+++ b/keras/src/layers/preprocessing/pipeline.py
@@ -68,9 +68,16 @@ class Pipeline(Layer):
 
     @classmethod
     def from_config(cls, config):
+        layers = config.get("layers")
+        if not isinstance(layers, (list, tuple)):
+            raise ValueError(
+                "`Pipeline` config must contain a `layers` key mapping to a "
+                "list of serialized layers. Received config with "
+                f"layers={layers}."
+            )
+        config = {**config}
         config["layers"] = [
-            serialization_lib.deserialize_keras_object(x)
-            for x in config["layers"]
+            serialization_lib.deserialize_keras_object(x) for x in layers
         ]
         return cls(**config)
 

--- a/keras/src/layers/preprocessing/pipeline_test.py
+++ b/keras/src/layers/preprocessing/pipeline_test.py
@@ -87,3 +87,19 @@ class PipelineTest(testing.TestCase):
         restored_output = restored(x)
         self.assertEqual(tuple(output.shape), (2, 8, 9, 3))
         self.assertAllClose(output, restored_output)
+
+    def test_from_config_malformed_raises_value_error(self):
+        # A missing or non-list `layers` key should raise a clear ValueError
+        # instead of an opaque KeyError / TypeError.
+        with self.assertRaisesRegex(ValueError, "layers"):
+            layers.Pipeline.from_config({"name": "test"})
+        with self.assertRaisesRegex(ValueError, "layers"):
+            layers.Pipeline.from_config({"layers": None, "name": "test"})
+
+    def test_from_config_does_not_mutate_input(self):
+        pipeline = layers.Pipeline([layers.AutoContrast()])
+        config = pipeline.get_config()
+        serialized_layers = config["layers"]
+        layers.Pipeline.from_config(config)
+        # `from_config` must not deserialize the caller's config in place.
+        self.assertIs(config["layers"], serialized_layers)


### PR DESCRIPTION
## Description

Fixes #22450.

`Pipeline.from_config()` accesses `config["layers"]` directly, so a malformed config raises an opaque error instead of an actionable one:

```python
from keras.layers import Pipeline

Pipeline.from_config({"name": "test"})               # KeyError: 'layers'
Pipeline.from_config({"layers": None, "name": "t"})  # TypeError: 'NoneType' object is not iterable
```

It also deserializes `config["layers"]` in place, mutating the caller's dict.

**Fix:**
- Validate that `layers` is a `list`/`tuple` and raise a clear `ValueError` otherwise.
- Build a shallow copy of `config` before reassigning `layers`, so the input dict isn't mutated.

**Tests** (added to `pipeline_test.py`):
- `test_from_config_malformed_raises_value_error` — missing key and `layers=None` both raise `ValueError`.
- `test_from_config_does_not_mutate_input` — `from_config` no longer deserializes the caller's config in place.

All 6 tests in `pipeline_test.py` pass locally (tensorflow backend); `ruff check` and `ruff format --check` are clean on the changed files. Scoped to `Pipeline` only to keep the change surgical (the issue notes `Wrapper`/`RNN` use similar patterns; those can be hardened separately).

**AI assistance disclosure (per the AI-Assisted Contribution Policy):** This PR was prepared with the assistance of Claude Code. The human author has reviewed and understands the change, takes full responsibility for it, and will respond to review feedback personally.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
