### PR TITLE
Reject compressed asset bombs in Keras archives

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1071,8 +1071,17 @@ class DiskIOStore:
             self.tmp_dir = get_temp_dir()
             if self.mode == "r":
                 if isinstance(self.archive, zipfile.ZipFile):
-                    for member in self.archive.infolist():
-                        _reject_zip_bomb(self.archive, member)
+                    for zinfo in self.archive.infolist():
+                        if (
+                            zinfo.file_size > _ZIP_MEMBER_BOMB_FLOOR_BYTES
+                            and zinfo.file_size > _ZIP_MEMBER_MAX_EXPANSION * zinfo.compress_size
+                        ):
+                            raise ValueError(
+                                f"Not allowed: ZIP member '{zinfo.filename}' declares "
+                                f"{readable_memory_size(zinfo.file_size)} but only "
+                                f"{readable_memory_size(zinfo.compress_size)} are stored on disk; "
+                                "refusing to load a potential decompression bomb."
+                            )
                 file_utils.extract_open_archive(self.archive, self.tmp_dir)
             self.working_dir = file_utils.join(
                 self.tmp_dir, self.root_path

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -445,7 +445,11 @@ _ZIP_MEMBER_MAX_EXPANSION = 100
 
 def _reject_zip_bomb(archive, name):
     """Raise if a ZIP member is a decompression bomb (see CWE-409)."""
-    info = archive.getinfo(name)
+    if isinstance(name, zipfile.ZipInfo):
+        info = name
+        name = info.filename
+    else:
+        info = archive.getinfo(name)
     if (
         info.file_size > _ZIP_MEMBER_BOMB_FLOOR_BYTES
         and info.file_size > _ZIP_MEMBER_MAX_EXPANSION * info.compress_size
@@ -1061,7 +1065,7 @@ class DiskIOStore:
             self.tmp_dir = get_temp_dir()
             if self.mode == "r":
                 if isinstance(self.archive, zipfile.ZipFile):
-                    for member in self.archive.namelist():
+                    for member in self.archive.infolist():
                         _reject_zip_bomb(self.archive, member)
                 file_utils.extract_open_archive(self.archive, self.tmp_dir)
             self.working_dir = file_utils.join(

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1060,6 +1060,9 @@ class DiskIOStore:
         if self.archive:
             self.tmp_dir = get_temp_dir()
             if self.mode == "r":
+                if isinstance(self.archive, zipfile.ZipFile):
+                    for member in self.archive.namelist():
+                        _reject_zip_bomb(self.archive, member)
                 file_utils.extract_open_archive(self.archive, self.tmp_dir)
             self.working_dir = file_utils.join(
                 self.tmp_dir, self.root_path

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1714,6 +1714,33 @@ class SafeZipReadTest(testing.TestCase):
             with self.assertRaisesRegex(ValueError, "decompression bomb"):
                 saving_lib.load_model(evil)
 
+    def test_load_model_rejects_bomb_assets(self):
+        # Asset members are extracted by DiskIOStore. They must get the same
+        # decompression-bomb guard as config and weights members.
+        import keras
+
+        model = keras.Sequential([keras.Input((4,)), keras.layers.Dense(3)])
+        good = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(good)
+        with zipfile.ZipFile(good) as zf:
+            members = {name: zf.read(name) for name in zf.namelist()}
+
+        evil = os.path.join(self.get_temp_dir(), "evil_asset.keras")
+        with zipfile.ZipFile(evil, "w") as zf:
+            for name, data in members.items():
+                zf.writestr(name, data)
+            info = zipfile.ZipInfo("assets/bomb.txt")
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, b"\x00" * 200_000)
+
+        self.assertLess(os.path.getsize(evil), 1 << 16)
+        with (
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64),
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_MAX_EXPANSION", 10),
+        ):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                saving_lib.load_model(evil)
+
 
 class SafeGetH5DatasetTest(testing.TestCase):
     def _shape_bomb_file(self):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1741,6 +1741,34 @@ class SafeZipReadTest(testing.TestCase):
             with self.assertRaisesRegex(ValueError, "decompression bomb"):
                 saving_lib.load_model(evil)
 
+    def test_load_model_rejects_duplicate_name_bomb_assets(self):
+        # `ZipFile.getinfo(name)` resolves to one entry for duplicate names,
+        # while extraction walks every ZipInfo. Validate each ZipInfo directly.
+        import keras
+
+        model = keras.Sequential([keras.Input((4,)), keras.layers.Dense(3)])
+        good = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(good)
+        with zipfile.ZipFile(good) as zf:
+            members = {name: zf.read(name) for name in zf.namelist()}
+
+        evil = os.path.join(self.get_temp_dir(), "evil_duplicate_asset.keras")
+        with zipfile.ZipFile(evil, "w") as zf:
+            for name, data in members.items():
+                zf.writestr(name, data)
+            info = zipfile.ZipInfo("assets/duplicate.txt")
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, b"\x00" * 200_000)
+            zf.writestr("assets/duplicate.txt", b"ok")
+
+        self.assertLess(os.path.getsize(evil), 1 << 16)
+        with (
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64),
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_MAX_EXPANSION", 10),
+        ):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                saving_lib.load_model(evil)
+
 
 class SafeGetH5DatasetTest(testing.TestCase):
     def _shape_bomb_file(self):


### PR DESCRIPTION
### Summary

This applies the existing Keras archive decompression-bomb guard to asset extraction as well as config and weights reads.

`DiskIOStore` extracts archive-backed assets through `extract_open_archive()`. Path safety is already handled there, but asset members did not pass through `_reject_zip_bomb()` before extraction. A highly compressed `assets/...` member could therefore expand during model loading without the same archive member ratio check used elsewhere in `saving_lib`.

### Changes

- Check every zip member with `_reject_zip_bomb()` before extracting archive-backed assets in read mode.
- Add a regression test with a compressed `assets/bomb.txt` member to confirm `load_model()` rejects it.

### Validation

Run locally on Windows with `KERAS_BACKEND=torch`:

```text
python -m pytest keras\src\saving\saving_lib_test.py::SafeZipReadTest::test_load_model_rejects_bomb_assets -q
# 1 passed

python -m pytest keras\src\saving\saving_lib_test.py::SafeZipReadTest -q
# 5 passed

python -m py_compile keras\src\saving\saving_lib.py keras\src\saving\saving_lib_test.py

git diff --check
```

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ ] I am a human, and not a bot.
- [ ] I will be responsible for responding to review comments in a timely manner.
- [ ] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
