### PR TITLE
Restrict unpickling when loading IMDB and Reuters datasets

### DIFF
--- a/keras/src/datasets/imdb.py
+++ b/keras/src/datasets/imdb.py
@@ -5,6 +5,7 @@ import json
 import numpy as np
 
 from keras.src.api_export import keras_export
+from keras.src.datasets import npz_utils
 from keras.src.utils.file_utils import get_file
 from keras.src.utils.python_utils import remove_long_seq
 
@@ -83,9 +84,12 @@ def load_data(
             "69664113be75683a8fe16e3ed0ab59fda8886cb3cd7ada244f7d9544e4676b9f"
         ),
     )
-    with np.load(path, allow_pickle=True) as f:
-        x_train, labels_train = f["x_train"], f["y_train"]
-        x_test, labels_test = f["x_test"], f["y_test"]
+    # The IMDB arrays are ragged (`dtype=object`) sequences, so they are stored
+    # as pickle streams. Load them with a restricted unpickler that only allows
+    # numpy array reconstruction instead of `np.load(allow_pickle=True)`.
+    f = npz_utils.load_npz(path)
+    x_train, labels_train = f["x_train"], f["y_train"]
+    x_test, labels_test = f["x_test"], f["y_test"]
 
     rng = np.random.RandomState(seed)
     indices = np.arange(len(x_train))

--- a/keras/src/datasets/npz_utils.py
+++ b/keras/src/datasets/npz_utils.py
@@ -6,27 +6,29 @@ import zipfile
 
 import numpy as np
 
-# Globals that are legitimately required to reconstruct the numpy object arrays
-# stored inside the IMDB / Reuters `.npz` files (ragged sequences are saved as
-# `dtype=object` arrays, which numpy persists as pickle streams). Both the
-# numpy < 2 (`numpy.core`) and numpy >= 2 (`numpy._core`) module spellings are
-# listed so files written by either can be read. Anything outside this set
-# (e.g. `os.system`, `builtins.eval`, `subprocess.Popen`) is refused, which
-# prevents a tampered `.npz` from executing code through a pickle `__reduce__`
-# gadget.
+# Globals required to reconstruct the numpy object arrays stored inside the
+# IMDB / Reuters `.npz` files. These datasets store ragged sequences as
+# `dtype=object` arrays, which numpy can only persist as a pickle stream, so
+# `np.load(allow_pickle=False)` refuses them outright ("Object arrays cannot be
+# loaded when allow_pickle=False"). Rebuilding such an array uses exactly three
+# globals -- `numpy.ndarray`, `numpy.dtype` and `multiarray._reconstruct` -- and
+# nothing else (verified against the actual IMDB and Reuters files). Both the
+# numpy < 2 (`numpy.core`) and numpy >= 2 (`numpy._core`) spellings of
+# `multiarray` are listed so files written by either can be read. Anything
+# outside this set (e.g. `os.system`, `builtins.eval`, `subprocess.Popen`) is
+# refused, which prevents a tampered `.npz` from executing code through a pickle
+# `__reduce__` gadget.
 _ALLOWED_PICKLE_GLOBALS = frozenset(
     {
         ("numpy", "ndarray"),
         ("numpy", "dtype"),
         ("numpy.core.multiarray", "_reconstruct"),
-        ("numpy.core.multiarray", "scalar"),
         ("numpy._core.multiarray", "_reconstruct"),
-        ("numpy._core.multiarray", "scalar"),
     }
 )
 
 
-class _RestrictedUnpickler(pickle.Unpickler):
+class RestrictedUnpickler(pickle.Unpickler):
     """An unpickler that only allows numpy array reconstruction globals."""
 
     def find_class(self, module, name):
@@ -38,11 +40,11 @@ class _RestrictedUnpickler(pickle.Unpickler):
         )
 
 
-def _load_npy_member(fp):
+def load_npy_member(fp):
     """Read a single `.npy` stream without allowing arbitrary unpickling.
 
     Numeric arrays are read with pickling disabled entirely. Object arrays
-    (which genuinely require pickle) are read with `_RestrictedUnpickler`, so
+    (which genuinely require pickle) are read with `RestrictedUnpickler`, so
     only numpy array reconstruction is permitted.
     """
     try:
@@ -63,7 +65,7 @@ def _load_npy_member(fp):
             np.lib.format.read_array_header_2_0(fp)
         else:
             raise ValueError(f"Unsupported `.npy` file version: {version}.")
-        return _RestrictedUnpickler(fp).load()
+        return RestrictedUnpickler(fp).load()
 
 
 def load_npz(path):
