### PR TITLE
Apply causal mask in MHA/GQA manual attention path

### DIFF
--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -1273,6 +1273,58 @@ def dot_product_attention(
             mask = ov_opset.add(mask, bias).output(0)
         else:
             mask = bias
+    if is_causal and mask is not None:
+        # OpenVINO's SDPA ignores `attention_mask` when `causal=True`, so a
+        # caller-provided mask would otherwise silently drop the causal
+        # constraint. Fold a lower-triangular mask into the explicit mask and
+        # disable the flag. `query`/`key` are [batch, heads, seq, head_dim].
+        seq_axis = ov_opset.constant([2], Type.i32).output(0)
+        gather_axis = ov_opset.constant(0, Type.i32).output(0)
+        squeeze_axis = ov_opset.constant([0], Type.i32).output(0)
+        t_len = ov_opset.squeeze(
+            ov_opset.gather(
+                ov_opset.shape_of(query).output(0), seq_axis, gather_axis
+            ).output(0),
+            squeeze_axis,
+        ).output(0)
+        s_len = ov_opset.squeeze(
+            ov_opset.gather(
+                ov_opset.shape_of(key).output(0), seq_axis, gather_axis
+            ).output(0),
+            squeeze_axis,
+        ).output(0)
+        zero_idx = ov_opset.constant(0, Type.i32).output(0)
+        one_idx = ov_opset.constant(1, Type.i32).output(0)
+        rows = ov_opset.unsqueeze(
+            ov_opset.range(
+                zero_idx, t_len, one_idx, output_type=Type.i32
+            ).output(0),
+            ov_opset.constant([1], Type.i32).output(0),
+        ).output(0)
+        cols = ov_opset.unsqueeze(
+            ov_opset.range(
+                zero_idx, s_len, one_idx, output_type=Type.i32
+            ).output(0),
+            ov_opset.constant([0], Type.i32).output(0),
+        ).output(0)
+        causal_keep = ov_opset.less_equal(cols, rows).output(0)
+        if mask.get_element_type() == Type.boolean:
+            false_const = ov_opset.constant(False, Type.boolean).output(0)
+            mask = ov_opset.select(causal_keep, mask, false_const).output(0)
+        else:
+            query_dtype = ov_to_keras_type(query.get_element_type())
+            min_val = (
+                np.finfo(np.float16).min
+                if query_dtype == "float16"
+                else np.finfo(np.float32).min
+            )
+            large_neg = ov_opset.constant(
+                min_val, query.get_element_type()
+            ).output(0)
+            zero = ov_opset.constant(0.0, query.get_element_type()).output(0)
+            causal_add = ov_opset.select(causal_keep, zero, large_neg).output(0)
+            mask = ov_opset.add(mask, causal_add).output(0)
+        is_causal = False
     scale = (
         get_ov_output(scale, query.get_element_type())
         if scale is not None

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1461,7 +1461,19 @@ def dot_product_attention(
 
     mask = mask if mask is None else convert_to_tensor(mask, dtype="bool")
     if mask is not None:
-        # Explicit set `is_causal` to `False` when `mask` is not `None`.
+        if is_causal:
+            # `scaled_dot_product_attention` treats `attn_mask` and
+            # `is_causal` as mutually exclusive, so a caller-provided mask
+            # would otherwise silently drop the causal constraint. Fold the
+            # causal mask into the explicit mask to honor both.
+            q_len, kv_len = query.shape[1], key.shape[1]
+            causal_mask = torch.tril(
+                torch.ones(
+                    (q_len, kv_len), dtype=torch.bool, device=mask.device
+                )
+            )
+            mask = torch.logical_and(mask, causal_mask)
+        # Explicitly set `is_causal` to `False` when `mask` is not `None`.
         is_causal = False
         mask = torch.where(mask, 0.0, _get_large_negative(query.dtype))
     if bias is not None:

--- a/keras/src/layers/attention/grouped_query_attention.py
+++ b/keras/src/layers/attention/grouped_query_attention.py
@@ -491,16 +491,6 @@ class GroupedQueryAttention(Layer):
                     flash_attention=self._flash_attention,
                 )
                 return attention_output, None
-            if use_causal_mask and attention_mask is not None:
-                # The native is_causal kernel above was skipped because an
-                # explicit mask was also provided. Fold the causal mask into it
-                # so both constraints apply. Backends disagree on whether
-                # is_causal composes with an explicit mask, so combine them here
-                # rather than forwarding the is_causal flag.
-                attention_mask = ops.logical_and(
-                    ops.cast(attention_mask, "bool"),
-                    self._compute_causal_mask(query, value),
-                )
             if attention_mask is not None:
                 # Ensure attention_mask has the correct shape for broadcasting
                 # Expected shape: [batch_size, num_heads, query_seq_len,
@@ -522,7 +512,7 @@ class GroupedQueryAttention(Layer):
                 bias=None,
                 mask=attention_mask,
                 scale=self._inverse_sqrt_head_dim,
-                is_causal=False,
+                is_causal=use_causal_mask,
                 flash_attention=self._flash_attention,
             )
             return attention_output, None

--- a/keras/src/layers/attention/grouped_query_attention.py
+++ b/keras/src/layers/attention/grouped_query_attention.py
@@ -491,6 +491,16 @@ class GroupedQueryAttention(Layer):
                     flash_attention=self._flash_attention,
                 )
                 return attention_output, None
