### PR TITLE
Remove progress bar double averaging of metrics.

### DIFF
--- a/keras/src/callbacks/progbar_logger.py
+++ b/keras/src/callbacks/progbar_logger.py
@@ -82,7 +82,10 @@ class ProgbarLogger(Callback):
     def _maybe_init_progbar(self):
         if self.progbar is None:
             self.progbar = Progbar(
-                target=self.target, verbose=self.verbose, unit_name="step"
+                target=self.target,
+                verbose=self.verbose,
+                unit_name="step",
+                stateless_metrics=set(),
             )
 
     def _update_progbar(self, batch, logs=None):

--- a/keras/src/utils/progbar.py
+++ b/keras/src/utils/progbar.py
@@ -13,13 +13,21 @@ from keras.src.utils import io_utils
 class Progbar:
     """Displays a progress bar.
 
+    If neither of `stateful_metrics` and `stateless_metrics` is provided, all
+    metrics are assumed to be stateless (averaged by the progress bar before
+    display).
+
     Args:
         target: Total number of steps expected, None if unknown.
         width: Progress bar width on screen.
         verbose: Verbosity mode, 0 (silent), 1 (verbose), 2 (semi-verbose)
         stateful_metrics: Iterable of string names of metrics that should *not*
             be averaged over time. Metrics in this list will be displayed as-is.
-            All others will be averaged by the progbar before display.
+            If provided, do not provide `stateless_metrics`.
+        stateless_metrics: Iterable of string names of metrics that *should* be
+            averaged over time. Metrics in this list will be averaged by the
+            progbar before display. If provided, do not provide
+            `stateful_metrics`.
         interval: Minimum visual progress update interval (in seconds).
         unit_name: Display name for step counts (usually "step" or "sample").
     """
@@ -31,17 +39,31 @@ class Progbar:
         verbose=1,
         interval=0.05,
         stateful_metrics=None,
+        stateless_metrics=None,
         unit_name="step",
     ):
+        if stateful_metrics is not None and stateless_metrics is not None:
+            raise ValueError(
+                "Only one off `stateful_metrics` metrics or "
+                "`stateless_metrics` must be provided. `stateful_metrics` is "
+                "used to have metrics be stateless by default with an "
+                "exclusion list. `stateless_metrics` is used to have metrics "
+                "be statefull by default with an exclusion list."
+            )
         self.target = target
         self.width = width
         self.verbose = verbose
         self.interval = interval
         self.unit_name = unit_name
-        if stateful_metrics:
+        if stateful_metrics is not None:
             self.stateful_metrics = set(stateful_metrics)
+            self.stateless_metrics = None
+        elif stateless_metrics is not None:
+            self.stateful_metrics = None
+            self.stateless_metrics = set(stateless_metrics)
         else:
             self.stateful_metrics = set()
+            self.stateless_metrics = None
 
         self._dynamic_display = (
             (hasattr(sys.stdout, "isatty") and sys.stdout.isatty())
@@ -82,7 +104,14 @@ class Progbar:
         for k, v in values:
             if k not in self._values_order:
                 self._values_order.append(k)
-            if k not in self.stateful_metrics:
+
+            stateless = False
+            if self.stateful_metrics is not None:
+                stateless = k not in self.stateful_metrics
+            if self.stateless_metrics is not None:
+                stateless = k in self.stateless_metrics
+
+            if stateless:
                 # In the case that progress bar doesn't have a target value in
                 # the first epoch, both on_batch_end and on_epoch_end will be
                 # called, which will cause 'current' and 'self._seen_so_far' to

--- a/keras/src/utils/progbar.py
+++ b/keras/src/utils/progbar.py
@@ -105,10 +105,9 @@ class Progbar:
             if k not in self._values_order:
                 self._values_order.append(k)
 
-            stateless = False
             if self.stateful_metrics is not None:
                 stateless = k not in self.stateful_metrics
-            if self.stateless_metrics is not None:
+            else:
                 stateless = k in self.stateless_metrics
 
             if stateless:

--- a/keras/src/utils/progbar.py
+++ b/keras/src/utils/progbar.py
@@ -44,11 +44,11 @@ class Progbar:
     ):
         if stateful_metrics is not None and stateless_metrics is not None:
             raise ValueError(
-                "Only one off `stateful_metrics` metrics or "
-                "`stateless_metrics` must be provided. `stateful_metrics` is "
-                "used to have metrics be stateless by default with an "
-                "exclusion list. `stateless_metrics` is used to have metrics "
-                "be statefull by default with an exclusion list."
+                "Only one of `stateful_metrics` or `stateless_metrics` "
+                "can be provided. `stateful_metrics` is used to make metrics "
+                "stateless by default (with an exclusion list), while "
+                "`stateless_metrics` is used to make metrics stateful by "
+                "default (with an exclusion list)."
             )
         self.target = target
         self.width = width

--- a/keras/src/utils/progbar_test.py
+++ b/keras/src/utils/progbar_test.py
@@ -1,3 +1,6 @@
+import contextlib
+import io
+
 import numpy as np
 from absl.testing import parameterized
 
@@ -35,3 +38,33 @@ class ProgbarTest(testing.TestCase):
     def test_zero_target(self, verbose):
         pb = progbar.Progbar(target=0, verbose=verbose)
         pb.update(0, finalize=True)
+
+    def test_stateful_stateless_raises(self):
+        with self.assertRaisesRegex(ValueError, "Only one off"):
+            progbar.Progbar(target=1, stateful_metrics=[], stateless_metrics=[])
+
+    @parameterized.named_parameters(
+        [
+            ("all_stateless", [], None, "1."),
+            ("one_stateless", ["value"], None, "2."),
+            ("all_stateful", None, [], "2."),
+            ("one_stateful", None, ["value"], "1."),
+        ]
+    )
+    def test_stateful_stateless_output(
+        self, stateful_metrics, stateless_metrics, expected_output
+    ):
+        captured = io.StringIO()
+        pb = progbar.Progbar(
+            target=3,
+            stateful_metrics=stateful_metrics,
+            stateless_metrics=stateless_metrics,
+            interval=0.0,
+            verbose=1,
+        )
+
+        pb.update(1, values=[("value", 0.0)])
+        with contextlib.redirect_stdout(captured):
+            pb.update(2, values=[("value", 2.0)])
+
+        self.assertIn(f"value: {expected_output}", captured.getvalue())

--- a/keras/src/utils/progbar_test.py
+++ b/keras/src/utils/progbar_test.py
@@ -40,7 +40,7 @@ class ProgbarTest(testing.TestCase):
         pb.update(0, finalize=True)
 
     def test_stateful_stateless_raises(self):
-        with self.assertRaisesRegex(ValueError, "Only one off"):
+        with self.assertRaisesRegex(ValueError, "Only one of"):
             progbar.Progbar(target=1, stateful_metrics=[], stateless_metrics=[])
 
     @parameterized.named_parameters(


### PR DESCRIPTION
All metrics emitted to the progress bar in `model.fit` and `mode.evaluate` are stateful. For instance, average metrics maintain the running sum and denominator and output the average.

Therefore, the progress bar needs to consider all of the metrics stateless. To make this easier without having to constantly update the list of stateful metrics (like Keras 2 does), added a backwards compatible parameter `stateless_metrics` to list stateless metrics instead.

Fixes https://github.com/keras-team/keras/issues/21301

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
