### PR TITLE
Fix: do not follow symlinks when writing downloads in `get_file`

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -384,24 +384,25 @@ def get_file(
                         self.finished = True
 
         error_msg = "URL fetch failure on {}: {} -- {}"
+        # Download to a temporary file in the cache directory and atomically
+        # move it into place. Writing directly to `download_target` would
+        # follow a pre-existing symlink at that path and could place the
+        # downloaded file outside the cache directory.
+        fd, tmp_download_target = tempfile.mkstemp(dir=datadir)
+        os.close(fd)
         try:
             try:
-                urlretrieve(origin, download_target, DLProgbar())
+                urlretrieve(origin, tmp_download_target, DLProgbar())
             except urllib.error.HTTPError as e:
                 raise Exception(error_msg.format(origin, e.code, e.msg))
             except urllib.error.URLError as e:
                 raise Exception(error_msg.format(origin, e.errno, e.reason))
-        except (Exception, KeyboardInterrupt):
-            if os.path.exists(download_target):
-                os.remove(download_target)
-            raise
 
-        # Validate download if succeeded and user provided an expected hash
-        # Security conscious users would get the hash of the file from a
-        # separate channel and pass it to this API to prevent MITM / corruption:
-        if os.path.exists(download_target) and file_hash is not None:
-            if not validate_file(
-                download_target, file_hash, algorithm=hash_algorithm
+            # Validate the download before moving it into place. Security
+            # conscious users would get the hash of the file from a separate
+            # channel and pass it to this API to prevent MITM / corruption:
+            if file_hash is not None and not validate_file(
+                tmp_download_target, file_hash, algorithm=hash_algorithm
             ):
                 raise ValueError(
                     "Incomplete or corrupted file detected. "
@@ -409,6 +410,11 @@ def get_file(
                     "file hash does not match the provided value "
                     f"of {file_hash}."
                 )
+            os.replace(tmp_download_target, download_target)
+        except (Exception, KeyboardInterrupt):
+            if os.path.exists(tmp_download_target):
+                os.remove(tmp_download_target)
+            raise
 
     if extract or untar:
         if untar:

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -388,8 +388,19 @@ def get_file(
         # move it into place. Writing directly to `download_target` would
         # follow a pre-existing symlink at that path and could place the
         # downloaded file outside the cache directory.
-        fd, tmp_download_target = tempfile.mkstemp(dir=datadir)
+        tmp_prefix = f".tmp_{os.path.basename(fname)}_"
+        fd, tmp_download_target = tempfile.mkstemp(
+            dir=datadir, prefix=tmp_prefix
+        )
         os.close(fd)
+        # `mkstemp` creates the file with 0o600 permissions, but the previous
+        # `urlretrieve` wrote it through `open(..., "wb")`, which honors the
+        # umask (typically 0o644). Restore that so cached files stay readable
+        # by other users of a shared cache directory.
+        try:
+            os.chmod(tmp_download_target, 0o644)
+        except OSError:
+            pass
         try:
             try:
                 urlretrieve(origin, tmp_download_target, DLProgbar())

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -403,6 +403,31 @@ class GetFileTest(test_case.TestCase):
         path = file_utils.get_file("test.txt", origin, file_hash=hashval)
         self.assertTrue(os.path.exists(path))
 
+    def test_get_file_does_not_follow_symlink(self):
+        """A pre-planted symlink at the download path must not be followed."""
+        cache_dir = self.get_temp_dir()
+        datadir = os.path.join(cache_dir, "datasets")
+        os.makedirs(datadir, exist_ok=True)
+        download_target = os.path.join(datadir, "test.txt")
+        # An attacker plants a symlink pointing outside the cache directory.
+        outside = os.path.join(self.get_temp_dir(), "outside_target")
+        os.symlink(outside, download_target)
+
+        src_path = os.path.join(self.get_temp_dir(), "src.txt")
+        with open(src_path, "w") as text_file:
+            text_file.write("downloaded content")
+        origin = urllib.parse.urljoin(
+            "file://", urllib.request.pathname2url(os.path.abspath(src_path))
+        )
+
+        path = file_utils.get_file("test.txt", origin, cache_dir=cache_dir)
+
+        # The write must not have been redirected through the symlink.
+        self.assertFalse(os.path.exists(outside))
+        self.assertFalse(os.path.islink(path))
+        with open(path) as text_file:
+            self.assertEqual(text_file.read(), "downloaded content")
+
     def test_cache_invalidation(self):
         """Test using a hash to force cache invalidation."""
         cache_dir = self.get_temp_dir()

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -411,7 +411,11 @@ class GetFileTest(test_case.TestCase):
         download_target = os.path.join(datadir, "test.txt")
         # An attacker plants a symlink pointing outside the cache directory.
         outside = os.path.join(self.get_temp_dir(), "outside_target")
-        os.symlink(outside, download_target)
+        try:
+            os.symlink(outside, download_target)
+        except OSError:
+            # Symlink creation may require privileges (e.g. on Windows).
+            self.skipTest("Symlinks are not supported in this environment.")
 
         src_path = os.path.join(self.get_temp_dir(), "src.txt")
         with open(src_path, "w") as text_file:


### PR DESCRIPTION
## Description

`get_file` downloaded to the predictable path
`<cache>/<cache_subdir>/<fname>` by passing it directly to `urlretrieve`, which
opens the destination with `open(path, "wb")` and therefore **follows a symbolic
link** present at that path. If the cache directory is writable by another user —
for example the world-writable `/tmp/.keras` fallback that is used when
`~/.keras` is not writable, or a shared `KERAS_HOME` — an attacker can pre-create
a symlink at the (predictable) download path so that the downloaded bytes are
written **through** it to an arbitrary location outside the cache directory.
Pointing the symlink at e.g. a Python `*.pth` file or `~/.config/autostart` turns
this into code execution.

This downloads to a unique temporary file in the cache directory, validates the
hash, and then atomically `os.replace()`s it into place. `os.replace()` replaces
a symlink at the destination instead of writing through it, so a download can no
longer escape the cache directory. As a side benefit the hash is now checked
before the file is moved into place, so a corrupted download is never left in the
cache.

A regression test is added verifying that a pre-planted symlink at the download
path is not followed.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