+            if use_causal_mask and attention_mask is not None:
+                # The native is_causal kernel above was skipped because an
+                # explicit mask was also provided. Fold the causal mask into it
+                # so both constraints apply. Backends disagree on whether
+                # is_causal composes with an explicit mask, so combine them here
+                # rather than forwarding the is_causal flag.
+                attention_mask = ops.logical_and(
+                    ops.cast(attention_mask, "bool"),
+                    self._compute_causal_mask(query, value),
+                )
             if attention_mask is not None:
                 # Ensure attention_mask has the correct shape for broadcasting
                 # Expected shape: [batch_size, num_heads, query_seq_len,
@@ -521,9 +531,17 @@ class GroupedQueryAttention(Layer):
         # scores. We skipped the fused is_causal kernel above, so build the
         # causal mask here. `call` drops attention_mask when causal is the
         # only mask source, expecting that kernel to run, and this path never
-        # sees the is_causal flag otherwise.
-        if use_causal_mask and attention_mask is None:
-            attention_mask = self._compute_causal_mask(query, value)
+        # sees the is_causal flag otherwise. When an explicit mask is also
+        # present, combine the two so neither constraint is lost.
+        if use_causal_mask:
+            causal_mask = self._compute_causal_mask(query, value)
+            attention_mask = (
+                causal_mask
+                if attention_mask is None
+                else ops.logical_and(
+                    ops.cast(attention_mask, "bool"), causal_mask
+                )
+            )
         query = ops.multiply(
             query, ops.cast(self._inverse_sqrt_head_dim, query.dtype)
         )

--- a/keras/src/layers/attention/grouped_query_attention.py
+++ b/keras/src/layers/attention/grouped_query_attention.py
@@ -518,7 +518,12 @@ class GroupedQueryAttention(Layer):
             return attention_output, None
 
         # Default behavior without flash attention, with explicit attention
-        # scores
+        # scores. We skipped the fused is_causal kernel above, so build the
+        # causal mask here. `call` drops attention_mask when causal is the
+        # only mask source, expecting that kernel to run, and this path never
+        # sees the is_causal flag otherwise.
+        if use_causal_mask and attention_mask is None:
+            attention_mask = self._compute_causal_mask(query, value)
         query = ops.multiply(
             query, ops.cast(self._inverse_sqrt_head_dim, query.dtype)
         )

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -461,6 +461,45 @@ class GroupedQueryAttentionTest(testing.TestCase):
         self.assertEqual(tuple(out1.shape), (2, 5, 16))
         self.assertAllClose(out1, out2, atol=1e-5)
 