@@ -87,5 +89,5 @@ def load_npz(path):
                 continue
             with archive.open(member) as raw:
                 buffer = io.BytesIO(raw.read())
-            arrays[member[: -len(".npy")]] = _load_npy_member(buffer)
+            arrays[member[: -len(".npy")]] = load_npy_member(buffer)
     return arrays

--- a/keras/src/datasets/npz_utils.py
+++ b/keras/src/datasets/npz_utils.py
@@ -54,7 +54,12 @@ def _load_npy_member(fp):
         version = np.lib.format.read_magic(fp)
         if version[0] == 1:
             np.lib.format.read_array_header_1_0(fp)
-        elif version[0] == 2:
+        elif version[0] in (2, 3):
+            # numpy exposes no public `read_array_header_3_0`. The 3.0 format
+            # only differs from 2.0 by encoding the header string as UTF-8
+            # instead of latin1; the 4-byte header-length layout we skip past
+            # to reach the pickle stream is identical, so 2.0's reader handles
+            # both.
             np.lib.format.read_array_header_2_0(fp)
         else:
             raise ValueError(f"Unsupported `.npy` file version: {version}.")

--- a/keras/src/datasets/npz_utils.py
+++ b/keras/src/datasets/npz_utils.py
@@ -1,0 +1,86 @@
+"""Utilities shared by the built-in datasets."""
+
+import io
+import pickle
+import zipfile
+
+import numpy as np
+
+# Globals that are legitimately required to reconstruct the numpy object arrays
+# stored inside the IMDB / Reuters `.npz` files (ragged sequences are saved as
+# `dtype=object` arrays, which numpy persists as pickle streams). Both the
+# numpy < 2 (`numpy.core`) and numpy >= 2 (`numpy._core`) module spellings are
+# listed so files written by either can be read. Anything outside this set
+# (e.g. `os.system`, `builtins.eval`, `subprocess.Popen`) is refused, which
+# prevents a tampered `.npz` from executing code through a pickle `__reduce__`
+# gadget.
+_ALLOWED_PICKLE_GLOBALS = frozenset(
+    {
+        ("numpy", "ndarray"),
+        ("numpy", "dtype"),
+        ("numpy.core.multiarray", "_reconstruct"),
+        ("numpy.core.multiarray", "scalar"),
+        ("numpy._core.multiarray", "_reconstruct"),
+        ("numpy._core.multiarray", "scalar"),
+    }
+)
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """An unpickler that only allows numpy array reconstruction globals."""
+
+    def find_class(self, module, name):
+        if (module, name) in _ALLOWED_PICKLE_GLOBALS:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Refusing to deserialize `{module}.{name}` while loading a Keras "
+            "dataset. The `.npz` file may be corrupted or malicious."
+        )
+
+
+def _load_npy_member(fp):
+    """Read a single `.npy` stream without allowing arbitrary unpickling.
+
+    Numeric arrays are read with pickling disabled entirely. Object arrays
+    (which genuinely require pickle) are read with `_RestrictedUnpickler`, so
+    only numpy array reconstruction is permitted.
+    """
+    try:
+        # Fast path: numeric arrays load with pickle fully disabled.
+        return np.lib.format.read_array(fp, allow_pickle=False)
+    except ValueError:
+        # Object array: rewind, skip the header, then restrict the unpickler.
+        fp.seek(0)
+        version = np.lib.format.read_magic(fp)
+        if version[0] == 1:
+            np.lib.format.read_array_header_1_0(fp)
+        elif version[0] == 2:
+            np.lib.format.read_array_header_2_0(fp)
+        else:
+            raise ValueError(f"Unsupported `.npy` file version: {version}.")
+        return _RestrictedUnpickler(fp).load()
+
+
+def load_npz(path):
+    """Safely load an `.npz` archive into a `dict` of arrays.
+
+    This is a drop-in replacement for `np.load(path, allow_pickle=True)` for
+    the built-in datasets that store ragged object arrays. Unlike
+    `allow_pickle=True`, it only ever unpickles numpy arrays, so loading a
+    maliciously crafted file cannot execute arbitrary code.
+
+    Args:
+        path: Path to the `.npz` file.
+
+    Returns:
+        A `dict` mapping each member name to its array.
+    """
+    arrays = {}
+    with zipfile.ZipFile(path) as archive:
+        for member in archive.namelist():
+            if not member.endswith(".npy"):
+                continue
+            with archive.open(member) as raw:
+                buffer = io.BytesIO(raw.read())
+            arrays[member[: -len(".npy")]] = _load_npy_member(buffer)
+    return arrays

