### PR TITLE
[Fix] ValueError when loading SAMImageSegmenter from preset sam_huge_sa1b in Keras Hub

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -99,7 +99,6 @@ class Functional(Function, Model):
     def __new__(cls, *args, **kwargs):
         return typing.cast(cls, super().__new__(cls))
 
-    @tracking.no_automatic_dependency_tracking
     def __init__(self, inputs, outputs, name=None, **kwargs):
         if isinstance(inputs, dict):
             for k, v in inputs.items():
@@ -133,21 +132,14 @@ class Functional(Function, Model):
         if not all(is_input_keras_tensor(t) for t in flat_inputs):
             inputs, outputs = clone_graph_nodes(inputs, outputs)
 
-        preexisting_layers = list(getattr(self, "_layers", []))
-
-        Function.__init__(self, inputs, outputs, name=name)
+        with tracking.DotNotTrackScope():
+            Function.__init__(self, inputs, outputs, name=name)
 
         if trainable is not None:
             self.trainable = trainable
 
-        graph_layers = self.layers
-        graph_layer_ids = {id(layer) for layer in graph_layers}
-        extra_layers = [
-            layer
-            for layer in preexisting_layers
-            if id(layer) not in graph_layer_ids
-        ]
-        self._layers = graph_layers + extra_layers
+        for layer in self.layers:
+            self._tracker.track(layer)
         self.build(None)
         # We will convert directly (to the correct dtype per input).
         self._convert_input_args = False

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -133,12 +133,21 @@ class Functional(Function, Model):
         if not all(is_input_keras_tensor(t) for t in flat_inputs):
             inputs, outputs = clone_graph_nodes(inputs, outputs)
 
+        preexisting_layers = list(getattr(self, "_layers", []))
+
         Function.__init__(self, inputs, outputs, name=name)
 
         if trainable is not None:
             self.trainable = trainable
 
-        self._layers = self.layers
+        graph_layers = self.layers
+        graph_layer_ids = {id(layer) for layer in graph_layers}
+        extra_layers = [
+            layer
+            for layer in preexisting_layers
+            if id(layer) not in graph_layer_ids
+        ]
+        self._layers = graph_layers + extra_layers
         self.build(None)
         # We will convert directly (to the correct dtype per input).
         self._convert_input_args = False

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -710,9 +710,12 @@ def operation_fn(operation, **call_context_args):
 
 
 def functional_like_constructor(cls):
-    init_args = inspect.getfullargspec(cls.__init__).args[1:]
+    init_spec = inspect.getfullargspec(cls.__init__)
+    init_args = init_spec.args[1:]
     functional_init_args = inspect.getfullargspec(Functional.__init__).args[1:]
     if init_args == functional_init_args:
+        return True
+    if init_spec.varargs is not None and init_spec.varkw is not None:
         return True
     return False
 

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -9,6 +9,7 @@ from absl.testing import parameterized
 
 from keras.src import layers
 from keras.src.legacy.saving.legacy_h5_format import save_model_to_hdf5
+from keras.src.models import Model
 from keras.src.models import Sequential
 from keras.src.saving import saving_api
 from keras.src.testing import test_case
@@ -115,6 +116,44 @@ class SaveModelTests(test_case.TestCase):
             new_model.layers[0].get_weights()[1],
             model.layers[0].get_weights()[1],
         )
+
+    def test_objects_to_skip_recurses_unflattened_attributes(self):
+        class Backbone(Model):
+            def __init__(self):
+                self.encoder = layers.Dense(4, name="encoder")
+                # This layer is owned by the backbone, but it is not part of
+                # the backbone Functional graph.
+                self.decoder = layers.Dense(2, name="decoder")
+                inputs = layers.Input((3,))
+                outputs = self.encoder(inputs)
+                super().__init__(inputs, outputs)
+
+        class Task(Model):
+            def __init__(self, backbone):
+                self.backbone = backbone
+                inputs = backbone.input
+                outputs = backbone.decoder(backbone(inputs))
+                super().__init__(inputs, outputs)
+
+        legacy_task = Task(Backbone())
+        legacy_task(np.ones((1, 3)))
+        filepath = os.path.join(
+            self.get_temp_dir(), "legacy_task.weights.h5"
+        )
+        # This simulates a legacy task weight file that contains the full task,
+        # while modern task loading skips backbone-owned objects.
+        saving_api.save_weights(legacy_task, filepath)
+
+        new_task = Task(Backbone())
+        new_task(np.ones((1, 3)))
+        decoder_kernel = np.array(new_task.backbone.decoder.kernel)
+        objects_to_skip = list(new_task.backbone._flatten_layers())
+
+        self.assertNotIn(new_task.backbone.decoder, objects_to_skip)
+        saving_api.load_weights(
+            new_task, filepath, objects_to_skip=objects_to_skip
+        )
+        self.assertAllClose(new_task.backbone.decoder.kernel, decoder_kernel)
 
 
 class LoadModelTests(test_case.TestCase):

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -124,9 +124,7 @@ class SaveModelTests(test_case.TestCase):
                 # part of the Functional graph. This matches e.g. a decoder
                 # attached to a backbone but called by a task model.
                 decoder = layers.Dense(2, name="decoder")
