### PR TITLE
[OpenVINO] Upgrade to opset16

### DIFF
--- a/keras/src/backend/openvino/core.py
+++ b/keras/src/backend/openvino/core.py
@@ -5,7 +5,7 @@ import warnings
 import ml_dtypes
 import numpy as np
 import openvino as ov
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 from openvino import Model
 from openvino import Tensor
 from openvino import Type

--- a/keras/src/backend/openvino/image.py
+++ b/keras/src/backend/openvino/image.py
@@ -1,7 +1,7 @@
 import itertools
 
 import numpy as np
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 from openvino import Type
 
 from keras.src import backend

--- a/keras/src/backend/openvino/linalg.py
+++ b/keras/src/backend/openvino/linalg.py
@@ -1,7 +1,7 @@
 import warnings
 
 import openvino as ov
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 from openvino import Model
 from openvino import Type
 

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -1,9 +1,7 @@
 import numpy as np
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 import scipy.signal
 from openvino import Type
-from openvino.opset16 import istft as ov_istft
-from openvino.opset16 import segment_max as ov_segment_max
 
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import cast
@@ -92,7 +90,7 @@ def _segment_reduce_via_scatter(
 
 
 def _segment_reduce_via_ov_max(data, segment_ids, num_segments):
-    """Sort + ov_segment_max reduction shared by segment_max and segment_min."""
+    """Sort + segment_max reduction shared by segment_max and segment_min."""
     zero = ov_opset.constant(0, Type.i32).output(0)
     zero_1d = ov_opset.constant([0], Type.i32).output(0)
     one_1d = ov_opset.constant([1], Type.i32).output(0)
@@ -102,7 +100,7 @@ def _segment_reduce_via_ov_max(data, segment_ids, num_segments):
     ).output(0)
     safe_seg = ov_opset.select(is_neg, num_segments, segment_ids).output(0)
 
-    # ov_segment_max requires sorted segment_ids.
+    # OpenVINO segment_max requires sorted segment_ids.
     n = ov_opset.squeeze(
         ov_opset.shape_of(safe_seg, output_type=Type.i32), zero_1d
     ).output(0)
@@ -114,7 +112,7 @@ def _segment_reduce_via_ov_max(data, segment_ids, num_segments):
     nseg_plus1 = ov_opset.add(
         num_segments, ov_opset.constant(1, num_segments.get_element_type())
     ).output(0)
