### PR TITLE
Fix: reject decompression-bomb archive members when loading a `.keras` model

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -431,10 +431,43 @@ def _model_from_config(config_json, custom_objects, compile, safe_mode):
     return model
 
 
+# Guard against ZIP "decompression bomb" archive members (CWE-409): a member
+# can store almost nothing on disk yet declare an enormous uncompressed size,
+# forcing a huge allocation when it is read into memory. Keras writes archive
+# members uncompressed (stored, ratio ~1:1) and DEFLATE cannot exceed ~1032:1,
+# so a member that both exceeds the floor and expands to more than
+# `_ZIP_MEMBER_MAX_EXPANSION`x its on-disk size is a bomb, not a genuine
+# artifact (this leaves ample headroom for an incidentally recompressed file).
+# The 4 GiB floor matches the HDF5 dataset guard for CVE-2026-0897.
+_ZIP_MEMBER_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
+_ZIP_MEMBER_MAX_EXPANSION = 100
+
+
+def _reject_zip_bomb(archive, name):
+    """Raise if a ZIP member is a decompression bomb (see CWE-409)."""
+    info = archive.getinfo(name)
+    if (
+        info.file_size > _ZIP_MEMBER_BOMB_FLOOR_BYTES
+        and info.file_size > _ZIP_MEMBER_MAX_EXPANSION * info.compress_size
+    ):
+        raise ValueError(
+            f"Not allowed: ZIP member '{name}' declares "
+            f"{readable_memory_size(info.file_size)} but only "
+            f"{readable_memory_size(info.compress_size)} are stored on disk; "
+            "refusing to load a potential decompression bomb."
+        )
+
+
+def _safe_zip_read(archive, name):
+    """Read a ZIP member into memory, rejecting bombs (see CWE-409)."""
+    _reject_zip_bomb(archive, name)
+    with archive.open(name, "r") as f:
+        return f.read()
+
+
 def _load_model_from_fileobj(fileobj, custom_objects, compile, safe_mode):
     with zipfile.ZipFile(fileobj, "r") as zf:
-        with zf.open(_CONFIG_FILENAME, "r") as f:
-            config_json = f.read()
+        config_json = _safe_zip_read(zf, _CONFIG_FILENAME)
 
         model = _model_from_config(
             config_json, custom_objects, compile, safe_mode
@@ -446,6 +479,12 @@ def _load_model_from_fileobj(fileobj, custom_objects, compile, safe_mode):
         asset_store = None
         try:
             if _VARS_FNAME_H5 in all_filenames:
+                # Reject a decompression-bomb weights member up front, outside
+                # the try/except below: the bare `except` falls back to reading
+                # the weights on the fly, so a check inside it would be
+                # swallowed and the bomb still read. Checking here covers the
+                # in-memory, extract-to-disk, and on-the-fly paths at once.
+                _reject_zip_bomb(zf, _VARS_FNAME_H5)
                 try:
                     if is_memory_sufficient(model):
                         # Load the entire file into memory if the system memory
@@ -1388,7 +1427,7 @@ class ShardedH5IOStore(H5IOStore):
         else:
             if self.archive:
                 self.sharding_config = json.loads(
-                    self.archive.open(str(self.path), "r").read()
+                    _safe_zip_read(self.archive, str(self.path))
                 )
             else:
                 with open(self.path, "r") as map_file:

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1639,3 +1639,76 @@ class SavingH5IOStoreTest(testing.TestCase):
             del vars_store["abc"]
 
         store.close()
+
+
+class SafeZipReadTest(testing.TestCase):
+    def _zip_with_member(self, name, data, compression=zipfile.ZIP_DEFLATED):
+        path = os.path.join(self.get_temp_dir(), "a.zip")
+        with zipfile.ZipFile(path, "w", compression=compression) as zf:
+            zf.writestr(name, data)
+        return path
+
+    def test_rejects_decompression_bomb(self):
+        # Highly compressible member: large declared size, ~nothing on disk.
+        path = self._zip_with_member("config.json", b"A" * 100_000)
+        with (
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64),
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_MAX_EXPANSION", 10),
+        ):
+            with zipfile.ZipFile(path, "r") as zf:
+                with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                    saving_lib._safe_zip_read(zf, "config.json")
+
+    def test_allows_incompressible_member(self):
+        # Stored (uncompressed) member: declared size == stored size.
+        data = os.urandom(100_000)
+        path = self._zip_with_member("w", data, compression=zipfile.ZIP_STORED)
+        with mock.patch.object(saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64):
+            with zipfile.ZipFile(path, "r") as zf:
+                self.assertEqual(saving_lib._safe_zip_read(zf, "w"), data)
+
+    def test_load_model_rejects_bomb_config(self):
+        # End-to-end: a tiny `.keras` whose config.json decompresses huge is
+        # rejected before the read allocates, with safe_mode=True.
+        path = os.path.join(self.get_temp_dir(), "bomb.keras")
+        payload = b'{"x":"' + b" " * 200_000 + b'"}'
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("metadata.json", b'{"keras_version":"3"}')
+            zf.writestr("config.json", payload)
+        self.assertLess(os.path.getsize(path), 1 << 16)  # tiny file on disk
+        with (
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64),
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_MAX_EXPANSION", 10),
+        ):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                saving_lib.load_model(path)
+
+    def test_load_model_rejects_bomb_weights(self):
+        # A bomb `model.weights.h5` member must be rejected up front, before the
+        # in-memory / extract-to-disk / on-the-fly read paths (and not swallowed
+        # by the on-the-fly fallback's bare `except`).
+        import keras
+
+        model = keras.Sequential([keras.Input((4,)), keras.layers.Dense(3)])
+        good = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(good)
+        with zipfile.ZipFile(good) as zf:
+            cfg = zf.read("config.json")
+            meta = zf.read("metadata.json")
+
+        evil = os.path.join(self.get_temp_dir(), "evil.keras")
+        with zipfile.ZipFile(
+            evil, "w"
+        ) as zf:  # config/metadata stored (ratio 1)
+            zf.writestr("metadata.json", meta)
+            zf.writestr("config.json", cfg)
+            info = zipfile.ZipInfo("model.weights.h5")
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, b"\x00" * 200_000)  # deflated bomb member
+
+        with (
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64),
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_MAX_EXPANSION", 10),
+        ):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                saving_lib.load_model(evil)