-                self._initialize_tracker()
-                self._tracker.track(decoder)
-                object.__setattr__(self, "decoder", decoder)
+                self.decoder = decoder
 
                 encoder = layers.Dense(4, name="encoder")
                 inputs = layers.Input((3,))

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -137,9 +137,7 @@ class SaveModelTests(test_case.TestCase):
 
         legacy_task = Task(Backbone())
         legacy_task(np.ones((1, 3)))
-        filepath = os.path.join(
-            self.get_temp_dir(), "legacy_task.weights.h5"
-        )
+        filepath = os.path.join(self.get_temp_dir(), "legacy_task.weights.h5")
         # This simulates a legacy task weight file that contains the full task,
         # while modern task loading skips backbone-owned objects.
         saving_api.save_weights(legacy_task, filepath)

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -124,12 +124,12 @@ class SaveModelTests(test_case.TestCase):
                 # part of the Functional graph. This matches e.g. a decoder
                 # attached to a backbone but called by a task model.
                 decoder = layers.Dense(2, name="decoder")
-                self.decoder = decoder
 
                 encoder = layers.Dense(4, name="encoder")
                 inputs = layers.Input((3,))
                 outputs = encoder(inputs)
                 super().__init__(inputs, outputs)
+                self.decoder = decoder
 
         class Task(Model):
             def __init__(self, backbone):

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -120,20 +120,23 @@ class SaveModelTests(test_case.TestCase):
     def test_objects_to_skip_recurses_unflattened_attributes(self):
         class Backbone(Model):
             def __init__(self):
-                self.encoder = layers.Dense(4, name="encoder")
+                encoder = layers.Dense(4, name="encoder")
+                inputs = layers.Input((3,))
+                outputs = encoder(inputs)
+                super().__init__(inputs, outputs)
+                self.encoder = encoder
                 # This layer is owned by the backbone, but it is not part of
                 # the backbone Functional graph.
-                self.decoder = layers.Dense(2, name="decoder")
-                inputs = layers.Input((3,))
-                outputs = self.encoder(inputs)
-                super().__init__(inputs, outputs)
+                object.__setattr__(
+                    self, "decoder", layers.Dense(2, name="decoder")
+                )
 
         class Task(Model):
             def __init__(self, backbone):
-                self.backbone = backbone
                 inputs = backbone.input
                 outputs = backbone.decoder(backbone(inputs))
                 super().__init__(inputs, outputs)
+                self.backbone = backbone
 
         legacy_task = Task(Backbone())
         legacy_task(np.ones((1, 3)))

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -117,19 +117,21 @@ class SaveModelTests(test_case.TestCase):
             model.layers[0].get_weights()[1],
         )
 
-    def test_objects_to_skip_recurses_unflattened_attributes(self):
+    def test_objects_to_skip_with_functional_subclass_attribute_layer(self):
         class Backbone(Model):
             def __init__(self):
+                # Simulate a layer owned by a Functional subclass, but not
+                # part of the Functional graph. This matches e.g. a decoder
+                # attached to a backbone but called by a task model.
+                decoder = layers.Dense(2, name="decoder")
+                self._initialize_tracker()
+                self._tracker.track(decoder)
+                object.__setattr__(self, "decoder", decoder)
+
                 encoder = layers.Dense(4, name="encoder")
                 inputs = layers.Input((3,))
                 outputs = encoder(inputs)
                 super().__init__(inputs, outputs)
-                self.encoder = encoder
-                # This layer is owned by the backbone, but it is not part of
-                # the backbone Functional graph.
-                object.__setattr__(
-                    self, "decoder", layers.Dense(2, name="decoder")
-                )
 
         class Task(Model):
             def __init__(self, backbone):
@@ -150,7 +152,7 @@ class SaveModelTests(test_case.TestCase):
         decoder_kernel = np.array(new_task.backbone.decoder.kernel)
         objects_to_skip = list(new_task.backbone._flatten_layers())
 
