### PR TITLE
Unskip more NumPy masking related tests.

### DIFF
--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -487,10 +487,6 @@ class MultiHeadAttentionTest(testing.TestCase):
         self.assertAllClose(output_1, output_2)
         self.assertAllClose(output_1, output_3)
 
-    @pytest.mark.skipif(
-        backend.backend() == "numpy",
-        reason="Numpy backend does not support masking.",
-    )
     def test_no_warning_with_keras_mask(self):
         layer = layers.MultiHeadAttention(num_heads=2, key_dim=2)
         query = np.array([[1, 2, 3, 0, 0], [3, 3, 1, 1, 2], [1, 0, 0, 0, 0]])

--- a/keras/src/losses/loss_test.py
+++ b/keras/src/losses/loss_test.py
@@ -1,7 +1,6 @@
 import pickle
 
 import numpy as np
-import pytest
 
 from keras.src import backend
 from keras.src import dtype_policies
@@ -79,10 +78,6 @@ class LossTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "Invalid value for argument"):
             ExampleLoss(reduction="abc")
 
-    @pytest.mark.skipif(
-        backend.backend() == "numpy",
-        reason="Numpy backend does not support masking.",
-    )
     def test_mask(self):
         mask = np.array([True, False, True, True])
         y_true = np.array([1.0, 0.0, 1.0, 0.0])
@@ -94,7 +89,7 @@ class LossTest(testing.TestCase):
         mask = ops.convert_to_tensor(mask)
         y_true = ops.convert_to_tensor(y_true)
         y_pred = ops.convert_to_tensor(y_pred)
-        y_pred._keras_mask = mask
+        backend.set_keras_mask(y_pred, mask)
 
         loss_fn = ExampleLoss()
         loss = loss_fn(y_true, y_pred)
@@ -105,7 +100,7 @@ class LossTest(testing.TestCase):
 
         # Test edge case where everything is masked.
         mask = np.array([False, False, False, False])
-        y_pred._keras_mask = mask
+        backend.set_keras_mask(y_pred, mask)
         loss = loss_fn(y_true, y_pred)
         self.assertEqual(backend.standardize_dtype(loss.dtype), "float32")
         self.assertAllClose(loss, 0)  # No NaN.
@@ -128,10 +123,6 @@ class LossTest(testing.TestCase):
         self.assertEqual(backend.standardize_dtype(loss.dtype), "float32")
         self.assertAllClose(loss, 0)  # No NaN.
 
-    @pytest.mark.skipif(
-        backend.backend() == "numpy",
-        reason="Numpy backend does not support masking.",
-    )
     def test_mask_and_sample_weight(self):
         sample_weight = np.array([0.4, 0.3, 0.2, 0.1])
         y_true = np.array([1.0, 0.0, 1.0, 0.0])
@@ -145,7 +136,7 @@ class LossTest(testing.TestCase):
         mask = ops.convert_to_tensor(mask)
         y_true = ops.convert_to_tensor(y_true)
         y_pred = ops.convert_to_tensor(y_pred)
-        y_pred._keras_mask = mask
+        backend.set_keras_mask(y_pred, mask)
 
         loss_fn = ExampleLoss()
         loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
@@ -156,10 +147,6 @@ class LossTest(testing.TestCase):
             loss,
         )
 
-    @pytest.mark.skipif(
-        backend.backend() == "numpy",
-        reason="Numpy backend does not support masking.",
-    )
     def test_mask_and_sample_weight_rank2(self):
         # check loss of inputs with duplicate rows doesn't change
         sample_weight = np.array([0.4, 0.3, 0.2, 0.1])
@@ -170,7 +157,7 @@ class LossTest(testing.TestCase):
         mask = ops.convert_to_tensor(mask)
         y_true = ops.convert_to_tensor(y_true)
         y_pred = ops.convert_to_tensor(y_pred)
-        y_pred._keras_mask = mask
+        backend.set_keras_mask(y_pred, mask)
 
         loss_fn = ExampleLoss()
         rank1_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
@@ -180,17 +167,13 @@ class LossTest(testing.TestCase):
         y_true = ops.tile(ops.expand_dims(y_true, axis=0), (2, 1))
         y_pred = ops.tile(ops.expand_dims(y_pred, axis=0), (2, 1))
         sample_weight = ops.tile(ops.expand_dims(sample_weight, axis=0), (2, 1))
-        y_pred._keras_mask = mask
+        backend.set_keras_mask(y_pred, mask)
         rank2_loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)
         self.assertAllClose(rank1_loss, rank2_loss)
 
     # @testing.parametrize(
     #     "uprank", ["mask", "sample_weight", "y_true", "y_pred"])
     # TODO: use parameterization decorator
-    @pytest.mark.skipif(
-        backend.backend() == "numpy",
-        reason="Numpy backend does not support masking.",
-    )
     def test_rank_adjustment(self):
         for uprank in ["mask", "sample_weight", "ys"]:
             sample_weight = np.array([0.4, 0.3, 0.2, 0.1])
@@ -213,7 +196,7 @@ class LossTest(testing.TestCase):
             mask = ops.convert_to_tensor(mask)
             y_true = ops.convert_to_tensor(y_true)
             y_pred = ops.convert_to_tensor(y_pred)
-            y_pred._keras_mask = mask
+            backend.set_keras_mask(y_pred, mask)
 
             loss_fn = ExampleLoss()
             loss = loss_fn(y_true, y_pred, sample_weight=sample_weight)


### PR DESCRIPTION
Follow-up to https://github.com/keras-team/keras/pull/22491

Simply, `backend.set_keras_mask` needs to be used to support NumPy.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
