### PR TITLE
Add foundational distribution metadata (num_processes, num_model_replicas, data_shard_id)

### DIFF
--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -326,6 +326,37 @@ class Distribution:
         self._device_mesh = device_mesh
         self._batch_dim_name = batch_dim_name
         self._auto_shard_dataset = auto_shard_dataset
+        if (
+            distribution_lib is not None
+            and hasattr(distribution_lib, "num_processes")
+            and hasattr(distribution_lib, "process_id")
+        ):
+            self._num_processes = distribution_lib.num_processes()
+            self._process_id = distribution_lib.process_id()
+        else:
+            self._num_processes = 1
+            self._process_id = 0
+        self._is_multi_process = self._num_processes > 1
+
+    @property
+    def num_processes(self):
+        """Total number of processes in the cluster."""
+        return self._num_processes
+
+    @property
+    def num_model_replicas(self):
+        """Number of model replicas."""
+        raise NotImplementedError()
+
+    @property
+    def data_shard_id(self):
+        """ID of the data shard for the current process."""
+        num_model_replicas = self.num_model_replicas
+        if num_model_replicas >= self.num_processes:
+            return self._process_id
+        else:
+            processes_per_replica = self.num_processes // num_model_replicas
+            return self._process_id // processes_per_replica
 
     def get_data_layout(self, data_shape):
         """Retrieve the `TensorLayout` for the input data.
@@ -448,11 +479,11 @@ class DataParallel(Distribution):
             self._initialize_mesh_from_devices(devices, auto_shard_dataset)
         else:
             self._initialize_mesh_from_list_devices(auto_shard_dataset)
+        self._num_model_replicas = self.device_mesh.devices.size
 
-        # Those following attributes might get convert to public methods.
-        self._num_process = distribution_lib.num_processes()
-        self._process_id = distribution_lib.process_id()
-        self._is_multi_process = self._num_process > 1
+    @property
+    def num_model_replicas(self):
+        return self._num_model_replicas
 
     def _initialize_with_device_mesh(self, device_mesh, auto_shard_dataset):
         if not isinstance(device_mesh, DeviceMesh):
@@ -536,16 +567,16 @@ class DataParallel(Distribution):
             )
         per_worker_batch_size = tf_data_distribute.batch_sizes_for_worker(
             global_batch_size=batch_size,
-            num_workers=self._num_process,
+            num_workers=self.num_processes,
             num_replicas_per_worker=1,  # We hard code this for now.
             worker_index=self._process_id,
         )
         distributed_dataset = dataset.rebatch(per_worker_batch_size)
         distributed_dataset = tf_data_distribute._AutoShardDataset(
             distributed_dataset,
-            num_workers=self._num_process,
+            num_workers=self.num_processes,
             index=self._process_id,
-            num_replicas=self._num_process,
+            num_replicas=self.num_processes,
         )
         return distributed_dataset.prefetch(tf.data.AUTOTUNE)
 
@@ -657,26 +688,25 @@ class ModelParallel(Distribution):
         super().__init__(device_mesh, batch_dim_name, auto_shard_dataset)
         self._layout_map = layout_map
 
-        # Those following attributes might get convert to public methods.
-        self._num_process = distribution_lib.num_processes()
-        self._process_id = distribution_lib.process_id()
-        self._is_multi_process = self._num_process > 1
-
         mesh_batch_dim_index = self.device_mesh.axis_names.index(
             self.batch_dim_name
         )
-        num_model_replicas = self.device_mesh.shape[mesh_batch_dim_index]
+        self._num_model_replicas = self.device_mesh.shape[mesh_batch_dim_index]
         if (
             self._is_multi_process
-            and self._num_process > num_model_replicas
-            and self._num_process % num_model_replicas != 0
+            and self.num_processes > self._num_model_replicas
+            and self.num_processes % self._num_model_replicas != 0
         ):
             raise ValueError(
-                "If `num_process` is greater than `num_model_replicas`, "
-                "`num_process` must be divisible by `num_model_replicas`. "
-                f"Got num_process={self._num_process}, "
-                f"num_model_replicas={num_model_replicas}."
+                "If `num_processes` is greater than `num_model_replicas`, "
+                "`num_processes` must be divisible by `num_model_replicas`. "
+                f"Got num_processes={self.num_processes}, "
+                f"num_model_replicas={self._num_model_replicas}."
             )
+
+    @property
+    def num_model_replicas(self):
+        return self._num_model_replicas
 
     def get_data_layout(self, data_shape):
         data_shard_spec = [None] * len(data_shape)
@@ -726,29 +756,26 @@ class ModelParallel(Distribution):
         # This will depend on how many model replicas we have on each process.
         # Note that this might be smaller than one if model replicas are sharded
         # across multiple processes.
-        mesh_batch_dim_index = self.device_mesh.axis_names.index(
-            self.batch_dim_name
-        )
-        num_model_replicas = self.device_mesh.shape[mesh_batch_dim_index]
+        num_model_replicas = self.num_model_replicas
         if num_model_replicas == 1:
             # No sharding is needed in this case. Each process will have the
             # global batch size, and data from the iterator will need to be
             # replicated across all processes.
             return dataset.prefetch(tf.data.AUTOTUNE)
-        num_model_replicas_per_process = num_model_replicas / self._num_process
+        num_model_replicas_per_process = num_model_replicas / self.num_processes
         if num_model_replicas_per_process >= 1:
             # Each process will have one or more full model replicas. Data will
             # be sharded across all processes without replication.
-            if global_batch_size % self._num_process != 0:
+            if global_batch_size % self.num_processes != 0:
                 raise ValueError(
                     "Global batch size must be divisible by the number of "
                     f"processes. `global_batch_size`={global_batch_size} and "
-                    f"`num_process`={self._num_process}"
+                    f"`num_processes`={self.num_processes}"
                 )
-            per_process_batch_size = global_batch_size // self._num_process
+            per_process_batch_size = global_batch_size // self.num_processes
             distributed_dataset = dataset.rebatch(per_process_batch_size)
             distributed_dataset = distributed_dataset.shard(
-                num_shards=self._num_process,
+                num_shards=self.num_processes,
                 index=self._process_id,
             )
             return distributed_dataset.prefetch(tf.data.AUTOTUNE)
@@ -764,7 +791,7 @@ class ModelParallel(Distribution):
                 )
             per_process_batch_size = global_batch_size // num_model_replicas
             distributed_dataset = dataset.rebatch(per_process_batch_size)
-            processes_per_replica = self._num_process // num_model_replicas
+            processes_per_replica = self.num_processes // num_model_replicas
             # Each process belongs to a replica group. Determine which replica
             # this process group belongs to.
             data_shard_id = self._process_id // processes_per_replica

--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -479,11 +479,10 @@ class DataParallel(Distribution):
             self._initialize_mesh_from_devices(devices, auto_shard_dataset)
         else:
             self._initialize_mesh_from_list_devices(auto_shard_dataset)
-        self._num_model_replicas = self.device_mesh.devices.size
 
     @property
     def num_model_replicas(self):
-        return self._num_model_replicas
+        return self.device_mesh.devices.size
 
     def _initialize_with_device_mesh(self, device_mesh, auto_shard_dataset):
         if not isinstance(device_mesh, DeviceMesh):
@@ -688,25 +687,24 @@ class ModelParallel(Distribution):
         super().__init__(device_mesh, batch_dim_name, auto_shard_dataset)
         self._layout_map = layout_map
 
-        mesh_batch_dim_index = self.device_mesh.axis_names.index(
-            self.batch_dim_name
-        )
-        self._num_model_replicas = self.device_mesh.shape[mesh_batch_dim_index]
         if (
             self._is_multi_process
-            and self.num_processes > self._num_model_replicas
-            and self.num_processes % self._num_model_replicas != 0
+            and self.num_processes > self.num_model_replicas
+            and self.num_processes % self.num_model_replicas != 0
         ):
             raise ValueError(
                 "If `num_processes` is greater than `num_model_replicas`, "
                 "`num_processes` must be divisible by `num_model_replicas`. "
                 f"Got num_processes={self.num_processes}, "
-                f"num_model_replicas={self._num_model_replicas}."
+                f"num_model_replicas={self.num_model_replicas}."
             )
 
     @property
     def num_model_replicas(self):
-        return self._num_model_replicas
+        mesh_batch_dim_index = self.device_mesh.axis_names.index(
+            self.batch_dim_name
+        )
+        return self.device_mesh.shape[mesh_batch_dim_index]
 
     def get_data_layout(self, data_shape):
         data_shard_spec = [None] * len(data_shape)
@@ -756,7 +754,10 @@ class ModelParallel(Distribution):
         # This will depend on how many model replicas we have on each process.
         # Note that this might be smaller than one if model replicas are sharded
         # across multiple processes.
-        num_model_replicas = self.num_model_replicas
+        mesh_batch_dim_index = self.device_mesh.axis_names.index(
+            self.batch_dim_name
+        )
+        num_model_replicas = self.device_mesh.shape[mesh_batch_dim_index]
         if num_model_replicas == 1:
             # No sharding is needed in this case. Each process will have the
             # global batch size, and data from the iterator will need to be

--- a/keras/src/distribution/distribution_lib_test.py
+++ b/keras/src/distribution/distribution_lib_test.py
@@ -191,7 +191,7 @@ class DataParallelDistributionTest(testing.TestCase):
 
         self.assertFalse(distribution._is_multi_process)
         self.assertEqual(distribution._process_id, 0)
-        self.assertEqual(distribution._num_process, 1)
+        self.assertEqual(distribution.num_processes, 1)
 
     def test_create_with_devices(self):
         distribution = distribution_lib.DataParallel(devices=self.devices)
@@ -247,6 +247,14 @@ class DataParallelDistributionTest(testing.TestCase):
         variable_layout = distribution.get_variable_layout(variable)
         self.assertIs(variable_layout.device_mesh, explicit_mesh)
         self.assertEqual(variable_layout.axes, explicit_layout.axes)
+
+    @mock.patch.object(backend_dlib, "num_processes", return_value=2)
+    def test_num_model_replicas(self, mock_backend_num_processes):
+        distribution = distribution_lib.DataParallel(
+            device_mesh=self.device_mesh
+        )
+        self.assertEqual(distribution.num_model_replicas, 8)
+        self.assertEqual(distribution.num_processes, 2)
 
     def test_get_tensor_layout(self):
         distribution = distribution_lib.DataParallel(
@@ -359,7 +367,7 @@ class ModelParallelDistributionTest(testing.TestCase):
         self.assertIs(dataset, distributed_dataset)
 
     @mock.patch.object(backend_dlib, "num_processes", return_value=4)
-    def test_num_process_validation(self, mock_backend_num_processes):
+    def test_num_processes_validation(self, mock_backend_num_processes):
         device_mesh = distribution_lib.DeviceMesh(
             (3, 2),
             ["data", "model"],
@@ -368,13 +376,27 @@ class ModelParallelDistributionTest(testing.TestCase):
         layout_map = distribution_lib.LayoutMap(device_mesh)
         with self.assertRaisesRegex(
             ValueError,
-            "`num_process` must be divisible by `num_model_replicas`",
+            "`num_processes` must be divisible by `num_model_replicas`",
         ):
             distribution_lib.ModelParallel(
                 layout_map=layout_map,
                 batch_dim_name="data",
                 auto_shard_dataset=True,
             )
+
+    @mock.patch.object(backend_dlib, "num_processes", return_value=2)
+    def test_num_model_replicas(self, mock_backend_num_processes):
+        device_mesh = distribution_lib.DeviceMesh(
+            (4, 2),
+            ["data", "model"],
+            [f"cpu:{i}" for i in range(8)],
+        )
+        layout_map = distribution_lib.LayoutMap(device_mesh)
+        distribution = distribution_lib.ModelParallel(
+            layout_map=layout_map, batch_dim_name="data"
+        )
+        self.assertEqual(distribution.num_model_replicas, 4)
+        self.assertEqual(distribution.num_processes, 2)
 
 
 class LayoutMapTest(testing.TestCase):
@@ -524,7 +546,7 @@ class DataShardingIntegrationTest(testing.TestCase):
 
         # Simulate one process per local device to exercise process-group
         # sharding semantics without backend mocking.
-        distribution._num_process = num_devices
+        distribution._num_processes = num_devices
         distribution._is_multi_process = True
 
         for process_id in range(num_devices):

--- a/keras/src/distribution/distribution_lib_test.py
+++ b/keras/src/distribution/distribution_lib_test.py
@@ -163,6 +163,50 @@ class DistributionTest(testing.TestCase):
 
         self.assertIsNone(distribution_lib.distribution())
 
+    def test_data_shard_id(self):
+        # Case 1: num_model_replicas >= num_processes
+        # data_shard_id should be process_id
+        distribution = distribution_lib.Distribution(self.device_mesh)
+        with (
+            mock.patch.object(
+                distribution.__class__,
+                "num_model_replicas",
+                new_callable=mock.PropertyMock,
+                return_value=8,
+            ),
+            mock.patch.object(
+                distribution.__class__,
+                "num_processes",
+                new_callable=mock.PropertyMock,
+                return_value=4,
+            ),
+        ):
+            for process_id in range(4):
+                with mock.patch.object(distribution, "_process_id", process_id):
+                    self.assertEqual(distribution.data_shard_id, process_id)
+
+        # Case 2: num_model_replicas < num_processes
+        # data_shard_id should be process_id //
+        # (num_processes // num_model_replicas)
+        with (
+            mock.patch.object(
+                distribution.__class__,
+                "num_model_replicas",
+                new_callable=mock.PropertyMock,
+                return_value=2,
+            ),
+            mock.patch.object(
+                distribution.__class__,
+                "num_processes",
+                new_callable=mock.PropertyMock,
+                return_value=4,
+            ),
+        ):
+            expected_data_shard_ids = [0, 0, 1, 1]
+            for process_id, expected in enumerate(expected_data_shard_ids):
+                with mock.patch.object(distribution, "_process_id", process_id):
+                    self.assertEqual(distribution.data_shard_id, expected)
+
 
 @pytest.mark.skipif(
     backend.backend() != "jax",


### PR DESCRIPTION
## Description
This is the first in a series of PRs to enhance the Keras Distribution API. It introduces foundational metadata properties to the Distribution base class and its subclasses to enable robust data sharding and saving logic in subsequent updates.

Key Changes:

   * New Properties: Added num_processes, num_model_replicas, and data_shard_id to the Distribution base class.
   * Subclass Implementation: Implemented logic for these properties in DataParallel and ModelParallel.

Rationale:

These properties provide a unified way for Keras components (like DataAdapter or saving utilities) to determine how data should be partitioned across workers and model replicas, regardless of the underlying distribution strategy.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
