### PR TITLE
feat: add CITATION.cff file for GitHub repository citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: Keras
+authors:
+  - family-names: Chollet
+    given-names: François
+  - name: "Keras Contributors"
+date-released: 2015-03-27
+url: "https://keras.io"
+preferred-citation:
+  type: generic
+  title: Keras
+  authors:
+    - family-names: Chollet
+      given-names: François
+    - name: "others"
+  year: 2015
+  url: "https://keras.io"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,5 +14,5 @@ preferred-citation:
     - family-names: Chollet
       given-names: François
     - name: "others"
-  year: 2015
+  date-released: 2015-03-27
   url: "https://keras.io"


### PR DESCRIPTION
## Description

Closes #22855

This PR adds a `CITATION.cff` file at the root of the repository so GitHub can display the native **“Cite this repository”** option.

The citation information is based on the official BibTeX entry provided in the Keras FAQ. Since GitHub validates `CITATION.cff` files against the CFF v1.2.0 schema and does not accept a plain year value for `date-released`, I used the initial commit date, `2015-03-27`, for that field.

The BibTeX entry also uses “others” for the author list, so I represented that through the `preferred-citation` block to keep the citation metadata aligned with the official reference while remaining valid CFF.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.