### PR TITLE
Resolve paths with realpath to prevent symlink traversal during archive extraction

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -41,7 +41,7 @@ def path_to_string(path):
 
 
 def resolve_path(path):
-    return os.path.realpath(os.path.abspath(path))
+    return os.path.realpath(path)
 
 
 def resolve_sub_path(base_dir, relative_path):

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -216,6 +216,20 @@ class FilterSafePathsTest(test_case.TestCase):
                 members[0].issym()
             )  # Explicitly assert it's a symbolic link.
 
+    def test_file_routed_through_symlink_is_rejected(self):
+        """A member routed through an in-bounds symlink via `..` is rejected."""
+        os.symlink(".", os.path.join(self.base_dir, "link"))
+        with tarfile.open(self.tar_path, "w") as tar:
+            tar.add(
+                self.target_path,
+                arcname=os.path.join("link", "..", "escaped.txt"),
+            )
+        with tarfile.open(self.tar_path, "r") as tar:
+            members = list(
+                file_utils.filter_safe_tarinfos(tar.getmembers(), self.base_dir)
+            )
+            self.assertEqual(members, [])
+
 
 class ExtractArchiveTest(test_case.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

`keras.utils.get_file(extract=True)` and `keras.utils.extract_archive` validate each
TAR member against the extraction directory using `resolve_sub_path`, which relies on
`resolve_path`:

```python
def resolve_path(path):
    return os.path.realpath(os.path.abspath(path))
```

`os.path.abspath` collapses `..` segments **lexically** (as text) *before* any symlink
is resolved. For a member named `link/../x`, the `..` cancels the `link` component
textually, so the subsequent `realpath` never traverses the symlink. The containment
check then concludes the member stays inside the extraction directory, while
`tarfile.extractall` writes it to the **real** location reached by following the
symlink — outside the directory.

As a result, an archive containing an in-bounds symlink `link -> .` plus a regular
file `link/../<name>` writes `<name>` into the **parent** of the extraction directory
(and chaining symlinks reaches deeper paths). Writing outside the extraction directory
during archive extraction is the issue this validation is meant to prevent.

## Fix

Use `os.path.realpath(path)` directly. `realpath` already returns an absolute path and
resolves symlinks component by component, so `..` is applied *after* the symlink is
resolved and `resolve_sub_path` correctly rejects members that escape the base
directory. For paths without a symlink-then-`..` sequence the result is unchanged.

## Reproduction (before this PR)

```python
import io, os, tarfile, tempfile, keras
work = tempfile.mkdtemp(); cache = os.path.join(work, "cache"); os.makedirs(cache)
tp = os.path.join(work, "evil.tar.gz")
with tarfile.open(tp, "w:gz") as tf:
    sl = tarfile.TarInfo("ln"); sl.type = tarfile.SYMTYPE; sl.linkname = "."
    tf.addfile(sl)
    data = b"escaped\n"
    fi = tarfile.TarInfo("ln/../ESCAPED"); fi.size = len(data)
    tf.addfile(fi, io.BytesIO(data))
keras.utils.get_file(fname="a", origin="file://"+tp, extract=True,
                     cache_dir=cache, cache_subdir="datasets")
# before: cache/datasets/ESCAPED exists (outside cache/datasets/a)
# after:  the member is skipped; nothing is written outside the extraction dir
```

## Tests

Added `FilterSafePathsTest.test_file_routed_through_symlink_is_rejected`. It fails on the
previous implementation and passes with this change. All existing `file_utils` tests
continue to pass.

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
