### PR TITLE
Fix torch median to average the two middle values for even-length inputs

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1265,44 +1265,12 @@ def maximum(x1, x2):
 
 def median(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    compute_dtype = dtypes.result_type(x.dtype, "float32")
-    result_dtype = dtypes.result_type(x.dtype, float)
-    x = cast(x, compute_dtype)
 
-    if axis is None and keepdims is False:
-        return cast(torch.median(x), result_dtype)
-    elif isinstance(axis, int):
-        return cast(
-            torch.median(x, dim=axis, keepdim=keepdims)[0], result_dtype
-        )
-
-    # support multiple axes
-    if axis is None:
-        y = reshape(x, [-1])
-    else:
-        # transpose
-        axis = [canonicalize_axis(a, x.ndim) for a in axis]
-        other_dims = sorted(set(range(x.ndim)).difference(axis))
-        perm = other_dims + list(axis)
-        x_permed = torch.permute(x, dims=perm)
-        # reshape
-        x_shape = list(x.shape)
-        other_shape = [x_shape[i] for i in other_dims]
-        end_shape = [math.prod([x_shape[i] for i in axis])]
-        full_shape = other_shape + end_shape
-        y = reshape(x_permed, full_shape)
-
-    y = torch.median(y, dim=-1)[0]
-
-    if keepdims:
-        if axis is None:
-            for _ in range(x.ndim):
-                y = expand_dims(y, axis=-1)
-        else:
-            for i in sorted(axis):
-                y = expand_dims(y, axis=i)
-
-    return cast(y, result_dtype)
+    # `torch.median` returns the lower of the two middle values for an
+    # even-length reduction, whereas numpy and the other backends average
+    # them. Delegate to `quantile(q=0.5)`, which averages (and returns a
+    # float result, including for an empty `axis`), matching numpy.
+    return quantile(x, q=0.5, axis=axis, keepdims=keepdims)
 
 
 def meshgrid(*x, indexing="xy"):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6028,6 +6028,18 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             np.median(x, axis=1, keepdims=True),
         )
 
+        # Even-length reductions must average the two middle values. The
+        # torch backend previously returned the lower one (e.g. 2.0 instead
+        # of 2.5 for `[1, 2, 3, 4]`).
+        x_even = np.array([[1, 2, 3, 4], [10, 20, 30, 40]]).astype("float32")
+        self.assertAllClose(knp.median(x_even), np.median(x_even))
+        self.assertAllClose(
+            knp.median(x_even, axis=0), np.median(x_even, axis=0)
+        )
+        self.assertAllClose(
+            knp.median(x_even, axis=1), np.median(x_even, axis=1)
+        )
+
         self.assertAllClose(knp.Median()(x), np.median(x))
         self.assertAllClose(knp.Median(axis=1)(x), np.median(x, axis=1))
         self.assertAllClose(


### PR DESCRIPTION
## Summary

`keras.ops.median` returns the wrong value on the torch backend for any reduction over an even number of elements. `torch.median` returns the lower of the two middle values, whereas numpy (which `keras.ops` mirrors) and the jax/tensorflow backends average them.

```python
import numpy as np
from keras import ops
# torch backend
ops.median(ops.convert_to_tensor(np.array([1., 2., 3., 4.])))  # 2.0  (wrong)
# numpy / jax / tensorflow backends, and np.median: 2.5
```

This was wrong on every code path (full reduction, single axis, multiple axes, with and without `keepdims`).

The fix delegates to `quantile(x, q=0.5, ...)`, whose default `method="linear"` averages the two middle values, matching numpy. This mirrors how `nanmedian` in the same module is already implemented (it delegates to `nanquantile(q=0.5)`), and lets the multi-axis / `keepdims` handling reuse the tested `quantile` path instead of a separate implementation.

The existing correctness test only used `[[1, 2, 3], [3, 2, 1]]`, where the two middle values of the flattened array are both `2` (so the lower value coincidentally equals the average) and the `axis=1` reductions are odd-length. No assertion ever exercised an even-length reduction whose middle values differ. This PR adds an even-length case.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.