### PR TITLE
Fix: refuse vocabulary file paths when deserializing lookup layers in safe mode

### DIFF
--- a/keras/src/layers/preprocessing/index_lookup.py
+++ b/keras/src/layers/preprocessing/index_lookup.py
@@ -11,6 +11,31 @@ from keras.src.utils import tf_utils
 from keras.src.utils.module_utils import tensorflow as tf
 
 
+def raise_for_unsafe_vocabulary_load(vocabulary):
+    """Fail closed when a vocabulary file path is deserialized in safe mode.
+
+    A vocabulary supplied as a string is a file path loaded from outside the
+    model archive (``tf.io.gfile`` also resolves remote URIs such as ``gs://``).
+    When reconstructing a layer from a (potentially untrusted) config via
+    ``from_config``, only allow it if safe mode has been explicitly disabled;
+    fail closed when safe mode is unset, so that deserializing an untrusted
+    config cannot read arbitrary local files or reach remote URLs.
+    """
+    if isinstance(vocabulary, str) and (
+        serialization_lib.in_safe_mode() is not False
+    ):
+        raise ValueError(
+            "Requested the loading of a vocabulary file outside of the model "
+            "archive while deserializing a layer. This carries a potential "
+            "risk of loading arbitrary and sensitive files and thus it is "
+            "disallowed by default. If you trust the source of the artifact, "
+            "you can override this error by passing `safe_mode=False` to the "
+            "loading function, or calling "
+            "`keras.config.enable_unsafe_deserialization()`. "
+            f"Vocabulary file: '{vocabulary}'"
+        )
+
+
 class IndexLookup(Layer):
     """Maps values from a vocabulary to integer indices.
 
@@ -402,6 +427,11 @@ class IndexLookup(Layer):
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+    @classmethod
+    def from_config(cls, config):
+        raise_for_unsafe_vocabulary_load(config.get("vocabulary"))
+        return cls(**config)
 
     def _record_vocabulary_size(self):
         self._ensure_vocab_size_unchanged()

--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -60,6 +60,37 @@ class StringLookupTest(testing.TestCase):
             ["[MASK]", "[OOV]", "a", "b", "c"],
         )
 
+    def test_from_config_vocabulary_path_fails_closed(self):
+        from keras.src.saving.serialization_lib import SafeModeScope
+
+        temp_dir = self.get_temp_dir()
+        vocab_path = os.path.join(temp_dir, "vocab.txt")
+        with open(vocab_path, "w") as file:
+            file.write("a\nb\nc\n")
+
+        # Craft a config that points `vocabulary` at a file path.
+        config = layers.StringLookup(vocabulary=["x", "y"]).get_config()
+        config["vocabulary"] = vocab_path
+
+        # Deserializing a vocabulary file path outside a `SafeModeScope` must
+        # be refused by default.
+        with self.assertRaisesRegex(ValueError, "vocabulary file"):
+            layers.StringLookup.from_config(dict(config))
+
+        # Allowed when safe mode is explicitly disabled.
+        with SafeModeScope(safe_mode=False):
+            layer = layers.StringLookup.from_config(dict(config))
+        self.assertEqual(
+            [str(v) for v in layer.get_vocabulary()][-3:], ["a", "b", "c"]
+        )
+
+        # Direct construction with a path is not a deserialization and is
+        # unaffected.
+        layer = layers.StringLookup(vocabulary=vocab_path)
+        self.assertEqual(
+            [str(v) for v in layer.get_vocabulary()][-3:], ["a", "b", "c"]
+        )
+
     def test_adapt_flow(self):
         layer = layers.StringLookup(
             output_mode="int",

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -4,6 +4,9 @@ from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
 from keras.src.layers.preprocessing.index_lookup import listify_tensors
+from keras.src.layers.preprocessing.index_lookup import (
+    raise_for_unsafe_vocabulary_load,
+)
 from keras.src.layers.preprocessing.string_lookup import StringLookup
 from keras.src.saving import serialization_lib
 from keras.src.utils import argument_validation
@@ -496,6 +499,7 @@ class TextVectorization(Layer):
 
     @classmethod
     def from_config(cls, config):
+        raise_for_unsafe_vocabulary_load(config.get("vocabulary"))
         if not isinstance(config["standardize"], str):
             config["standardize"] = serialization_lib.deserialize_keras_object(
                 config["standardize"]


### PR DESCRIPTION
## Description

`IndexLookup` / `StringLookup` / `IntegerLookup` / `TextVectorization` accept a
`vocabulary` argument that may be a string **file path**. `set_vocabulary`
guards loading such a path with `if in_safe_mode():`, which does **not** fire
when the layer is deserialized outside of a `SafeModeScope` — e.g. a direct
`keras.Model.from_config(...)` / `Layer.from_config(...)` call — because
`in_safe_mode()` returns `None` there (falsy). As a result, deserializing an
untrusted config whose `vocabulary` is a file path reads an arbitrary local file
(and, via `tf.io.gfile`, a remote URI such as `gs://` / `http(s)://`) into the
layer's vocabulary, which is then recoverable via `get_vocabulary()`.

This adds a `from_config` that fails closed: a string `vocabulary` (file path)
is refused unless safe mode is explicitly disabled (`safe_mode=False`,
`SafeModeScope(False)`, or `keras.config.enable_unsafe_deserialization()`),
matching the fail-closed handling already used by `TFSMLayer.from_config`.

Behavior that is intentionally **unchanged**:

- Direct construction `StringLookup(vocabulary="vocab.txt")` (not a
  deserialization) still loads the file.
- `load_model` / `model_from_json` already establish a `SafeModeScope`, so the
  normal loading paths are unaffected.
- The normal round-trip of a list / asset vocabulary (the only forms
  `get_config` produces) is unaffected.

Adds a regression test.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
