### PR TITLE
Make Lambda and TorchModuleWrapper from_config fail closed when safe_mode is unset

### DIFF
--- a/keras/src/layers/core/lambda_layer.py
+++ b/keras/src/layers/core/lambda_layer.py
@@ -181,7 +181,16 @@ class Lambda(Layer):
 
     @classmethod
     def from_config(cls, config, custom_objects=None, safe_mode=None):
-        safe_mode = safe_mode or serialization_lib.in_safe_mode()
+        # When `safe_mode` is unset, fall back to the ambient deserialization
+        # scope, treating an unset scope as safe. This fails closed so that
+        # deserializing a `Lambda` outside of a `SafeModeScope` (e.g. a direct
+        # `from_config` call) does not silently allow arbitrary code execution.
+        effective_safe_mode = (
+            safe_mode
+            if safe_mode is not None
+            else serialization_lib.in_safe_mode()
+        )
+        safe_mode = effective_safe_mode is not False
         fn_config = config["function"]
         if (
             isinstance(fn_config, dict)

--- a/keras/src/layers/core/lambda_layer_test.py
+++ b/keras/src/layers/core/lambda_layer_test.py
@@ -80,6 +80,14 @@ class LambdaTest(testing.TestCase):
         output = layer(2 * np.ones((2, 3)))
         self.assertAllClose(4 * np.ones((2, 3)), output)
 
+    def test_from_config_fails_closed_without_safe_mode_scope(self):
+        # Without an ambient `SafeModeScope` and without an explicit
+        # `safe_mode`, deserializing a lambda `function` must be refused by
+        # default rather than silently loading the marshalled bytecode.
+        config = layers.Lambda(lambda x: x**2).get_config()
+        with self.assertRaisesRegex(ValueError, "Lambda"):
+            layers.Lambda.from_config(config)
+
     def test_correctness_lambda_shape(self):
         layer = layers.Lambda(lambda x: x**2, output_shape=lambda x: x)
         output = layer(2 * np.ones((2, 3)))

--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -167,7 +167,11 @@ class TorchModuleWrapper(Layer):
         import torch
 
         if "module" in config:
-            if in_safe_mode():
+            # Fail closed: an unset ambient scope (`in_safe_mode()` is `None`,
+            # e.g. a direct `from_config` call) is treated as safe, so a
+            # `torch.load()` pickle is not deserialized unless safe mode was
+            # explicitly disabled.
+            if in_safe_mode() is not False:
                 raise ValueError(
                     "Requested the deserialization of a `torch.nn.Module` "
                     "object via `torch.load()`. This carries a potential risk "

--- a/keras/src/utils/torch_utils.py
+++ b/keras/src/utils/torch_utils.py
@@ -163,15 +163,19 @@ class TorchModuleWrapper(Layer):
         return {**base_config, **config}
 
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, custom_objects=None, safe_mode=None):
         import torch
 
         if "module" in config:
-            # Fail closed: an unset ambient scope (`in_safe_mode()` is `None`,
-            # e.g. a direct `from_config` call) is treated as safe, so a
-            # `torch.load()` pickle is not deserialized unless safe mode was
-            # explicitly disabled.
-            if in_safe_mode() is not False:
+            # When `safe_mode` is unset, fall back to the ambient
+            # deserialization scope, treating an unset scope (`in_safe_mode()`
+            # is `None`, e.g. a direct `from_config` call) as safe. This fails
+            # closed so that the `torch.load()` pickle is not deserialized
+            # unless safe mode was explicitly disabled.
+            effective_safe_mode = (
+                safe_mode if safe_mode is not None else in_safe_mode()
+            )
+            if effective_safe_mode is not False:
                 raise ValueError(
                     "Requested the deserialization of a `torch.nn.Module` "
                     "object via `torch.load()`. This carries a potential risk "

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -12,6 +12,7 @@ from keras.src import models
 from keras.src import saving
 from keras.src import testing
 from keras.src.backend.torch.core import get_device
+from keras.src.saving.serialization_lib import SafeModeScope
 from keras.src.utils.torch_utils import TorchModuleWrapper
 
 
@@ -234,9 +235,20 @@ class TorchUtilsTest(testing.TestCase):
         module = torch.nn.Sequential(torch.nn.Linear(2, 4))
         mw = TorchModuleWrapper(module)
         config = mw.get_config()
-        new_mw = TorchModuleWrapper.from_config(config)
+        # Deserializing the embedded `torch.load()` pickle requires safe mode to
+        # be explicitly disabled (it fails closed otherwise).
+        with SafeModeScope(safe_mode=False):
+            new_mw = TorchModuleWrapper.from_config(config)
         for ref_w, new_w in zip(mw.get_weights(), new_mw.get_weights()):
             self.assertAllClose(new_w, ref_w, atol=1e-5)
+
+    def test_from_config_fails_closed_without_safe_mode_scope(self):
+        # Without an ambient `SafeModeScope`, deserializing the embedded
+        # `torch.load()` pickle must be refused by default.
+        module = torch.nn.Sequential(torch.nn.Linear(2, 4))
+        config = TorchModuleWrapper(module).get_config()
+        with self.assertRaisesRegex(ValueError, "torch.load"):
+            TorchModuleWrapper.from_config(config)
 
     def test_build_model(self):
         x = keras.Input([4])

--- a/keras/src/utils/torch_utils_test.py
+++ b/keras/src/utils/torch_utils_test.py
@@ -234,11 +234,19 @@ class TorchUtilsTest(testing.TestCase):
     def test_from_config(self):
         module = torch.nn.Sequential(torch.nn.Linear(2, 4))
         mw = TorchModuleWrapper(module)
-        config = mw.get_config()
+
         # Deserializing the embedded `torch.load()` pickle requires safe mode to
-        # be explicitly disabled (it fails closed otherwise).
+        # be explicitly disabled (it fails closed otherwise). It can be disabled
+        # via the `safe_mode` argument...
+        new_mw = TorchModuleWrapper.from_config(
+            mw.get_config(), safe_mode=False
+        )
+        for ref_w, new_w in zip(mw.get_weights(), new_mw.get_weights()):
+            self.assertAllClose(new_w, ref_w, atol=1e-5)
+
+        # ...or an ambient `SafeModeScope`.
         with SafeModeScope(safe_mode=False):
-            new_mw = TorchModuleWrapper.from_config(config)
+            new_mw = TorchModuleWrapper.from_config(mw.get_config())
         for ref_w, new_w in zip(mw.get_weights(), new_mw.get_weights()):
             self.assertAllClose(new_w, ref_w, atol=1e-5)
 


### PR DESCRIPTION
## Description

`Lambda.from_config` computed `safe_mode = safe_mode or in_safe_mode()`, which
evaluates to `None` (falsy) when a `Lambda` is deserialized outside of a
`SafeModeScope` and without an explicit `safe_mode` — for example a direct
`keras.Model.from_config(...)` / `keras.Sequential.from_config(...)` call, or a
layer config that omits the `"module"` key (which is routed through the legacy
deserializer). In that case the safe-mode guard did not fire and the marshalled
lambda bytecode was loaded via `func_load`, which can execute arbitrary code.
`TorchModuleWrapper.from_config` had the same problem with its `torch.load()`
pickle (`if in_safe_mode():`).

This makes both fail closed: an unset safe mode is treated as safe, matching the
handling already used by `TFSMLayer.from_config`. Deserialization is refused
unless safe mode is explicitly disabled via `safe_mode=False`,
`SafeModeScope(False)`, or `keras.config.enable_unsafe_deserialization()`.
`load_model` and `model_from_json` are unaffected — they already establish a
`SafeModeScope`, so the default loading paths behave exactly as before.

Adds regression tests for both layers (deserializing outside a `SafeModeScope`
is now refused) and updates the `TorchModuleWrapper` round-trip test to disable
safe mode explicitly.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