+    @parameterized.named_parameters(
+        ("scores_only", 0.0, True),
+        ("dropout_only", 0.1, False),
+        ("dropout_and_scores", 0.1, True),
+    )
+    def test_causal_only_masks_when_fused_path_disabled(
+        self, dropout, return_attention_scores
+    ):
+        # dropout>0 and return_attention_scores=True both disable the fused
+        # is_causal kernel and send us down the manual softmax path. That path
+        # has to apply the causal mask too, or future keys leak in. See #22910.
+        t = 6
+        future = np.triu(np.ones((t, t)), k=1).astype(bool)
+        x = np.random.RandomState(0).randn(1, t, 16).astype("float32")
+        layer = layers.GroupedQueryAttention(
+            head_dim=4,
+            num_query_heads=4,
+            num_key_value_heads=2,
+            dropout=dropout,
+        )
+
+        if return_attention_scores:
+            # No weight should land on a strictly-future key.
+            _, scores = layer(
+                x,
+                x,
+                use_causal_mask=True,
+                return_attention_scores=True,
+                training=False,
+            )
+            leak = backend.convert_to_numpy(scores)[..., future].sum()
+            self.assertLess(leak, 1e-6)
+        else:
+            # use_causal_mask should match passing the same mask explicitly.
+            out_causal = layer(x, x, use_causal_mask=True, training=False)
+            explicit = (~future)[None]
+            out_explicit = layer(x, x, attention_mask=explicit, training=False)
+            self.assertAllClose(out_causal, out_explicit, atol=1e-5)
+
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):
             layers.GroupedQueryAttention(

--- a/keras/src/layers/attention/grouped_query_attention_test.py
+++ b/keras/src/layers/attention/grouped_query_attention_test.py
@@ -500,6 +500,45 @@ class GroupedQueryAttentionTest(testing.TestCase):
             out_explicit = layer(x, x, attention_mask=explicit, training=False)
             self.assertAllClose(out_causal, out_explicit, atol=1e-5)
 
+    @parameterized.named_parameters(
+        ("fused_fallback", False),
+        ("manual_path", True),
+    )
+    def test_compute_attention_combines_causal_and_explicit_mask(
+        self, return_attention_scores
+    ):
+        # `_compute_attention` is a documented override point. Called directly
+        # with both use_causal_mask=True and an explicit attention_mask, it must
+        # apply both. `call` folds the causal mask in upstream, but a subclass
+        # reusing this method does not, so the method must honor its own flag.
+        t = 5
+        layer = layers.GroupedQueryAttention(
+            head_dim=4, num_query_heads=4, num_key_value_heads=2
+        )
+        layer.build(query_shape=(1, t, 16), value_shape=(1, t, 16))
+        layer._return_attention_scores = return_attention_scores
+
+        rng = np.random.RandomState(0)
+        # After projection and head repeat, q/k/v are [B, T, num_query_heads,
+        # head_dim].
+        query = rng.randn(1, t, 4, 4).astype("float32")
+        key = rng.randn(1, t, 4, 4).astype("float32")
+        value = rng.randn(1, t, 4, 4).astype("float32")
+
+        # A non-causal extra constraint so the causal mask is not redundant.
+        extra = np.ones((1, t, t), dtype="bool")
+        extra[:, 3, 1] = False
+        causal = np.tril(np.ones((t, t), dtype="bool"))[None]
+        merged = extra & causal
+
+        out_both, _ = layer._compute_attention(
+            query, key, value, attention_mask=extra, use_causal_mask=True
+        )
+        out_merged, _ = layer._compute_attention(
+            query, key, value, attention_mask=merged, use_causal_mask=False
+        )
+        self.assertAllClose(out_both, out_merged, atol=1e-5)
+
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):
             layers.GroupedQueryAttention(

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -539,6 +539,16 @@ class MultiHeadAttention(Layer):
                     flash_attention=self._flash_attention,
                 )
                 return attention_output, None
