### PR TITLE
Save seed in Attention layer get_config

### DIFF
--- a/keras/src/layers/attention/attention.py
+++ b/keras/src/layers/attention/attention.py
@@ -75,6 +75,7 @@ class Attention(Layer):
         self.use_scale = use_scale
         self.score_mode = score_mode
         self.dropout = dropout
+        self.seed = seed
         if self.dropout > 0:
             self.seed_generator = backend.random.SeedGenerator(seed=seed)
 
@@ -314,5 +315,6 @@ class Attention(Layer):
             "use_scale": self.use_scale,
             "score_mode": self.score_mode,
             "dropout": self.dropout,
+            "seed": self.seed,
         }
         return {**base_config, **config}

--- a/keras/src/layers/attention/attention_test.py
+++ b/keras/src/layers/attention/attention_test.py
@@ -41,6 +41,13 @@ class AttentionTest(testing.TestCase):
             run_training_check=False,
         )
 
+    def test_attention_seed_preserved_in_config(self):
+        layer = layers.Attention(dropout=0.5, seed=1337)
+        config = layer.get_config()
+        self.assertEqual(config["seed"], 1337)
+        restored = layers.Attention.from_config(config)
+        self.assertEqual(restored.seed, 1337)
+
     def test_attention_correctness(self):
         query = np.array([[[1.0, 0.0], [0.0, 1.0]]])
         key = np.array([[[0.0, 1.0], [1.0, 0.0]]])


### PR DESCRIPTION
## Summary

`Attention` accepts a `seed` argument and uses it to seed the dropout `SeedGenerator`, but its `get_config` never emits it. A `from_config(get_config())` round-trip (e.g. `save` / `load_model`) silently resets `seed` to `None`, so a layer built with an explicit seed reloads with a different one and draws different dropout masks - the reloaded model is no longer reproducible.

Every other layer with a `seed` argument already saves it: `SimpleRNN`, `GRU`, `LSTM`, `MultiHeadAttention`, and `GroupedQueryAttention` - this layer is the only gap. `AdditiveAttention` subclasses `Attention` and was missing it for the same reason.

The fix stores `self.seed` and emits it from `get_config`, covering `AdditiveAttention` too through `super().get_config()`.

`run_layer_test` did not catch this because it compares the revived layer's re-serialized config against the original config, and since both omitted `seed` they matched while the behavior silently changed. This PR adds a round-trip test that constructs the layer with an explicit seed, reserializes, and asserts it is preserved.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.