### PR TITLE
Save output_padding in Conv1D/2D/3DTranspose get_config

### DIFF
--- a/keras/src/layers/convolutional/base_conv_transpose.py
+++ b/keras/src/layers/convolutional/base_conv_transpose.py
@@ -255,6 +255,7 @@ class BaseConvTranspose(Layer):
                 "kernel_size": self.kernel_size,
                 "strides": self.strides,
                 "padding": self.padding,
+                "output_padding": self.output_padding,
                 "data_format": self.data_format,
                 "dilation_rate": self.dilation_rate,
                 "activation": activations.serialize(self.activation),

--- a/keras/src/layers/convolutional/conv_transpose_test.py
+++ b/keras/src/layers/convolutional/conv_transpose_test.py
@@ -500,23 +500,32 @@ class ConvTransposeBasicTest(testing.TestCase):
             supports_masking=False,
         )
 
-    def test_output_padding_serialization(self):
+    @parameterized.parameters(
+        {
+            "layer_cls": layers.Conv1DTranspose,
+            "input_shape": (1, 8, 3),
+        },
+        {
+            "layer_cls": layers.Conv2DTranspose,
+            "input_shape": (1, 5, 5, 3),
+        },
+        {
+            "layer_cls": layers.Conv3DTranspose,
+            "input_shape": (1, 5, 5, 5, 3),
+        },
+    )
+    def test_output_padding_serialization(self, layer_cls, input_shape):
         # `output_padding` was previously dropped from `get_config`, so a
         # round-trip silently reset it to `None` and changed the output shape.
-        for layer_cls, input_shape in [
-            (layers.Conv1DTranspose, (1, 8, 3)),
-            (layers.Conv2DTranspose, (1, 5, 5, 3)),
-            (layers.Conv3DTranspose, (1, 5, 5, 5, 3)),
-        ]:
-            layer = layer_cls(2, 3, strides=2, output_padding=1)
-            config = layer.get_config()
-            self.assertIn("output_padding", config)
-            revived = layer_cls.from_config(config)
-            self.assertEqual(layer.output_padding, revived.output_padding)
-            self.assertEqual(
-                layer.compute_output_shape(input_shape),
-                revived.compute_output_shape(input_shape),
-            )
+        layer = layer_cls(2, 3, strides=2, output_padding=1)
+        config = layer.get_config()
+        self.assertIn("output_padding", config)
+        revived = layer_cls.from_config(config)
+        self.assertEqual(layer.output_padding, revived.output_padding)
+        self.assertEqual(
+            layer.compute_output_shape(input_shape),
+            revived.compute_output_shape(input_shape),
+        )
 
     def test_bad_init_args(self):
         # `filters` is not positive.

--- a/keras/src/layers/convolutional/conv_transpose_test.py
+++ b/keras/src/layers/convolutional/conv_transpose_test.py
@@ -500,6 +500,24 @@ class ConvTransposeBasicTest(testing.TestCase):
             supports_masking=False,
         )
 
+    def test_output_padding_serialization(self):
+        # `output_padding` was previously dropped from `get_config`, so a
+        # round-trip silently reset it to `None` and changed the output shape.
+        for layer_cls, input_shape in [
+            (layers.Conv1DTranspose, (1, 8, 3)),
+            (layers.Conv2DTranspose, (1, 5, 5, 3)),
+            (layers.Conv3DTranspose, (1, 5, 5, 5, 3)),
+        ]:
+            layer = layer_cls(2, 3, strides=2, output_padding=1)
+            config = layer.get_config()
+            self.assertIn("output_padding", config)
+            revived = layer_cls.from_config(config)
+            self.assertEqual(layer.output_padding, revived.output_padding)
+            self.assertEqual(
+                layer.compute_output_shape(input_shape),
+                revived.compute_output_shape(input_shape),
+            )
+
     def test_bad_init_args(self):
         # `filters` is not positive.
         with self.assertRaisesRegex(


### PR DESCRIPTION
## Summary

`Conv1DTranspose`, `Conv2DTranspose`, and `Conv3DTranspose` accept an `output_padding` argument and store it as `self.output_padding`, but the shared `get_config` in `BaseConvTranspose` never emits it. A `from_config(get_config())` round-trip (e.g. `save` / `load_model`) silently resets `output_padding` to `None`, which changes the layer's output shape - the reloaded model is a different architecture, and its weights no longer line up with the surrounding layers.

The fix adds `output_padding` to `BaseConvTranspose.get_config`, covering all three transpose layers.

`run_layer_test` did not catch this because it compares the revived layer's re-serialized config against the original config, and since both omitted `output_padding` they matched while the behavior silently changed. This PR adds an explicit round-trip test that constructs the layers with `output_padding`, reserializes, and asserts both `output_padding` and the computed output shape are preserved.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.