-        self.assertNotIn(new_task.backbone.decoder, objects_to_skip)
+        self.assertIn(new_task.backbone.decoder, objects_to_skip)
         saving_api.load_weights(
             new_task, filepath, objects_to_skip=objects_to_skip
         )

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -591,7 +591,7 @@ def save_weights_only(
         else:
             weights_store = H5IOStore(filepath, mode="w")
         if objects_to_skip is not None:
-            visited_saveables = _get_saveable_ids(objects_to_skip)
+            visited_saveables = set(id(o) for o in objects_to_skip)
         else:
             visited_saveables = set()
         _save_state(
@@ -645,7 +645,7 @@ def load_weights_only(
 
         failed_saveables = set()
         if objects_to_skip is not None:
-            visited_saveables = _get_saveable_ids(objects_to_skip)
+            visited_saveables = set(id(o) for o in objects_to_skip)
         else:
             visited_saveables = set()
         error_msgs = {}
@@ -738,53 +738,6 @@ def _walk_saveable(saveable):
             # Avoid raising the exception when visiting the attributes.
             continue
         yield child_attr, child_obj
-
-
-def _get_saveable_ids(saveables):
-    visited_saveables = set()
-    visited_containers = set()
-    for saveable in saveables:
-        _collect_saveable_ids(
-            saveable,
-            visited_saveables=visited_saveables,
-            visited_containers=visited_containers,
-        )
-    return visited_saveables
-
-
-def _collect_saveable_ids(saveable, visited_saveables, visited_containers):
-    from keras.src.saving.keras_saveable import KerasSaveable
-
-    if isinstance(saveable, KerasSaveable):
-        if id(saveable) in visited_saveables:
-            return
-        visited_saveables.add(id(saveable))
-        for _, child_obj in _walk_saveable(saveable):
-            _collect_saveable_ids(
-                child_obj,
-                visited_saveables=visited_saveables,
-                visited_containers=visited_containers,
-            )
-    elif isinstance(saveable, dict):
-        if id(saveable) in visited_containers:
-            return
-        visited_containers.add(id(saveable))
-        for child_obj in saveable.values():
-            _collect_saveable_ids(
-                child_obj,
-                visited_saveables=visited_saveables,
-                visited_containers=visited_containers,
-            )
-    elif isinstance(saveable, (list, tuple, set)):
-        if id(saveable) in visited_containers:
-            return
-        visited_containers.add(id(saveable))
-        for child_obj in saveable:
-            _collect_saveable_ids(
-                child_obj,
-                visited_saveables=visited_saveables,
-                visited_containers=visited_containers,
-            )
 
 
 def _save_state(

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -591,7 +591,7 @@ def save_weights_only(
         else:
             weights_store = H5IOStore(filepath, mode="w")
         if objects_to_skip is not None:
-            visited_saveables = set(id(o) for o in objects_to_skip)
+            visited_saveables = _get_saveable_ids(objects_to_skip)
         else:
             visited_saveables = set()
         _save_state(
@@ -645,7 +645,7 @@ def load_weights_only(
 
         failed_saveables = set()
         if objects_to_skip is not None:
-            visited_saveables = set(id(o) for o in objects_to_skip)
+            visited_saveables = _get_saveable_ids(objects_to_skip)
         else:
             visited_saveables = set()
         error_msgs = {}
@@ -738,6 +738,53 @@ def _walk_saveable(saveable):
             # Avoid raising the exception when visiting the attributes.
             continue
         yield child_attr, child_obj
+
+
+def _get_saveable_ids(saveables):
+    visited_saveables = set()
+    visited_containers = set()
+    for saveable in saveables:
+        _collect_saveable_ids(
+            saveable,
+            visited_saveables=visited_saveables,
+            visited_containers=visited_containers,
+        )
+    return visited_saveables
+
+
+def _collect_saveable_ids(saveable, visited_saveables, visited_containers):
+    from keras.src.saving.keras_saveable import KerasSaveable
+
+    if isinstance(saveable, KerasSaveable):
+        if id(saveable) in visited_saveables:
+            return
+        visited_saveables.add(id(saveable))
+        for _, child_obj in _walk_saveable(saveable):
+            _collect_saveable_ids(
+                child_obj,
+                visited_saveables=visited_saveables,
+                visited_containers=visited_containers,
+            )
+    elif isinstance(saveable, dict):
+        if id(saveable) in visited_containers:
+            return
+        visited_containers.add(id(saveable))
+        for child_obj in saveable.values():
+            _collect_saveable_ids(
+                child_obj,
+                visited_saveables=visited_saveables,
+                visited_containers=visited_containers,
+            )
+    elif isinstance(saveable, (list, tuple, set)):
+        if id(saveable) in visited_containers:
+            return
+        visited_containers.add(id(saveable))
+        for child_obj in saveable:
+            _collect_saveable_ids(
+                child_obj,
+                visited_saveables=visited_saveables,
+                visited_containers=visited_containers,
+            )
 
 
 def _save_state(


### PR DESCRIPTION


## Description

Fixes: #23018 
I changed Keras so objects_to_skip expands recursively through the same saveable traversal used by saving/loading. Now when KerasHub passes the backbone in the skip list, Keras also skips backbone-owned children like SAM’s mask_decoder, even if _flatten_layers() misses them.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