-    result = ov_segment_max(
+    result = ov_opset.segment_max(
         sorted_data, sorted_seg, nseg_plus1, fill_mode="LOWEST"
     ).output(0)
 
@@ -718,7 +716,7 @@ def istft(
     ori_dtype = x[0].dtype
 
     if window is None:
-        # ov_istft always applies OLA normalization via window, so the
+        # OpenVINO ISTFT always applies OLA normalization via window, so the
         # unnormalized window=None case uses the manual irfft + OLA path,
         # matching TF and Torch backend.
         frames = irfft(x, fft_length)
@@ -847,7 +845,8 @@ def istft(
         stacked, ov_opset.constant(perm, Type.i32)
     ).output(0)
 
-    # ov_istft only accepts rank 3 or 4; flatten leading batch dims if needed
+    # OpenVINO ISTFT only accepts rank 3 or 4; flatten leading batch dims if
+    # needed.
     num_batch_dims = rank - 3
     if num_batch_dims > 1:
         data_shape_node = ov_opset.shape_of(data, output_type=Type.i32).output(
@@ -877,7 +876,7 @@ def istft(
         else None
     )
 
-    result = ov_istft(
+    result = ov_opset.istft(
         data,
         win_node,
         frame_size_node,

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1,5 +1,5 @@
 import numpy as np
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 from openvino import Type
 
 import keras.src.backend.openvino.numpy as onp

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -349,6 +349,9 @@ def average_pool(
     padding="valid",
     data_format=None,
 ):
+    num_spatial_dims = (
+        get_ov_output(inputs).get_partial_shape().rank.get_length() - 2
+    )
     return _pool(
         inputs,
         pool_size,
@@ -357,6 +360,7 @@ def average_pool(
         padding,
         data_format,
         exclude_pad=True,
+        dilations=[1] * num_spatial_dims,
     )
 
 
@@ -429,6 +433,7 @@ def _adaptive_pool_ov(
                 kernel_shape=small_kernel,
                 exclude_pad=True,
                 auto_pad="VALID",
+                dilations=[1] * num_spatial_dims,
             ).output(0)
         else:
             small_pool = ov_opset.max_pool(
@@ -454,6 +459,7 @@ def _adaptive_pool_ov(
                     kernel_shape=big_kernel,
                     exclude_pad=True,
                     auto_pad="VALID",
+                    dilations=[1] * num_spatial_dims,
                 ).output(0)
             else:
                 big_pool = ov_opset.max_pool(

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1,6 +1,6 @@
 import numpy as np
 import openvino as ov
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 from openvino import Type
 
 from keras.src.backend import config

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1117,37 +1117,18 @@ def bincount(x, weights=None, minlength=0, sparse=False):
         return OpenVINOKerasTensor(final_output)
 
 
-def _bitwise_op_i8u8(ov_op, x, y):
-    """Apply an OV bitwise op, working around a SIMD bug in 8-bit kernels.
-
-    OpenVINO's int8/uint8 bitwise kernels have a vectorization bug: when the
-    last dimension is >= 32, elements at non-stride-4 positions (0..31 range)
-    receive wrong values.  Casting to int32/uint32 avoids the buggy kernel.
-    """
-    elem_type = x.get_element_type()
-    if elem_type in (Type.i8, Type.u8):
-        cast_type = Type.i32 if elem_type == Type.i8 else Type.u32
-        x = ov_opset.convert(x, cast_type).output(0)
-        y = ov_opset.convert(y, cast_type).output(0)
-        result = ov_op(x, y).output(0)
-        return OpenVINOKerasTensor(
-            ov_opset.convert(result, elem_type).output(0)
-        )
-    return OpenVINOKerasTensor(ov_op(x, y).output(0))
-
-
 def bitwise_and(x, y):
     x = get_ov_output(x)
     y = get_ov_output(y)
     x, y = _align_operand_types(x, y, "bitwise_and()")
-    return _bitwise_op_i8u8(ov_opset.bitwise_and, x, y)
+    return OpenVINOKerasTensor(ov_opset.bitwise_and(x, y).output(0))
 
 
 def bitwise_xor(x, y):
     x = get_ov_output(x)
     y = get_ov_output(y)
     x, y = _align_operand_types(x, y, "bitwise_xor()")
-    return _bitwise_op_i8u8(ov_opset.bitwise_xor, x, y)
+    return OpenVINOKerasTensor(ov_opset.bitwise_xor(x, y).output(0))
 
 
 def bitwise_invert(x):
@@ -1163,7 +1144,7 @@ def bitwise_or(x, y):
     x = get_ov_output(x)
     y = get_ov_output(y)
     x, y = _align_operand_types(x, y, "bitwise_or()")
-    return _bitwise_op_i8u8(ov_opset.bitwise_or, x, y)
+    return OpenVINOKerasTensor(ov_opset.bitwise_or(x, y).output(0))
 
 
 def blackman(x):

--- a/keras/src/backend/openvino/random.py
+++ b/keras/src/backend/openvino/random.py
@@ -1,5 +1,5 @@
 import numpy as np
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 from openvino import Type
 
 from keras.src.backend.config import floatx

--- a/keras/src/backend/openvino/rnn.py
+++ b/keras/src/backend/openvino/rnn.py
@@ -1,7 +1,7 @@
 import logging
 
 import numpy as np
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 from openvino import Model
 from openvino import Type
 

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -1,6 +1,6 @@
 import numpy as np
 import openvino as ov
-import openvino.opset15 as ov_opset
+import openvino.opset16 as ov_opset
 
 from keras.src import backend
 from keras.src import callbacks as callbacks_module

--- a/keras/src/export/openvino.py
+++ b/keras/src/export/openvino.py
@@ -56,7 +56,7 @@ def export_openvino(
         )
 
     import openvino as ov
-    import openvino.opset15 as ov_opset
+    import openvino.opset16 as ov_opset
 
     from keras.src.backend.openvino.core import OPENVINO_DTYPES
     from keras.src.backend.openvino.core import OpenVINOKerasTensor


### PR DESCRIPTION
## Description
OpenVINO's opset16 had a bug in the earlier release releted to missing ops. But this was fixed upstream in the latest release 2026.2. Due to this bug, we previously did a partial upgrade for some ops in #22600. Since it's fixed, this PR implements a full upgrade to OpenVINO's opset16, for all ops.

Also removed the turnaround introduced in #22389, since that bug was also fixed upstream.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