### PR DESCRIPTION
## Summary

`_load_model_from_fileobj` (behind `keras.saving.load_model`) reads
`config.json`, the embedded `model.weights.h5`, and the shard map straight
into memory (or extracts them to disk) with no bound on the decompressed size.
The `config.json` read is the very first thing the loader does — before the
model is built, before weights are touched, and regardless of `safe_mode`.

A ZIP member can store almost nothing on disk yet declare an enormous
uncompressed size. A crafted `.keras` of a few MB can therefore declare a
multi-gigabyte member; reading it allocates memory for the **declared** size
(OOM-kill) or, on the extract-to-disk weights path, writes the full decompressed
member to disk (disk exhaustion) — CWE-409. No Lambda, no custom objects, and
`safe_mode=True` does not help (the read precedes deserialization).

Verified on master: a 1.5 MB `.keras` (config.json declaring 1.5 GiB) drives
`keras.saving.load_model(..., safe_mode=True)` toward a multi-GiB allocation;
scaling the member up reaches OOM.

## Relationship to CVE-2026-0897

CVE-2026-0897 / GHSA-mgx6 addressed the same class one layer down: an HDF5
*dataset* that declares far more data than it stores, guarded in
`safe_get_h5_dataset` by a declared-vs-stored ratio check. The `.keras`
*container* itself was not covered — the same "tiny on disk, huge in memory"
primitive is still reachable through the archive members the loader reads
before (and around) the HDF5 layer. This PR adds the equivalent guard at the
ZIP-member layer.

## Fix

`keras/src/saving/saving_lib.py`:

- Add `_reject_zip_bomb(archive, name)` — rejects a member whose declared size
  (`ZipInfo.file_size`) both exceeds a floor (4 GiB, matching the HDF5 dataset
  guard) and exceeds its on-disk size (`ZipInfo.compress_size`) by more than
  100x — and `_safe_zip_read` (checks, then reads into memory).
- Guard `config.json` and the sharded `weight_map` via `_safe_zip_read`.
- Guard `model.weights.h5` via `_reject_zip_bomb` placed **before** the
  in-memory / extract-to-disk / on-the-fly `try/except`. The bare `except`
  there falls back to reading the weights on the fly, so a check *inside* it
  would be swallowed and the bomb still read; checking up front covers all
  three weights-read paths at once.

Keras writes archive members uncompressed (ratio ~1:1) and DEFLATE cannot
exceed ~1032:1, so genuine artifacts — including arbitrarily large legitimate
models — stay well under the factor; the storage-ratio check (rather than a
flat cap) keeps large legitimate models loadable.

## Test plan

`keras/src/saving/saving_lib_test.py` — new `SafeZipReadTest`:

- `test_rejects_decompression_bomb`: a highly-compressible member is rejected
  by `_safe_zip_read`.
- `test_allows_incompressible_member`: an ordinary (stored) member is returned
  unchanged.
- `test_load_model_rejects_bomb_config`: end-to-end, `keras.saving.load_model`
  on a tiny `.keras` whose `config.json` decompresses huge is rejected.
- `test_load_model_rejects_bomb_weights`: end-to-end, a bomb `model.weights.h5`
  member is rejected up front (covering the extract/on-the-fly paths).

```
$ pytest keras/src/saving/saving_lib_test.py -k SafeZipRead
4 passed
```

`ruff check` and `ruff format` pass on the changed files.

## Disclosure

Reported via huntr (decompression-bomb sibling of CVE-2026-0897 /
GHSA-mgx6-5cf9-rr43 at the `.keras` archive-container layer).
<!-- huntr bounty link: add here -->

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
