### PR TITLE
[Distribution] Implement sharding support for Keras PyDataset adapter

### DIFF
--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -38,12 +38,14 @@ def get_data_adapter(
         distribution is not None
         and getattr(distribution, "_is_multi_process", False)
         and getattr(distribution, "auto_shard_dataset", False)
-        and not is_tf_dataset(x)
+        and not (
+            is_tf_dataset(x) or isinstance(x, py_dataset_adapter.PyDataset)
+        )
     ):
         raise ValueError(
             "When using a multi-worker distribution with auto-sharding enabled, "
-            "the data must be provided as a `tf.data.Dataset` instance. "
-            f"Received: type(x)={type(x)}. "
+            "the data must be provided as a `tf.data.Dataset` or a "
+            f"`keras.utils.PyDataset` instance. Received: type(x)={type(x)}. "
             "If the dataset is already sharded across workers, then set "
             "`distribution.auto_shard_dataset = False`."
         )

--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -10,6 +10,7 @@ from contextlib import closing
 import numpy as np
 
 from keras.src.api_export import keras_export
+from keras.src.distribution import distribution_lib
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.data_adapters.data_adapter import DataAdapter
 
@@ -210,6 +211,16 @@ class PyDatasetAdapter(DataAdapter):
         self.shuffle = shuffle
         self._output_signature = None
         self._within_epoch = False
+        self._epoch = 0
+
+        dist = distribution_lib.distribution()
+        self._num_data_shards = 1
+        self._data_shard_id = 0
+        if dist is not None and getattr(dist, "auto_shard_dataset", False):
+            self._num_data_shards = min(
+                dist.num_model_replicas, dist.num_processes
+            )
+            self._data_shard_id = dist.data_shard_id
 
         workers = self.py_dataset.workers
         use_multiprocessing = self.py_dataset.use_multiprocessing
@@ -220,6 +231,8 @@ class PyDatasetAdapter(DataAdapter):
                 use_multiprocessing=use_multiprocessing,
                 max_queue_size=self.py_dataset.max_queue_size,
                 shuffle=self.shuffle,
+                num_data_shards=self._num_data_shards,
+                data_shard_id=self._data_shard_id,
             )
 
     def _standardize_batch(self, batch):
@@ -251,29 +264,30 @@ class PyDatasetAdapter(DataAdapter):
         return batch
 
     def _infinite_generator(self):
-        for i in itertools.count():
+        for i in itertools.count(
+            start=self._data_shard_id, step=self._num_data_shards
+        ):
             yield self._standardize_batch(self.py_dataset[i])
 
     def _finite_generator(self):
-        indices = range(self.py_dataset.num_batches)
+        num_batches = self.py_dataset.num_batches
+        indices = list(range(num_batches))
         if self.shuffle:
-            indices = list(indices)
-            random.shuffle(indices)
+            random.Random(self._epoch).shuffle(indices)
 
-        for i in indices:
-            yield self._standardize_batch(self.py_dataset[i])
+        for i in range(self._data_shard_id, num_batches, self._num_data_shards):
+            yield self._standardize_batch(self.py_dataset[indices[i]])
 
     def _infinite_enqueuer_generator(self):
-        self.enqueuer.start()
+        self.enqueuer.start(self._epoch)
         for batch in self.enqueuer.get():
             yield self._standardize_batch(batch)
 
     def _finite_enqueuer_generator(self):
-        self.enqueuer.start()
-        num_batches = self.py_dataset.num_batches
+        self.enqueuer.start(self._epoch)
         for i, batch in enumerate(self.enqueuer.get()):
             yield self._standardize_batch(batch)
-            if i >= num_batches - 1:
+            if i >= self.num_batches - 1:
                 self.enqueuer.stop()
                 return
 
@@ -338,7 +352,7 @@ class PyDatasetAdapter(DataAdapter):
             )
         self._within_epoch = True
         if self.enqueuer:
-            self.enqueuer.start()
+            self.enqueuer.start(self._epoch)
         self.py_dataset.on_epoch_begin()
 
     def on_epoch_end(self):
