### PR TITLE
Reject npz weight members that declare far more data than is stored

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -13,6 +13,7 @@ import zipfile
 
 import ml_dtypes
 import numpy as np
+from numpy.lib import format as npy_format
 
 from keras.src import backend
 from keras.src.backend.common import global_state
@@ -47,6 +48,11 @@ _VARS_FNAME_H5 = f"{_VARS_FNAME}.h5"
 _VARS_FNAME_NPZ = f"{_VARS_FNAME}.npz"
 _ASSETS_DIRNAME = "assets"
 _MEMORY_UPPER_BOUND = 0.5  # 50%
+# An npz member is rejected as a shape/decompression "bomb" when its declared
+# array size exceeds both this floor and this multiple of its stored size.
+# Mirrors the `_ZIP_MEMBER_*` guard used by `_reject_zip_bomb`.
+_NPZ_MEMBER_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
+_NPZ_MEMBER_MAX_EXPANSION = 100
 
 
 _MODEL_CARD_TEMPLATE = """
@@ -1748,8 +1754,46 @@ class NpzIOStore:
                 return dict(self.contents["__root__"])
             return {}
         if path in self.contents:
+            self._reject_npz_bomb(path)
             return self.contents[path].tolist()
         return {}
+
+    def _reject_npz_bomb(self, path):
+        """Guard against npz shape/decompression bombs.
+
+        Reading `self.contents[path]` makes NumPy allocate an array sized to
+        the `.npy` header's declared shape before the stored data is
+        validated, so a tiny member can declare a huge shape and drive an
+        unbounded allocation. Reject a member whose declared size hugely
+        exceeds the number of bytes actually stored for it.
+        """
+        zip_file = getattr(self.contents, "zip", None)
+        if zip_file is None:
+            return
+        try:
+            info = zip_file.getinfo(f"{path}.npy")
+        except KeyError:
+            return
+        with zip_file.open(info) as member_file:
+            major, _ = npy_format.read_magic(member_file)
+            read_header = getattr(
+                npy_format,
+                f"read_array_header_{major}_0",
+                npy_format.read_array_header_2_0,
+            )
+            shape, _, dtype = read_header(member_file)
+        declared_bytes = math.prod(shape) * dtype.itemsize
+        stored_bytes = max(info.compress_size, 1)
+        if (
+            declared_bytes > _NPZ_MEMBER_BOMB_FLOOR_BYTES
+            and declared_bytes > _NPZ_MEMBER_MAX_EXPANSION * stored_bytes
+        ):
+            raise ValueError(
+                f"Refusing to load npz weight '{path}': its header declares "
+                f"{readable_memory_size(declared_bytes)} but only "
+                f"{readable_memory_size(info.compress_size)} is stored on "
+                "disk; refusing to load a potential decompression bomb."
+            )
 
     def has_path(self, path):
         """Return True if `path` exists as a key in the npz contents."""

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1769,3 +1769,36 @@ class SafeGetH5DatasetTest(testing.TestCase):
         )
         with self.assertRaises(ValueError):
             reloaded.load_weights(good_path)
+
+
+class SavingNpzIOStoreTest(testing.TestCase):
+    def _write_npz_member(self, path, name, shape, descr="<f8", data=b""):
+        """Write an npz `name` member declaring `shape` but storing no `data`.
+
+        Used to craft a member whose `.npy` header declares a huge array while
+        almost nothing is stored on disk (a shape/decompression bomb).
+        """
+        header = BytesIO()
+        np.lib.format.write_array_header_1_0(
+            header,
+            {"descr": descr, "fortran_order": False, "shape": shape},
+        )
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(f"{name}.npy", header.getvalue() + data)
+
+    def test_npz_io_store_rejects_shape_bomb(self):
+        # Member declares an 8 PiB array but stores only its header.
+        temp_filepath = os.path.join(self.get_temp_dir(), "bomb.npz")
+        self._write_npz_member(temp_filepath, "w", shape=(2**50,))
+        store = saving_lib.NpzIOStore(temp_filepath, mode="r")
+        with self.assertRaisesRegex(
+            ValueError, r"Refusing to load npz weight 'w'"
+        ):
+            store.get("w")
+
+    def test_npz_io_store_loads_normal_array(self):
+        temp_filepath = os.path.join(self.get_temp_dir(), "store.npz")
+        a = np.arange(6, dtype="float32").reshape(2, 3)
+        np.savez(temp_filepath, w=a)
+        store = saving_lib.NpzIOStore(temp_filepath, mode="r")
+        self.assertAllClose(store.get("w"), a.tolist())


### PR DESCRIPTION
## Summary

`keras.saving.load_model` selects the npz weight reader `NpzIOStore` whenever the model
archive contains `model.weights.npz` and not `model.weights.h5`. That choice is made
purely from the archive's file list, so an attacker who supplies the `.keras` file
controls which reader runs.

`NpzIOStore.get` returns `self.contents[path].tolist()`. Accessing `self.contents[path]`
makes NumPy read the corresponding `.npy` member and allocate an `ndarray` sized to the
member's **declared header shape** before any of the stored data is validated. A `.npy`
header can declare an enormous shape while carrying little or no data, so a tiny member
drives a huge allocation. `safe_mode=True` does not gate weight I/O and provides no
protection here.

A ~2 KB crafted `.keras` therefore forces an arbitrarily large allocation through the
standard model-loading API. Two impact variants:

- an astronomical declared shape that NumPy refuses up front (`MemoryError`, surfaced as
  a failed load); and
- a shape tuned near the victim's RAM whose zero-filled member compresses heavily, so
  the array is actually materialized and the kernel OOM killer terminates the process
  (uncatchable `SIGKILL`).

## Fix

Before materializing a member, peek its `.npy` header (`read_magic` +
`read_array_header_*`, which does not allocate) and reject the member when its declared
size exceeds **both** a 4 GiB floor **and** 100x the bytes actually stored for it
(`ZipInfo.compress_size`). Keras writes npz with `np.savez` (uncompressed), so legitimate
members have a declared/stored ratio near 1 and are unaffected; only members that declare
far more than they store (the bomb signature) are rejected.

## Reproduction (before this PR)

```python
import io, zipfile
import numpy as np
import numpy.lib.format as fmt
from keras.src.saving.saving_lib import NpzIOStore

hdr = io.BytesIO()
fmt.write_array_header_1_0(hdr, {"descr": "<f8", "fortran_order": False, "shape": (2**50,)})
with zipfile.ZipFile("bomb.npz", "w", zipfile.ZIP_DEFLATED) as zf:
    zf.writestr("w.npy", hdr.getvalue())   # ~190 byte file

NpzIOStore("bomb.npz", mode="r").get("w")
# before: MemoryError: Unable to allocate 8.00 PiB ...
# after:  ValueError: Refusing to load npz weight 'w': ... only 83 bytes are stored ...
```

## Tests

Added `SavingNpzIOStoreTest` with `test_npz_io_store_rejects_shape_bomb` (a member
declaring 8 PiB while storing only its header is rejected) and
`test_npz_io_store_loads_normal_array` (a normal array still loads). Existing
`H5IOStore`/`ShardedH5IOStore` tests continue to pass.

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