+            if use_causal_mask and attention_mask is not None:
+                # The native is_causal kernel above was skipped because an
+                # explicit mask was also provided. Fold the causal mask into it
+                # so both constraints apply. Backends disagree on whether
+                # is_causal composes with an explicit mask, so combine them here
+                # rather than forwarding the is_causal flag.
+                attention_mask = ops.logical_and(
+                    ops.cast(attention_mask, "bool"),
+                    self._compute_causal_mask(query, value),
+                )
             if attention_mask is not None:
                 # Ensure attention_mask has the correct shape for broadcasting
                 # Expected shape: [batch_size, num_heads, query_seq_len,
@@ -569,9 +579,17 @@ class MultiHeadAttention(Layer):
         # scores. We skipped the fused is_causal kernel above, so build the
         # causal mask here. `call` drops attention_mask when causal is the
         # only mask source, expecting that kernel to run, and this path never
-        # sees the is_causal flag otherwise.
-        if use_causal_mask and attention_mask is None:
-            attention_mask = self._compute_causal_mask(query, value)
+        # sees the is_causal flag otherwise. When an explicit mask is also
+        # present, combine the two so neither constraint is lost.
+        if use_causal_mask:
+            causal_mask = self._compute_causal_mask(query, value)
+            attention_mask = (
+                causal_mask
+                if attention_mask is None
+                else ops.logical_and(
+                    ops.cast(attention_mask, "bool"), causal_mask
+                )
+            )
         query = ops.multiply(
             query, ops.cast(self._inverse_sqrt_key_dim, query.dtype)
         )

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -539,16 +539,6 @@ class MultiHeadAttention(Layer):
                     flash_attention=self._flash_attention,
                 )
                 return attention_output, None
-            if use_causal_mask and attention_mask is not None:
-                # The native is_causal kernel above was skipped because an
-                # explicit mask was also provided. Fold the causal mask into it
-                # so both constraints apply. Backends disagree on whether
-                # is_causal composes with an explicit mask, so combine them here
-                # rather than forwarding the is_causal flag.
-                attention_mask = ops.logical_and(
-                    ops.cast(attention_mask, "bool"),
-                    self._compute_causal_mask(query, value),
-                )
             if attention_mask is not None:
                 # Ensure attention_mask has the correct shape for broadcasting
                 # Expected shape: [batch_size, num_heads, query_seq_len,
@@ -570,7 +560,7 @@ class MultiHeadAttention(Layer):
                 bias=None,
                 mask=attention_mask,
                 scale=self._inverse_sqrt_key_dim,
-                is_causal=False,
+                is_causal=use_causal_mask,
                 flash_attention=self._flash_attention,
             )
             return attention_output, None

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -566,7 +566,12 @@ class MultiHeadAttention(Layer):
             return attention_output, None
 
         # Default behavior without flash attention, with explicit attention
-        # scores
+        # scores. We skipped the fused is_causal kernel above, so build the
+        # causal mask here. `call` drops attention_mask when causal is the
+        # only mask source, expecting that kernel to run, and this path never
+        # sees the is_causal flag otherwise.
+        if use_causal_mask and attention_mask is None:
+            attention_mask = self._compute_causal_mask(query, value)
         query = ops.multiply(
             query, ops.cast(self._inverse_sqrt_key_dim, query.dtype)
         )

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -605,6 +605,57 @@ class MultiHeadAttentionTest(testing.TestCase):
         self.assertEqual(tuple(out1.shape), (2, 5, 8))
         self.assertAllClose(out1, out2, atol=1e-5)
 
