### PR TITLE
[Distribution] Implement centralized distribute_dataset

### DIFF
--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -429,14 +429,97 @@ class Distribution:
 
         Returns:
             If `auto_shard_dataset` is `True`, returns a sharded dataset that
-            only produces data for the current local worker/process.  Otherwise,
+            only produces data for the current local worker/process. Otherwise,
             returns the original dataset.
 
         Raises:
             ValueError: if auto-sharding is requested in a multi-process
             setting, but the dataset type is not supported.
         """
-        raise NotImplementedError()
+        if not self._is_multi_process or not self.auto_shard_dataset:
+            return dataset
+
+        from keras.src.utils.module_utils import tensorflow as tf
+
+        if tf.available and isinstance(dataset, tf.data.Dataset):
+            return self.distribute_tf_dataset(dataset)
+
+        raise ValueError(
+            f"The dataset type {type(dataset)} is not supported for "
+            "auto-sharding in multi-process setting."
+        )
+
+    def distribute_tf_dataset(self, dataset):
+        from tensorflow.python.data.experimental.ops import (
+            distribute as tf_data_distribute,
+        )
+
+        from keras.src.utils.module_utils import tensorflow as tf
+
+        # Check if the dataset is batched.
+        if not all(
+            hasattr(spec, "shape") and spec.shape.rank > 0
+            for spec in tf.nest.flatten(dataset.element_spec)
+        ):
+            raise ValueError(
+                "The batch size of the input dataset is "
+                "unknown. Please config the batch size for "
+                "the input dataset, e.g via `dataset.batch(batch_size)`"
+            )
+
+        global_batch_size = tf_data_distribute.compute_batch_size(dataset)
+        if global_batch_size.numpy() < 0:
+            raise ValueError(
+                "The batch size of the input dataset is "
+                "unknown. Please config the batch size for "
+                "the input dataset, e.g via `dataset.batch(batch_size)`"
+            )
+
+        global_batch_size = int(global_batch_size.numpy())
+        num_model_replicas = self.num_model_replicas
+
+        if num_model_replicas == 1:
+            # No sharding is needed. Each process runs the global batch size,
+            # and data from the iterator is replicated across all processes.
+            return dataset.prefetch(tf.data.AUTOTUNE)
+
+        num_model_replicas_per_process = num_model_replicas / self.num_processes
+
+        if num_model_replicas_per_process >= 1:
+            # Each process hosts one or more full model replicas (includes
+            # pure DataParallel). Data is sharded across all processes
+            # without inner-process replication.
+            if global_batch_size % self.num_processes != 0:
+                raise ValueError(
+                    "Global batch size must be divisible by the number of "
+                    f"processes. `global_batch_size`={global_batch_size} and "
+                    f"`num_processes`={self.num_processes}"
+                )
+            per_process_batch_size = global_batch_size // self.num_processes
+            distributed_dataset = dataset.rebatch(per_process_batch_size)
+            distributed_dataset = distributed_dataset.shard(
+                num_shards=self.num_processes,
+                index=self._process_id,
+            )
+            return distributed_dataset.prefetch(tf.data.AUTOTUNE)
+
+        else:
+            # Model replicas are sharded across multiple processes. Data is
+            # sharded across model replicas, and replicated across processes
+            # within the same replica.
+            if global_batch_size % num_model_replicas != 0:
+                raise ValueError(
+                    "Global batch size must be divisible by the number of "
+                    f"replicas. `global_batch_size`={global_batch_size} and "
+                    f"`num_model_replicas`={num_model_replicas}"
+                )
+            per_process_batch_size = global_batch_size // num_model_replicas
+            distributed_dataset = dataset.rebatch(per_process_batch_size)
+            distributed_dataset = distributed_dataset.shard(
+                num_shards=num_model_replicas,
+                index=self.data_shard_id,
+            )
+            return distributed_dataset.prefetch(tf.data.AUTOTUNE)
 
     def __repr__(self):
         return f"<{self.__class__.__name__} device_mesh={self.device_mesh}>"
@@ -539,45 +622,6 @@ class DataParallel(Distribution):
     def get_tensor_layout(self, path):
         # For data parallel training, the intermediate state is not changed.
         return None
-
-    def distribute_dataset(self, dataset):
-        if not self._is_multi_process or not self.auto_shard_dataset:
-            return dataset
-
-        # Try to distribute a global tf.data.Dataset.
-        from keras.src.utils.module_utils import tensorflow as tf
-
-        if not tf.available or not isinstance(dataset, tf.data.Dataset):
-            raise ValueError(
-                "Only `tf.data.Dataset` is supported for auto-sharding, "
-                f"got {type(dataset)}"
-            )
-
-        from tensorflow.python.data.experimental.ops import (
-            distribute as tf_data_distribute,
-        )
-
-        batch_size = tf_data_distribute.compute_batch_size(dataset)
-        if batch_size.numpy() < 0:
-            raise ValueError(
-                "The batch size of the input dataset is "
-                "unknown. Please config the batch size for "
-                "the input dataset, e.g via `dataset.batch(batch_size)`"
-            )
-        per_worker_batch_size = tf_data_distribute.batch_sizes_for_worker(
-            global_batch_size=batch_size,
-            num_workers=self.num_processes,
-            num_replicas_per_worker=1,  # We hard code this for now.
-            worker_index=self._process_id,
-        )
-        distributed_dataset = dataset.rebatch(per_worker_batch_size)
-        distributed_dataset = tf_data_distribute._AutoShardDataset(
-            distributed_dataset,
-            num_workers=self.num_processes,
-            index=self._process_id,
-            num_replicas=self.num_processes,
-        )
-        return distributed_dataset.prefetch(tf.data.AUTOTUNE)
 
 
 @keras_export("keras.distribution.ModelParallel")
@@ -724,83 +768,6 @@ class ModelParallel(Distribution):
 
     def get_tensor_layout(self, path):
         return self._layout_map[path]
-
-    def distribute_dataset(self, dataset):
-        if not self._is_multi_process or not self.auto_shard_dataset:
-            return dataset
-
-        # Try to distribute a global tf.data.Dataset.
-        from keras.src.utils.module_utils import tensorflow as tf
-
-        if not tf.available or not isinstance(dataset, tf.data.Dataset):
-            raise ValueError(
-                "Only `tf.data.Dataset` is supported for auto-sharding, "
-                f"got {type(dataset)}"
-            )
-
-        from tensorflow.python.data.experimental.ops import (
-            distribute as tf_data_distribute,
-        )
-
-        global_batch_size = tf_data_distribute.compute_batch_size(dataset)
-        if global_batch_size.numpy() < 0:
-            raise ValueError(
-                "The batch size of the input dataset is "
-                "unknown. Please config the batch size for "
-                "the input dataset, e.g via `dataset.batch(batch_size)`"
-            )
-
-        # We need to compute the per-process/worker/host batch size.
-        # This will depend on how many model replicas we have on each process.
-        # Note that this might be smaller than one if model replicas are sharded
-        # across multiple processes.
-        mesh_batch_dim_index = self.device_mesh.axis_names.index(
-            self.batch_dim_name
-        )
-        num_model_replicas = self.device_mesh.shape[mesh_batch_dim_index]
-        if num_model_replicas == 1:
-            # No sharding is needed in this case. Each process will have the
-            # global batch size, and data from the iterator will need to be
-            # replicated across all processes.
-            return dataset.prefetch(tf.data.AUTOTUNE)
-        num_model_replicas_per_process = num_model_replicas / self.num_processes
-        if num_model_replicas_per_process >= 1:
-            # Each process will have one or more full model replicas. Data will
-            # be sharded across all processes without replication.
-            if global_batch_size % self.num_processes != 0:
-                raise ValueError(
-                    "Global batch size must be divisible by the number of "
-                    f"processes. `global_batch_size`={global_batch_size} and "
-                    f"`num_processes`={self.num_processes}"
-                )
-            per_process_batch_size = global_batch_size // self.num_processes
-            distributed_dataset = dataset.rebatch(per_process_batch_size)
-            distributed_dataset = distributed_dataset.shard(
-                num_shards=self.num_processes,
-                index=self._process_id,
-            )
-            return distributed_dataset.prefetch(tf.data.AUTOTUNE)
-        else:
-            # Model replicas are sharded across multiple processes. Data will be
-            # sharded across model replicas, and replicated across processes
-            # within the same model replica.
-            if global_batch_size % num_model_replicas != 0:
-                raise ValueError(
-                    "Global batch size must be divisible by the number of "
-                    f"replicas. `global_batch_size`={global_batch_size} and "
-                    f"`num_model_replicas`={num_model_replicas}"
-                )
-            per_process_batch_size = global_batch_size // num_model_replicas
-            distributed_dataset = dataset.rebatch(per_process_batch_size)
-            processes_per_replica = self.num_processes // num_model_replicas
-            # Each process belongs to a replica group. Determine which replica
-            # this process group belongs to.
-            data_shard_id = self._process_id // processes_per_replica
-            distributed_dataset = distributed_dataset.shard(
-                num_shards=num_model_replicas,
-                index=data_shard_id,
-            )
-            return distributed_dataset.prefetch(tf.data.AUTOTUNE)
 
 
 @keras_export("keras.distribution.LayoutMap")

--- a/keras/src/distribution/distribution_lib_test.py
+++ b/keras/src/distribution/distribution_lib_test.py
@@ -443,6 +443,132 @@ class ModelParallelDistributionTest(testing.TestCase):
         self.assertEqual(distribution.num_processes, 2)
 
 
+class TfDatasetDistributionTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.devices = [f"cpu:{i}" for i in range(8)]
+        self.device_mesh = distribution_lib.DeviceMesh(
+            (4, 2), ["data", "model"], self.devices
+        )
+        self.layout_map = distribution_lib.LayoutMap(self.device_mesh)
+        self.distribution = distribution_lib.ModelParallel(
+            layout_map=self.layout_map, batch_dim_name="data"
+        )
+
+    def test_distribute_tf_dataset_multiple_replicas_per_process(self):
+        # Case: num_model_replicas=4, num_processes=2 => 2 replicas per process
+        dataset = tf.data.Dataset.range(16).batch(8)
+        with (
+            mock.patch.object(
+                self.distribution.__class__,
+                "num_model_replicas",
+                new_callable=mock.PropertyMock,
+                return_value=4,
+            ),
+            mock.patch.object(
+                self.distribution.__class__,
+                "num_processes",
+                new_callable=mock.PropertyMock,
+                return_value=2,
+            ),
+            mock.patch.object(self.distribution, "_is_multi_process", True),
+            mock.patch.object(self.distribution, "_process_id", 0),
+        ):
+            # Global batch size 8 is divisible by num_processes 2
+            distributed_dataset = self.distribution.distribute_dataset(dataset)
+            # per_process_batch_size = 8 // 2 = 4
+            # num_shards = 2, index = 0
+            # Original dataset has 16 items, batched by 8 => 2 batches:
+            # [0..7], [8..15]
+            # Rebatched by 4 => 4 batches: [0..3], [4..7], [8..11], [12..15]
+            # Sharded by 2, index 0 => batches 0 and 2: [0..3], [8..11]
+            data = list(distributed_dataset.as_numpy_iterator())
+            self.assertEqual(len(data), 2)
+            self.assertAllClose(data[0], [0, 1, 2, 3])
+            self.assertAllClose(data[1], [8, 9, 10, 11])
+
+        with (
+            mock.patch.object(
+                self.distribution.__class__,
+                "num_model_replicas",
+                new_callable=mock.PropertyMock,
+                return_value=4,
+            ),
+            mock.patch.object(
+                self.distribution.__class__,
+                "num_processes",
+                new_callable=mock.PropertyMock,
+                return_value=2,
+            ),
+            mock.patch.object(self.distribution, "_is_multi_process", True),
+            mock.patch.object(self.distribution, "_process_id", 1),
+        ):
+            distributed_dataset = self.distribution.distribute_dataset(dataset)
+            # Sharded by 2, index 1 => batches 1 and 3: [4..7], [12..15]
+            data = list(distributed_dataset.as_numpy_iterator())
+            self.assertEqual(len(data), 2)
+            self.assertAllClose(data[0], [4, 5, 6, 7])
+            self.assertAllClose(data[1], [12, 13, 14, 15])
+
+    def test_distribute_tf_dataset_error_not_divisible(self):
+        dataset = tf.data.Dataset.range(16).batch(7)
+        with (
+            mock.patch.object(
+                self.distribution.__class__,
+                "num_model_replicas",
+                new_callable=mock.PropertyMock,
+                return_value=4,
+            ),
+            mock.patch.object(
+                self.distribution.__class__,
+                "num_processes",
+                new_callable=mock.PropertyMock,
+                return_value=2,
+            ),
+            mock.patch.object(self.distribution, "_is_multi_process", True),
+        ):
+            # Global batch size 7 is NOT divisible by num_processes 2
+            with self.assertRaisesRegex(
+                ValueError, "Global batch size must be divisible by the number"
+            ):
+                self.distribution.distribute_dataset(dataset)
+
+    def test_unsupported_dataset_type(self):
+        with (
+            mock.patch.object(self.distribution, "_is_multi_process", True),
+            self.assertRaisesRegex(
+                ValueError, "is not supported for auto-sharding"
+            ),
+        ):
+            self.distribution.distribute_dataset([1, 2, 3])
+
+    def test_unknown_batch_size(self):
+        dataset = tf.data.Dataset.range(16)
+        with (
+            mock.patch.object(self.distribution, "_is_multi_process", True),
+            self.assertRaisesRegex(ValueError, "batch size .* is unknown"),
+        ):
+            self.distribution.distribute_dataset(dataset)
+
+    def test_num_model_replicas_one(self):
+        dataset = tf.data.Dataset.range(16).batch(8)
+        with (
+            mock.patch.object(
+                self.distribution.__class__,
+                "num_model_replicas",
+                new_callable=mock.PropertyMock,
+                return_value=1,
+            ),
+            mock.patch.object(self.distribution, "_is_multi_process", True),
+        ):
+            distributed_dataset = self.distribution.distribute_dataset(dataset)
+            # Should return the same data (with prefetch)
+            data = list(distributed_dataset.as_numpy_iterator())
+            self.assertEqual(len(data), 2)
+            self.assertAllClose(data[0], np.arange(8))
+            self.assertAllClose(data[1], np.arange(8, 16))
+
+
 class LayoutMapTest(testing.TestCase):
     def setUp(self):
         super().setUp()

--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -150,10 +150,10 @@ def get_data_adapter(
 
     elif isinstance(x, types.GeneratorType):
         if y is not None:
-            raise_unsupported_arg("y", "the targets", "PyDataset")
+            raise_unsupported_arg("y", "the targets", "generator")
         if sample_weight is not None:
             raise_unsupported_arg(
-                "sample_weights", "the sample weights", "PyDataset"
+                "sample_weights", "the sample weights", "generator"
             )
         if class_weight is not None:
             raise ValueError(

--- a/keras/src/trainers/data_adapters/data_adapter_utils_test.py
+++ b/keras/src/trainers/data_adapters/data_adapter_utils_test.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -105,3 +107,40 @@ class TestClassWeightToSampleWeights(testing.TestCase):
             class_weight_to_sample_weights(y_one_hot, {0: 1.0, 1: 2.0, 2: 3.0}),
             np.array([1.0, 2.0, 1.0, 3.0]),
         )
+
+
+class TestMultiWorkerValidation(testing.TestCase):
+    @mock.patch("keras.src.distribution.distribution_lib.distribution")
+    def test_unsupported_type_multi_worker(self, mock_distribution):
+        from keras.src.distribution import distribution_lib
+        from keras.src.trainers.data_adapters import get_data_adapter
+
+        # Mock a multi-worker distribution
+        dist = distribution_lib.DataParallel(devices=["cpu:0", "cpu:1"])
+        dist._num_processes = 2
+        dist._is_multi_process = True
+        dist.auto_shard_dataset = True
+        mock_distribution.return_value = dist
+
+        # Raw generator is not supported for auto-sharding
+        def generator():
+            yield np.ones((10, 2))
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "When using a multi-worker distribution with auto-sharding enabled",
+        ):
+            get_data_adapter(generator())
+
+
+class TestDataAdapterFactory(testing.TestCase):
+    def test_generator_with_y_error(self):
+        from keras.src.trainers.data_adapters import get_data_adapter
+
+        def generator():
+            yield np.ones((10, 2))
+
+        # Passing y along with a generator should raise ValueError mentioning
+        # "generator"
+        with self.assertRaisesRegex(ValueError, "providing `x` as a generator"):
+            get_data_adapter(generator(), y=np.ones((10, 1)))


### PR DESCRIPTION
## Description
This PR refactors the distribute_dataset logic in the Distribution base class to establish a backend-agnostic routing infrastructure. It centralizes how Keras identifies and shards datasets in a multi-process environment, allowing for modular support of multiple data formats.

Key Changes:

   * Centralized Routing: Implemented a unified distribute_dataset method that serves as a central router. This PR includes the full implementation for TensorFlow (`distribute_tf_dataset`), while support for other formats (like Torch DataLoader) is architected to be added in subsequent PRs.
   * TF Dataset Refactor: Moves existing tf.data.Dataset distribution logic into a dedicated method. It introduces improved safety guards, such as checking for a static batch dimension to avoid IndexError and explicitly casting tensor batch sizes to Python integers.
   * Bug Fix (Error Messaging): Corrected a bug in the data adapter factory (get_data_adapter) where providing invalid arguments (like a separate y target) to a Python generator resulted in a confusing error message incorrectly citing the input as a "PyDataset". The error now correctly identifies the input as a "generator".

[2nd PR]: This PR should be rebased after merging of PR https://github.com/keras-team/keras/pull/23025
## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
