### PR TITLE
Transpose channels_first to NHWC on CPU for depthwise/separable conv

### DIFF
--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -1,3 +1,4 @@
+import functools
 import math
 import warnings
 
@@ -16,6 +17,17 @@ from keras.src.backend.common.backend_utils import (
 )
 from keras.src.backend.tensorflow.core import cast
 from keras.src.backend.tensorflow.core import convert_to_tensor
+
+
+@functools.lru_cache(maxsize=None)
+def _cpu_only():
+    """Whether the TF runtime sees only CPU devices.
+
+    Cached because the device list does not change during a run and
+    `tf.config.list_logical_devices()` is comparatively expensive to call on
+    every conv invocation in eager mode.
+    """
+    return all(d.device_type == "CPU" for d in tf.config.list_logical_devices())
 
 
 def relu(x):
@@ -979,9 +991,7 @@ def depthwise_conv(
         # `tf.nn.depthwise_conv2d` does not support `channels_first` with
         # dilations on CPU. Transpose to `channels_last`, compute, and
         # transpose back to avoid the limitation.
-        need_transpose = data_format == "channels_first" and all(
-            d.device_type == "CPU" for d in tf.config.list_logical_devices()
-        )
+        need_transpose = data_format == "channels_first" and _cpu_only()
         if need_transpose:
             inputs = _transpose_spatial_inputs(inputs)
         if need_transpose or data_format == "channels_last":
@@ -1016,9 +1026,7 @@ def depthwise_conv(
     # Transpose to `channels_last`, compute, and transpose back to avoid the
     # limitation. On GPU, `channels_first` (NCHW) is supported natively, so we
     # keep it to avoid unnecessary copies.
-    need_transpose = data_format == "channels_first" and all(
-        d.device_type == "CPU" for d in tf.config.list_logical_devices()
-    )
+    need_transpose = data_format == "channels_first" and _cpu_only()
     if need_transpose:
         inputs = _transpose_spatial_inputs(inputs)
     if need_transpose or data_format == "channels_last":
@@ -1082,9 +1090,7 @@ def separable_conv(
         # 1D separable conv.
         # `tf.nn.separable_conv2d` does not support `channels_first` on CPU.
         # Transpose to `channels_last`, compute, and transpose back.
-        need_transpose = data_format == "channels_first" and all(
-            d.device_type == "CPU" for d in tf.config.list_logical_devices()
-        )
+        need_transpose = data_format == "channels_first" and _cpu_only()
         if need_transpose:
             inputs = _transpose_spatial_inputs(inputs)
         if need_transpose or data_format == "channels_last":
@@ -1117,9 +1123,7 @@ def separable_conv(
     # `tf.nn.separable_conv2d` does not support `channels_first` on CPU.
     # Transpose to `channels_last`, compute, and transpose back. On GPU,
     # NCHW is supported natively, so we keep it to avoid unnecessary copies.
-    need_transpose = data_format == "channels_first" and all(
-        d.device_type == "CPU" for d in tf.config.list_logical_devices()
-    )
+    need_transpose = data_format == "channels_first" and _cpu_only()
     if need_transpose:
         inputs = _transpose_spatial_inputs(inputs)
     if need_transpose or data_format == "channels_last":

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -1012,20 +1012,32 @@ def depthwise_conv(
             outputs = _transpose_spatial_outputs(outputs)
         return outputs
 
-    if data_format == "channels_last":
+    # `tf.nn.depthwise_conv2d` does not support `channels_first` on CPU.
+    # Transpose to `channels_last`, compute, and transpose back to avoid the
+    # limitation. On GPU, `channels_first` (NCHW) is supported natively, so we
+    # keep it to avoid unnecessary copies.
+    need_transpose = data_format == "channels_first" and all(
+        d.device_type == "CPU" for d in tf.config.list_logical_devices()
+    )
+    if need_transpose:
+        inputs = _transpose_spatial_inputs(inputs)
+    if need_transpose or data_format == "channels_last":
         strides = (1,) + strides + (1,)
-        spatial_start_dim = 1
+        conv_data_format = _convert_data_format("channels_last", 4)
     else:
         strides = (1, 1) + strides
-        spatial_start_dim = 2
-    return tf.nn.depthwise_conv2d(
+        conv_data_format = tf_data_format
+    outputs = tf.nn.depthwise_conv2d(
         inputs,
         kernel,
         strides,
         padding,
-        data_format=tf_data_format,
+        data_format=conv_data_format,
         dilations=dilation_rate,
     )
+    if need_transpose:
+        outputs = _transpose_spatial_outputs(outputs)
+    return outputs
 
 
 def separable_conv(
@@ -1067,13 +1079,22 @@ def separable_conv(
             pointwise_kernel=pointwise_kernel,
         )
     if num_spatial_dims == 1:
-        # 1D depthwise conv.
-        if data_format == "channels_last":
+        # 1D separable conv.
+        # `tf.nn.separable_conv2d` does not support `channels_first` on CPU.
+        # Transpose to `channels_last`, compute, and transpose back.
+        need_transpose = data_format == "channels_first" and all(
+            d.device_type == "CPU" for d in tf.config.list_logical_devices()
+        )
+        if need_transpose:
+            inputs = _transpose_spatial_inputs(inputs)
+        if need_transpose or data_format == "channels_last":
             strides = (1,) + strides * 2 + (1,)
             spatial_start_dim = 1
+            conv_data_format = _convert_data_format("channels_last", 4)
         else:
             strides = (1, 1) + strides * 2
             spatial_start_dim = 2
+            conv_data_format = _convert_data_format("channels_first", 4)
         inputs = tf.expand_dims(inputs, spatial_start_dim)
         depthwise_kernel = tf.expand_dims(depthwise_kernel, axis=0)
         pointwise_kernel = tf.expand_dims(pointwise_kernel, axis=0)
@@ -1085,24 +1106,40 @@ def separable_conv(
             pointwise_kernel,
             strides,
             padding,
-            data_format=tf_data_format,
+            data_format=conv_data_format,
             dilations=dilation_rate,
         )
-        return tf.squeeze(outputs, [spatial_start_dim])
+        outputs = tf.squeeze(outputs, [spatial_start_dim])
+        if need_transpose:
+            outputs = _transpose_spatial_outputs(outputs)
+        return outputs
 
-    if data_format == "channels_last":
+    # `tf.nn.separable_conv2d` does not support `channels_first` on CPU.
+    # Transpose to `channels_last`, compute, and transpose back. On GPU,
+    # NCHW is supported natively, so we keep it to avoid unnecessary copies.
+    need_transpose = data_format == "channels_first" and all(
+        d.device_type == "CPU" for d in tf.config.list_logical_devices()
+    )
+    if need_transpose:
+        inputs = _transpose_spatial_inputs(inputs)
+    if need_transpose or data_format == "channels_last":
         strides = (1,) + strides + (1,)
+        conv_data_format = _convert_data_format("channels_last", 4)
     else:
         strides = (1, 1) + strides
-    return tf.nn.separable_conv2d(
+        conv_data_format = tf_data_format
+    outputs = tf.nn.separable_conv2d(
         inputs,
         depthwise_kernel,
         pointwise_kernel,
         strides,
         padding,
-        data_format=tf_data_format,
+        data_format=conv_data_format,
         dilations=dilation_rate,
     )
+    if need_transpose:
+        outputs = _transpose_spatial_outputs(outputs)
+    return outputs
 
 
 def conv_transpose(

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1927,17 +1927,6 @@ class NNOpsCorrectnessTest(testing.TestCase):
     def test_depthwise_conv_2d(
         self, strides, padding, dilation_rate, data_format
     ):
-        if (
-            backend.backend() == "tensorflow"
-            and data_format == "channels_first"
-            and not testing.tensorflow_uses_gpu()
-            and not (strides == (2, 2) and dilation_rate == (2, 2))
-        ):
-            # On TF CPU, channels_first depthwise conv only works on the
-            # stride+dilation decomposition path (which transposes to NHWC).
-            # The regular path passes NCHW to tf.nn and is unsupported on CPU;
-            # that is a separate pre-existing gap.
-            pytest.skip("channels_first depthwise conv unsupported on TF CPU")
         if data_format == "channels_last":
             input_shape = (2, 10, 10, 3)
         else:
@@ -1974,15 +1963,6 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self, strides, padding, dilation_rate, data_format
     ):
         # Test 2D conv.
-        if (
-            backend.backend() == "tensorflow"
-            and data_format == "channels_first"
-            and not testing.tensorflow_uses_gpu()
-            and not (strides == 2 and dilation_rate == (2, 2))
-        ):
-            # See test_depthwise_conv_2d: channels_first separable conv on TF
-            # CPU only works on the stride+dilation decomposition path.
-            pytest.skip("channels_first separable conv unsupported on TF CPU")
         if data_format == "channels_last":
             input_shape = (2, 10, 10, 3)
         else:
@@ -2073,15 +2053,6 @@ class NNOpsCorrectnessTest(testing.TestCase):
     def test_separable_conv_1d(
         self, strides, padding, dilation_rate, data_format
     ):
-        if (
-            backend.backend() == "tensorflow"
-            and data_format == "channels_first"
-            and not testing.tensorflow_uses_gpu()
-            and not (strides == 2 and dilation_rate == 2)
-        ):
-            # See test_depthwise_conv_2d: channels_first separable conv on TF
-            # CPU only works on the stride+dilation decomposition path.
-            pytest.skip("channels_first separable conv unsupported on TF CPU")
         if data_format == "channels_last":
             input_shape = (2, 10, 3)
         else:


### PR DESCRIPTION
## Description

Fixes #23031. On the TensorFlow backend, channels_first `depthwise_conv` (2D) and `separable_conv` (1D and 2D) failed on CPU with "Depthwise convolution on CPU is only supported for NHWC format", because these paths passed NCHW straight to the `tf.nn` ops. The 1D depthwise path and the stride+dilation decomposition from #23027 already transpose channels_first to NHWC on CPU. This applies the same pattern to the three remaining paths. It transposes to channels_last on CPU, computes, transposes back, and keeps NCHW on GPU where it is supported.

It also removes the channels_first skip guards #23027 added to the conv tests, since those cases now pass. Verified on the TF, JAX, and NumPy backends (the previously skipped cases now run and pass) plus the depthwise and separable layer tests on TF.

Prepared with AI assistance from Claude Code and OpenAI Codex. I reviewed and verified the change, ran the conv op and layer tests locally across backends, and take responsibility for it.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
