### PR TITLE
Suppress spurious 'Skipping nested container' warning on freshly-saved files

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -883,6 +883,37 @@ def _container_path_present(weights_store, assets_store, path):
     )
 
 
+def _container_has_unvisited_saveables(container, visited_saveables, seen=None):
+    """True if `container` transitively holds an unvisited `KerasSaveable`.
+
+    A container can show up in the in-memory traversal even when its state
+    has no corresponding group in the saved file — either because it holds
+    no `KerasSaveable` at all (e.g. lists of strings inside
+    `variable_serialization_spec`), or because every saveable in it was
+    already loaded via another path (e.g. `_operations_by_depth` mirrors
+    the `layers` collection that's loaded first). In neither case is a
+    missing group an error worth warning about.
+    """
+    from keras.src.saving.keras_saveable import KerasSaveable
+
+    if seen is None:
+        seen = set()
+    if id(container) in seen:
+        return False
+    seen.add(id(container))
+    if isinstance(container, dict):
+        container = container.values()
+    for item in container:
+        if isinstance(item, KerasSaveable):
+            if visited_saveables is None or id(item) not in visited_saveables:
+                return True
+        elif isinstance(
+            item, (list, dict, tuple)
+        ) and _container_has_unvisited_saveables(item, visited_saveables, seen):
+            return True
+    return False
+
+
 def _save_container_state(
     container,
     weights_store,
@@ -976,19 +1007,28 @@ def _load_container_state(
             if not _container_path_present(
                 weights_store, assets_store, nested_path
             ):
-                # Legacy files saved before PR #22362 didn't write the
-                # `container*` groups for nested containers — silently
-                # skip so the model still loads (sublayers keep their
-                # freshly-initialized weights).
-                warnings.warn(
-                    f"Skipping nested container at '{nested_path}': no "
-                    "matching group found in the saved file. This usually "
-                    "means the file was saved with a Keras version that "
-                    "did not serialize sublayers nested inside containers. "
-                    "Affected layers will retain their freshly-initialized "
-                    "weights.",
-                    stacklevel=2,
-                )
+                # Only warn when the in-memory container would actually have
+                # contributed loadable state — i.e. it transitively holds at
+                # least one `KerasSaveable`. Containers of pure metadata
+                # (e.g. lists of strings inside `variable_serialization_spec`)
+                # have nothing to load and a missing group there is expected,
+                # not an error.
+                if _container_has_unvisited_saveables(
+                    saveable, visited_saveables
+                ):
+                    # Legacy files saved before PR #22362 didn't write the
+                    # `container*` groups for nested containers — silently
+                    # skip so the model still loads (sublayers keep their
+                    # freshly-initialized weights).
+                    warnings.warn(
+                        f"Skipping nested container at '{nested_path}': no "
+                        "matching group found in the saved file. This "
+                        "usually means the file was saved with a Keras "
+                        "version that did not serialize sublayers nested "
+                        "inside containers. Affected layers will retain "
+                        "their freshly-initialized weights.",
+                        stacklevel=2,
+                    )
                 continue
             _load_container_state(
                 saveable,

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -883,37 +883,6 @@ def _container_path_present(weights_store, assets_store, path):
     )
 
 
-def _container_has_unvisited_saveables(container, visited_saveables, seen=None):
-    """True if `container` transitively holds an unvisited `KerasSaveable`.
-
-    A container can show up in the in-memory traversal even when its state
-    has no corresponding group in the saved file — either because it holds
-    no `KerasSaveable` at all (e.g. lists of strings inside
-    `variable_serialization_spec`), or because every saveable in it was
-    already loaded via another path (e.g. `_operations_by_depth` mirrors
-    the `layers` collection that's loaded first). In neither case is a
-    missing group an error worth warning about.
-    """
-    from keras.src.saving.keras_saveable import KerasSaveable
-
-    if seen is None:
-        seen = set()
-    if id(container) in seen:
-        return False
-    seen.add(id(container))
-    if isinstance(container, dict):
-        container = container.values()
-    for item in container:
-        if isinstance(item, KerasSaveable):
-            if visited_saveables is None or id(item) not in visited_saveables:
-                return True
-        elif isinstance(
-            item, (list, dict, tuple)
-        ) and _container_has_unvisited_saveables(item, visited_saveables, seen):
-            return True
-    return False
-
-
 def _save_container_state(
     container,
     weights_store,
@@ -1007,15 +976,32 @@ def _load_container_state(
             if not _container_path_present(
                 weights_store, assets_store, nested_path
             ):
-                # Only warn when the in-memory container would actually have
-                # contributed loadable state — i.e. it transitively holds at
-                # least one `KerasSaveable`. Containers of pure metadata
-                # (e.g. lists of strings inside `variable_serialization_spec`)
-                # have nothing to load and a missing group there is expected,
-                # not an error.
-                if _container_has_unvisited_saveables(
-                    saveable, visited_saveables
-                ):
+                # The container's group is missing from the saved file.
+                # Try to load it recursively anyway with `skip_mismatch=True`,
+                # then warn only if doing so produced new failures — i.e. the
+                # container genuinely held an unvisited `KerasSaveable` that
+                # needed loading. This silently skips two benign cases:
+                #   - Containers of pure metadata (e.g. lists of strings in
+                #     `variable_serialization_spec`).
+                #   - Containers that mirror already-loaded saveables (e.g.
+                #     a Functional model's `_operations_by_depth` whose
+                #     items are also in the `layers` collection).
+                tracked_failures = (
+                    failed_saveables if failed_saveables is not None else set()
+                )
+                failed_before = len(tracked_failures)
+                _load_container_state(
+                    saveable,
+                    weights_store,
+                    assets_store,
+                    inner_path=nested_path,
+                    skip_mismatch=True,
+                    visited_saveables=visited_saveables,
+                    failed_saveables=tracked_failures,
+                    error_msgs=error_msgs,
+                    visited_containers=visited_containers,
+                )
+                if len(tracked_failures) > failed_before:
                     # Legacy files saved before PR #22362 didn't write the
                     # `container*` groups for nested containers — silently
                     # skip so the model still loads (sublayers keep their

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1384,6 +1384,36 @@ class SavingBattleTest(testing.TestCase):
             atol=1e-6,
         )
 
+    def test_fresh_save_load_emits_no_container_skip_warning(self):
+        # The legacy-skip warning should fire only when an in-memory
+        # container would have contributed unvisited `KerasSaveable` state
+        # that isn't present in the file. Containers of pure metadata
+        # (e.g. `variable_serialization_spec`) and containers that mirror
+        # already-loaded saveables (e.g. Functional's `_operations_by_depth`)
+        # have nothing left to load, so a missing group there is expected.
+        path = os.path.join(self.get_temp_dir(), "model.keras")
+        inp = keras.layers.Input(shape=(5,))
+        model = keras.Model(
+            inp, keras.layers.EinsumDense("ab,bc->ac", output_shape=(7,))(inp)
+        )
+        model.save(path)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            keras.saving.load_model(path)
+        spurious = [
+            str(w.message)
+            for w in caught
+            if "Skipping nested container" in str(w.message)
+        ]
+        self.assertEqual(
+            spurious,
+            [],
+            msg=(
+                "Loading a freshly-saved model should not emit the "
+                f"'Skipping nested container' warning. Got: {spurious}"
+            ),
+        )
+
     def test_remove_weights_only_saving_and_loading(self):
         def is_remote_path(path):
             return True


### PR DESCRIPTION
## Description

Fixes #23021.

`load_model` emits multiple `UserWarning: Skipping nested container at '...': no matching group found in the saved file. ... Affected layers will retain their freshly-initialized weights.` even when loading a file that was just saved with the current version. The wording suggests weight loss, but weights round-trip correctly — it's a false positive.

The warning was added in #22362 to catch legacy files predating nested-container serialization, but it also fires for two benign cases on current-version files:

1. **Containers of pure metadata** — e.g. `variable_serialization_spec`, a list of strings (axis/variable names). No `KerasSaveable` inside, nothing to load.
2. **Containers that mirror already-loaded saveables** — e.g. Functional's `_operations_by_depth` / `_nodes_by_depth`, whose items are the same layers already loaded via the `layers` collection (so they're already in `visited_saveables`).

### Before

```python
inp = layers.Input(shape=(5,))
model = keras.Model(inp, layers.EinsumDense("ab,bc->ac", output_shape=(7,))(inp))
model.save("m.keras")
keras.models.load_model("m.keras")
# UserWarning: Skipping nested container at 'layers/einsum_dense/variable_serialization_spec/container': ...
# UserWarning: Skipping nested container at '_operations_by_depth/container': ...
# (etc., 4+ warnings, all spurious)
```

### After

Zero spurious warnings on a freshly-saved file. Verified that weights still round-trip and outputs match for Dense, EinsumDense, Embedding+Dense, MultiHeadAttention.

### Implementation

In `_load_container_state`, replaced the unconditional warning with a check via a new `_container_has_unvisited_saveables(container, visited_saveables)`:

- Returns `True` only when the container transitively holds at least one `KerasSaveable` that hasn't been loaded yet via another path.
- Pure-metadata containers (e.g. `variable_serialization_spec`) return `False`.
- Containers like `_operations_by_depth` that mirror `layers` return `False` because every saveable in them is already in `visited_saveables`.

The legitimate legacy-file warning path is preserved — `test_legacy_load_skips_missing_nested_containers` still emits and asserts the warning correctly.

Added `test_fresh_save_load_emits_no_container_skip_warning` covering the false-positive case. All 63 saving tests pass.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.