--- a/keras/src/datasets/npz_utils_test.py
+++ b/keras/src/datasets/npz_utils_test.py
@@ -1,0 +1,52 @@
+import os
+import pickle
+
+import numpy as np
+
+from keras.src import testing
+from keras.src.datasets import npz_utils
+
+
+class LoadNpzTest(testing.TestCase):
+    def test_loads_ragged_object_arrays(self):
+        # IMDB/Reuters store ragged sequences as `dtype=object` arrays.
+        xs = np.array([[1, 14, 22], [1, 194], [1, 14, 47, 8]], dtype=object)
+        ys = np.array([1, 0, 1])
+        path = os.path.join(self.get_temp_dir(), "ragged.npz")
+        np.savez(path, x=xs, y=ys)
+
+        loaded = npz_utils.load_npz(path)
+
+        self.assertEqual(
+            [list(seq) for seq in loaded["x"]],
+            [[1, 14, 22], [1, 194], [1, 14, 47, 8]],
+        )
+        self.assertAllEqual(loaded["y"], ys)
+
+    def test_loads_numeric_arrays(self):
+        path = os.path.join(self.get_temp_dir(), "numeric.npz")
+        np.savez(path, a=np.arange(10), b=np.ones((3, 4), dtype="float32"))
+
+        loaded = npz_utils.load_npz(path)
+
+        self.assertAllEqual(loaded["a"], np.arange(10))
+        self.assertEqual(loaded["b"].shape, (3, 4))
+        self.assertEqual(loaded["b"].dtype, np.float32)
+
+    def test_rejects_pickle_gadget(self):
+        # A crafted member whose unpickling would run code must be refused,
+        # without executing the payload.
+        marker = os.path.join(self.get_temp_dir(), "marker")
+
+        class Exploit:
+            def __reduce__(self):
+                return (os.system, (f"touch {marker}",))
+
+        payload = np.empty(1, dtype=object)
+        payload[0] = Exploit()
+        path = os.path.join(self.get_temp_dir(), "evil.npz")
+        np.savez(path, x=payload)
+
+        with self.assertRaisesRegex(pickle.UnpicklingError, "Refusing"):
+            npz_utils.load_npz(path)
+        self.assertFalse(os.path.exists(marker))

--- a/keras/src/datasets/reuters.py
+++ b/keras/src/datasets/reuters.py
@@ -5,6 +5,7 @@ import json
 import numpy as np
 
 from keras.src.api_export import keras_export
+from keras.src.datasets import npz_utils
 from keras.src.utils.file_utils import get_file
 from keras.src.utils.python_utils import remove_long_seq
 
@@ -92,8 +93,12 @@ def load_data(
             "d6586e694ee56d7a4e65172e12b3e987c03096cb01eab99753921ef915959916"
         ),
     )
-    with np.load(path, allow_pickle=True) as f:
-        xs, labels = f["x"], f["y"]
+    # The Reuters arrays are ragged (`dtype=object`) sequences, so they are
+    # stored as pickle streams. Load them with a restricted unpickler that only
+    # allows numpy array reconstruction instead of
+    # `np.load(allow_pickle=True)`.
+    f = npz_utils.load_npz(path)
+    xs, labels = f["x"], f["y"]
 
     rng = np.random.RandomState(seed)
     indices = np.arange(len(xs))


### PR DESCRIPTION
## Description

`keras.datasets.imdb.load_data` and `keras.datasets.reuters.load_data` load
their `.npz` files with `np.load(allow_pickle=True)`. Loading a crafted `.npz`
therefore unpickles arbitrary objects, which can execute code through a pickle
`__reduce__` gadget (insecure deserialization, CWE-502).

#23026 and #23034 removed `allow_pickle=True` from the numeric datasets
(`mnist`, `boston_housing`, `california_housing`) and `NpzIOStore`, but IMDB and
Reuters were left unchanged. These two datasets store ragged sequences as
`dtype=object` arrays, which numpy can only persist via pickle, so
`allow_pickle=False` cannot be used here without breaking the dataset format.

This PR adds `keras.src.datasets.npz_utils.load_npz`, used by both loaders:

- numeric members are read with pickling fully disabled;
- object members are read with a restricted unpickler that only permits numpy
  array reconstruction (`numpy.ndarray`, `numpy.dtype`, and the
  `numpy(._core).multiarray` `_reconstruct`/`scalar` globals).

This keeps the existing dataset format working while preventing a crafted
`.npz` from executing arbitrary code. A new `npz_utils_test.py` covers loading
ragged object arrays, loading numeric arrays, and rejecting a pickle gadget
without executing its payload.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
