### PR TITLE
Save data_format in image preprocessing layers' get_config

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/base_image_preprocessing_layer.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/base_image_preprocessing_layer.py
@@ -256,6 +256,7 @@ class BaseImagePreprocessingLayer(DataLayer):
 
     def get_config(self):
         config = super().get_config()
+        config.update({"data_format": self.data_format})
         if self.bounding_box_format is not None:
             config.update(
                 {

--- a/keras/src/layers/preprocessing/image_preprocessing/base_image_preprocessing_layer_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/base_image_preprocessing_layer_test.py
@@ -1,0 +1,71 @@
+from absl.testing import parameterized
+
+from keras.src import backend
+from keras.src import layers
+from keras.src import testing
+
+
+class BaseImagePreprocessingLayerTest(testing.TestCase):
+    @parameterized.named_parameters(
+        ("aug_mix", layers.AugMix, {}),
+        ("auto_contrast", layers.AutoContrast, {}),
+        ("center_crop", layers.CenterCrop, {"height": 4, "width": 4}),
+        (
+            "clahe",
+            layers.ContrastLimitedAdaptiveHistogramEqualization,
+            {},
+        ),
+        ("cut_mix", layers.CutMix, {}),
+        ("equalization", layers.Equalization, {}),
+        (
+            "max_num_bounding_boxes",
+            layers.MaxNumBoundingBoxes,
+            {"max_number": 5},
+        ),
+        ("mix_up", layers.MixUp, {}),
+        ("rand_augment", layers.RandAugment, {}),
+        ("random_brightness", layers.RandomBrightness, {"factor": 0.5}),
+        (
+            "random_color_degeneration",
+            layers.RandomColorDegeneration,
+            {"factor": 0.5},
+        ),
+        ("random_color_jitter", layers.RandomColorJitter, {}),
+        ("random_contrast", layers.RandomContrast, {"factor": 0.5}),
+        ("random_crop", layers.RandomCrop, {"height": 4, "width": 4}),
+        ("random_elastic_transform", layers.RandomElasticTransform, {}),
+        ("random_erasing", layers.RandomErasing, {}),
+        ("random_flip", layers.RandomFlip, {}),
+        ("random_gaussian_blur", layers.RandomGaussianBlur, {}),
+        ("random_grayscale", layers.RandomGrayscale, {}),
+        ("random_hue", layers.RandomHue, {"factor": 0.5}),
+        ("random_invert", layers.RandomInvert, {}),
+        ("random_perspective", layers.RandomPerspective, {}),
+        ("random_posterization", layers.RandomPosterization, {"factor": 4}),
+        ("random_rotation", layers.RandomRotation, {"factor": 0.5}),
+        ("random_saturation", layers.RandomSaturation, {"factor": 0.5}),
+        ("random_sharpness", layers.RandomSharpness, {"factor": 0.5}),
+        ("random_shear", layers.RandomShear, {}),
+        (
+            "random_translation",
+            layers.RandomTranslation,
+            {"height_factor": 0.2, "width_factor": 0.2},
+        ),
+        ("random_zoom", layers.RandomZoom, {"height_factor": 0.2}),
+        ("resizing", layers.Resizing, {"height": 4, "width": 4}),
+        ("solarization", layers.Solarization, {}),
+    )
+    def test_data_format_serialization(self, layer_cls, init_kwargs):
+        # `data_format` was previously dropped from `get_config` in layers
+        # that rely on the base class to save it, so a save/load round-trip
+        # silently reset it to the global image data format.
+        data_format = (
+            "channels_first"
+            if backend.image_data_format() == "channels_last"
+            else "channels_last"
+        )
+        layer = layer_cls(data_format=data_format, **init_kwargs)
+        config = layer.get_config()
+        self.assertIn("data_format", config)
+        revived = layer_cls.from_config(config)
+        self.assertEqual(revived.data_format, data_format)


### PR DESCRIPTION
## Summary

`BaseImagePreprocessingLayer` stores `data_format` but its `get_config` never emits it. 22 of the 31 image preprocessing layers (RandomHue, RandomContrast, CutMix, MixUp, AugMix, RandAugment, Solarization, etc.) rely on the base class to serialize it, so a `from_config(get_config())` round-trip (e.g. `save` / `load_model`) silently resets `data_format` to the global image data format. A model built with `channels_first` augmentation layers reloads as `channels_last` and transforms the wrong axes.

The other 9 layers in the family (Resizing, CenterCrop, RandomFlip, ...) already emit `data_format` in their own `get_config`, and every other layer with a `data_format` argument (conv, pooling, adaptive pooling) saves it correctly - this family is the only gap.

The fix emits `data_format` from the base class `get_config`, covering all subclasses at once.

`run_layer_test` did not catch this because it compares the revived layer's re-serialized config against the original config, and since both omitted `data_format` they matched while the behavior silently changed. This PR adds a round-trip test that constructs each of the 31 layers with a non-default `data_format`, reserializes, and asserts it is preserved.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.