### PR TITLE
Validate DiskIOStore asset paths stay within the working directory

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1076,10 +1076,31 @@ class DiskIOStore:
                 ).replace("\\", "/")
                 file_utils.makedirs(self.working_dir)
 
+    def _full_path(self, path):
+        """Resolve `path` under the working dir, rejecting traversal."""
+        # Normalize separators first so a `\\` cannot bypass the check below.
+        path = path.replace("\\", "/")
+        if file_utils.is_remote_path(self.working_dir):
+            # `resolve_path` (realpath/abspath) would corrupt a remote prefix
+            # such as `gs://bucket`, so validate remote paths by string.
+            if path.startswith("/") or "://" in path or ".." in path.split("/"):
+                raise ValueError(
+                    f"Invalid asset path: '{path}' escapes the asset directory."
+                )
+            return file_utils.join(self.working_dir, path).replace("\\", "/")
+        resolved = file_utils.resolve_sub_path(
+            file_utils.resolve_path(self.working_dir), path
+        )
+        if resolved is None:
+            raise ValueError(
+                f"Invalid asset path: '{path}' escapes the asset directory."
+            )
+        return resolved.replace("\\", "/")
+
     def make(self, path):
         if not path:
             return self.working_dir
-        path = file_utils.join(self.working_dir, path).replace("\\", "/")
+        path = self._full_path(path)
         if not file_utils.exists(path):
             file_utils.makedirs(path)
         return path
@@ -1087,16 +1108,19 @@ class DiskIOStore:
     def get(self, path):
         if not path:
             return self.working_dir
-        path = file_utils.join(self.working_dir, path).replace("\\", "/")
+        path = self._full_path(path)
         if file_utils.exists(path):
             return path
         return None
 
     def has_path(self, path):
         """Return True if `path` exists on disk under the store's root."""
-        return file_utils.exists(
-            file_utils.join(self.working_dir, path).replace("\\", "/")
-        )
+        if not path:
+            return file_utils.exists(self.working_dir)
+        try:
+            return file_utils.exists(self._full_path(path))
+        except ValueError:
+            return False
 
     def close(self):
         if self.mode == "w" and self.archive:

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1769,3 +1769,43 @@ class SafeGetH5DatasetTest(testing.TestCase):
         )
         with self.assertRaises(ValueError):
             reloaded.load_weights(good_path)
+
+
+class SavingDiskIOStoreTest(testing.TestCase):
+    def test_disk_io_store_rejects_path_traversal(self):
+        store = saving_lib.DiskIOStore("assets", archive=None, mode="w")
+        working_dir = os.path.realpath(store.working_dir)
+        for bad in ["../escape", os.path.join("a", "..", "..", "escape"), ".."]:
+            with self.assertRaisesRegex(ValueError, "Invalid asset path"):
+                store.make(bad)
+            with self.assertRaisesRegex(ValueError, "Invalid asset path"):
+                store.get(bad)
+            self.assertFalse(store.has_path(bad))
+        # Nothing was created outside the working directory.
+        self.assertFalse(
+            os.path.exists(os.path.join(os.path.dirname(working_dir), "escape"))
+        )
+        # Normal nested asset paths still work.
+        made = store.make(os.path.join("layers", "dense"))
+        self.assertTrue(os.path.isdir(made))
+        self.assertTrue(os.path.realpath(made).startswith(working_dir + os.sep))
+        self.assertIsNotNone(store.get(os.path.join("layers", "dense")))
+        store.close()
+
+    def test_disk_io_store_rejects_backslash_traversal(self):
+        store = saving_lib.DiskIOStore("assets", archive=None, mode="w")
+        for bad in ["..\\escape", "a\\..\\..\\escape"]:
+            with self.assertRaisesRegex(ValueError, "Invalid asset path"):
+                store.make(bad)
+        store.close()
+
+    def test_disk_io_store_remote_working_dir_is_preserved(self):
+        store = saving_lib.DiskIOStore(
+            "gs://bucket/model", archive=None, mode="r"
+        )
+        resolved = store._full_path(os.path.join("layers", "dense"))
+        self.assertTrue(resolved.startswith("gs://bucket/model/"))
+        self.assertTrue(resolved.endswith("layers/dense"))
+        for bad in ["../escape", "/abs", os.path.join("x", "..", "..", "y")]:
+            with self.assertRaisesRegex(ValueError, "Invalid asset path"):
+                store._full_path(bad)


### PR DESCRIPTION
## Summary

`DiskIOStore` (the asset store used by `save_model`/`load_model` and the Orbax asset path)
joins a caller-supplied asset path onto its working directory:

```python
def make(self, path):           # creates the directory
    path = file_utils.join(self.working_dir, path).replace("\\", "/")
    if not file_utils.exists(path):
        file_utils.makedirs(path)
    return path

def get(self, path):            # returns the path for reading
    path = file_utils.join(self.working_dir, path).replace("\\", "/")
    ...
```

No check verifies that the joined path stays inside `working_dir`. This is the one asset
I/O path in the save/load pipeline that skips the containment already applied elsewhere:
archive extraction goes through `filter_safe_tarinfos`/`filter_safe_zipinfos`, and the Orbax
asset writer `_write_nested_dict_to_dir` calls `resolve_sub_path` — but `DiskIOStore.make`/
`get` do not. A `make()` with a path containing `..` would create a directory (and a saveable
would then write its asset) outside the asset directory.

This is a **defense-in-depth / consistency** fix: in the current code the asset path passed to
`DiskIOStore` is derived from class names and Python attribute names (not from attacker-
controlled config strings), so I am not claiming a presently-reachable exploit. The point is
that this sink lacks the containment the rest of the pipeline has, and should not be the weak
link if a future saveable ever routes config-derived names into the asset path.

## Fix

Add a `_full_path` helper that resolves the path with `resolve_sub_path` (the same primitive
used by archive extraction and Orbax assets) and rejects anything that escapes `working_dir`;
use it in `make`/`get`/`has_path`. Normal nested asset paths (e.g. `layers/dense`) are
unaffected.

## Tests

Added `SavingDiskIOStoreTest.test_disk_io_store_rejects_path_traversal` (traversal via `..` is
rejected in `make`/`get`/`has_path`, nothing is created outside the working dir, and normal
nested paths still work). The existing asset round-trip test
`SavingTest::test_saving_custom_assets_and_variables` and the `H5IOStore`/`ShardedH5IOStore`
tests continue to pass.

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