+    @parameterized.named_parameters(
+        ("scores_only", 0.0, True),
+        ("dropout_only", 0.1, False),
+        ("dropout_and_scores", 0.1, True),
+    )
+    def test_causal_only_masks_when_fused_path_disabled(
+        self, dropout, return_attention_scores
+    ):
+        # dropout>0 and return_attention_scores=True both disable the fused
+        # is_causal kernel and send us down the manual softmax path. That path
+        # has to apply the causal mask too, or future keys leak in. See #22910.
+        t = 6
+        future = np.triu(np.ones((t, t)), k=1).astype(bool)
+        x = np.random.RandomState(0).randn(1, t, 8).astype("float32")
+        layer = layers.MultiHeadAttention(
+            num_heads=2, key_dim=4, dropout=dropout
+        )
+
+        if return_attention_scores:
+            # No weight should land on a strictly-future key.
+            _, scores = layer(
+                x,
+                x,
+                use_causal_mask=True,
+                return_attention_scores=True,
+                training=False,
+            )
+            leak = backend.convert_to_numpy(scores)[..., future].sum()
+            self.assertLess(leak, 1e-6)
+        else:
+            # use_causal_mask should match passing the same mask explicitly.
+            out_causal = layer(x, x, use_causal_mask=True, training=False)
+            explicit = (~future)[None]
+            out_explicit = layer(x, x, attention_mask=explicit, training=False)
+            self.assertAllClose(out_causal, out_explicit, atol=1e-5)
+
+    def test_causal_only_masks_non_4d_inputs(self):
+        # A rank-5 projected query (extra attention axis) is the third thing
+        # that disables the fused kernel, so check that path masks too.
+        t = 5
+        future = np.triu(np.ones((t, t)), k=1).astype(bool)
+        x = np.random.RandomState(0).randn(1, t, 3, 8).astype("float32")
+        layer = layers.MultiHeadAttention(
+            num_heads=2, key_dim=4, attention_axes=1
+        )
+        _, scores = layer(
+            x, x, use_causal_mask=True, return_attention_scores=True
+        )
+        scores = backend.convert_to_numpy(scores)
+        self.assertLess(scores[..., future].sum(), 1e-6)
+
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):
             layers.MultiHeadAttention(num_heads=2, key_dim=4, sliding_window=0)

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -656,6 +656,50 @@ class MultiHeadAttentionTest(testing.TestCase):
         scores = backend.convert_to_numpy(scores)
         self.assertLess(scores[..., future].sum(), 1e-6)
 
+    @parameterized.named_parameters(
+        ("fused_fallback", False),
+        ("manual_path", True),
+    )
+    def test_compute_attention_combines_causal_and_explicit_mask(
+        self, return_attention_scores
+    ):
+        # `_compute_attention` is a documented override point. Called directly
+        # with both use_causal_mask=True and an explicit attention_mask, it must
+        # apply both. `call` folds the causal mask in upstream, but a subclass
+        # reusing this method does not, so the method must honor its own flag.
+        t = 5
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        layer.build(query_shape=(1, t, 8), value_shape=(1, t, 8))
+
+        rng = np.random.RandomState(0)
+        query = rng.randn(1, t, 2, 4).astype("float32")
+        key = rng.randn(1, t, 2, 4).astype("float32")
+        value = rng.randn(1, t, 2, 4).astype("float32")
+
+        # A non-causal extra constraint so the causal mask is not redundant.
+        extra = np.ones((1, t, t), dtype="bool")
+        extra[:, 3, 1] = False
+        causal = np.tril(np.ones((t, t), dtype="bool"))[None]
+        merged = extra & causal
+
+        out_both, _ = layer._compute_attention(
+            query,
+            key,
+            value,
+            attention_mask=extra,
+            use_causal_mask=True,
+            return_attention_scores=return_attention_scores,
+        )
+        out_merged, _ = layer._compute_attention(
+            query,
+            key,
+            value,
+            attention_mask=merged,
+            use_causal_mask=False,
+            return_attention_scores=return_attention_scores,
+        )
+        self.assertAllClose(out_both, out_merged, atol=1e-5)
+
     def test_sliding_window_validation(self):
         with self.assertRaisesRegex(ValueError, "sliding_window"):
             layers.MultiHeadAttention(num_heads=2, key_dim=4, sliding_window=0)


### PR DESCRIPTION
## Description

Regression from #22910: `use_causal_mask=True` silently applies no mask when the fused SDPA path is off (dropout>0, return_attention_scores=True, or non-4D), so queries attend to future keys. GQA has the same bug. Fixes #23038.

Fix materializes the causal mask in the manual attention fallthrough. Tests cover all three triggers on both layers.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