@@ -346,10 +360,18 @@ class PyDatasetAdapter(DataAdapter):
             self.enqueuer.stop()
         self.py_dataset.on_epoch_end()
         self._within_epoch = False
+        self._epoch += 1
 
     @property
     def num_batches(self):
-        return self.py_dataset.num_batches
+        if self.py_dataset.num_batches is None:
+            return None
+        return (
+            self.py_dataset.num_batches
+            - self._data_shard_id
+            + self._num_data_shards
+            - 1
+        ) // self._num_data_shards
 
     @property
     def batch_size(self):
@@ -414,7 +436,7 @@ class PyDatasetEnqueuer:
 
     ```python
         enqueuer = PyDatasetEnqueuer(...)
-        enqueuer.start()
+        enqueuer.start(epoch=0)
         datas = enqueuer.get()
         for data in datas:
             # Use the inputs; training, evaluating, predicting.
@@ -473,15 +495,19 @@ class PyDatasetEnqueuer:
         """
         return self.running
 
-    def start(self):
+    def start(self, epoch):
         """Starts the handler's workers.
 
         This method is thread safe but is called from the main thread.
         It is safe to call this method multiple times, extra calls are ignored.
+
+        Args:
+            epoch: Integer, the current epoch.
         """
         with self.start_stop_lock:
             if self.running:
                 return
+            self.epoch = epoch
             self.running = True
             self.run_thread = threading.Thread(target=self._run)
             self.run_thread.name = f"Worker_{self.uid}"
@@ -579,15 +605,21 @@ class OrderedEnqueuer(PyDatasetEnqueuer):
         use_multiprocessing=False,
         max_queue_size=10,
         shuffle=False,
+        num_data_shards=1,
+        data_shard_id=0,
     ):
         super().__init__(
             py_dataset, workers, use_multiprocessing, max_queue_size
         )
         self.shuffle = shuffle
+        self._num_data_shards = num_data_shards
+        self._data_shard_id = data_shard_id
         if self.py_dataset.num_batches is None:
             # For infinite datasets, `self.indices` is created here once for all
             # so that subsequent runs resume from where they stopped.
-            self.indices = itertools.count()
+            self.indices = itertools.count(
+                start=self._data_shard_id, step=self._num_data_shards
+            )
 
     def _get_executor_init(self, workers):
         """Gets the Pool initializer for multiprocessing.
@@ -622,7 +654,17 @@ class OrderedEnqueuer(PyDatasetEnqueuer):
                 indices = range(self.py_dataset.num_batches)
                 if self.shuffle:
                     indices = list(indices)
-                    random.shuffle(indices)
+                    random.Random(self.epoch).shuffle(indices)
+
+                if self._num_data_shards > 1:
+                    indices = [
+                        indices[i]
+                        for i in range(
+                            self._data_shard_id,
+                            len(indices),
+                            self._num_data_shards,
+                        )
+                    ]
                 self.indices = iter(indices)
             self._send_py_dataset()  # Share the initial py_dataset
 

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -10,6 +10,7 @@ from absl.testing import parameterized
 
 from keras.src import backend
 from keras.src import testing
+from keras.src.distribution import distribution_lib as dist_lib
 from keras.src.testing.test_utils import named_product
 from keras.src.trainers.data_adapters import py_dataset_adapter
 from keras.src.utils.rng_utils import set_random_seed
@@ -453,3 +454,132 @@ class PyDatasetAdapterTest(testing.TestCase):
         for index, _ in enumerate(NoLenDataset()):
             if index >= 10:
                 break
+
+    @parameterized.named_parameters(
+        named_product(
+            [
+                {
+                    "testcase_name": "dataparallel",
+                    "dist_type": "dp",
+                    "num_processes": 4,
+                    "process_id": 1,
+                    "mesh_shape": (4,),
+                },
+                {
+                    "testcase_name": "modelparallel",
+                    "dist_type": "mp",
+                    "num_processes": 8,
+                    "process_id": 5,
+                    "mesh_shape": (2, 4),
+                },
+                {
+                    "testcase_name": "modelparallel_large_mesh",
+                    "dist_type": "mp",
+                    "num_processes": 4,
+                    "process_id": 2,
+                    "mesh_shape": (8, 2),
+                },
+            ],
+            shuffle=[False, True],
+        )
+    )
+    def test_sharding(
+        self,
+        dist_type,
+        num_processes,
+        process_id,
+        mesh_shape,
+        shuffle,
+    ):
+        if dist_type == "dp":
+            dist = dist_lib.DataParallel(devices=["cpu:0"] * num_processes)
+        else:
+            device_mesh = dist_lib.DeviceMesh(
+                shape=mesh_shape,
+                axis_names=("data", "model"),
+                devices=["cpu:0"] * np.prod(mesh_shape),
+            )
+            dist = dist_lib.ModelParallel(
+                device_mesh=device_mesh,
+                layout_map=dist_lib.LayoutMap(device_mesh),
+                batch_dim_name="data",
+            )
+        dist._num_processes = num_processes
+        dist._process_id = process_id
+        dist.auto_shard_dataset = True
+
+        expected_num_replicas = min(dist.num_model_replicas, num_processes)
+        expected_shard_id = dist.data_shard_id
+
+        x = np.array([[i] * 10 for i in range(100)], dtype="float32")
+        y = np.array([[i] for i in range(100)], dtype="float32")
+        py_dataset = ExamplePyDataset(x, y, batch_size=10)
+
+        with dist.scope():
+            adapter = py_dataset_adapter.PyDatasetAdapter(
+                py_dataset, shuffle=shuffle
+            )
+
+            it_methods = ["get_numpy_iterator"]
+            backend_it_method = {
+                "tensorflow": "get_tf_dataset",
+                "jax": "get_jax_iterator",
+                "torch": "get_torch_dataloader",
+            }.get(backend.backend())
+            if backend_it_method:
+                it_methods.append(backend_it_method)
+
+        self.assertEqual(adapter._num_data_shards, expected_num_replicas)
+        self.assertEqual(adapter._data_shard_id, expected_shard_id)
+
+        def get_order(it_fn):
+            order = []
+            for batch in it_fn():
+                bx = batch[0]
+                bx = backend.convert_to_numpy(bx)
+                order.extend(bx[:, 0].tolist())
+            return order
+
+        for it_method in it_methods:
+            it_fn = getattr(adapter, it_method)
+            if not shuffle:
+                batches = list(it_fn())
+                expected_num_batches = (
+                    10 - expected_shard_id + expected_num_replicas - 1
+                ) // expected_num_replicas
+                self.assertEqual(len(batches), expected_num_batches)
+
+                for i, batch in enumerate(batches):
+                    bx, by = batch
+                    bx = backend.convert_to_numpy(bx)
+                    by = backend.convert_to_numpy(by)
+                    expected_batch_index = (
+                        expected_shard_id + i * expected_num_replicas
+                    )
+                    expected_first_sample_value = expected_batch_index * 10
+                    self.assertAllClose(
+                        bx[:, 0],
+                        np.arange(
+                            expected_first_sample_value,
+                            expected_first_sample_value + 10,
+                        ),
+                    )
+                    self.assertAllClose(
+                        by[:, 0],
+                        np.arange(
+                            expected_first_sample_value,
+                            expected_first_sample_value + 10,
+                        ),
+                    )
+            else:
+                # Same epoch should have same shuffle
+                adapter._epoch = 1
+                order1 = get_order(it_fn)
+                adapter._epoch = 1
+                order2 = get_order(it_fn)
+                self.assertAllClose(order1, order2)
+
+                # Different epochs should have different shuffle
+                adapter._epoch = 2
+                order3 = get_order(it_fn)
+                self.assertNotAllClose(order1, order3)


### PR DESCRIPTION
## Description
This PR implements native sharding support for keras.utils.PyDataset (and its underlying enqueuer), enabling parallel Python-based data pipelines in multi-process distributed training.

   * `PyDatasetAdapter` Sharding: Implements logic to shard indices across model replicas. Each process now only iterates over its designated data shard, significantly reducing redundant I/O and preprocessing in a distributed cluster.
   
[4th PR]: This PR should be rebased after merging of PR https://github.com/keras-team/keras/pull/23043


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
