### PR TITLE
🛡️ Sentinel: [HIGH] Fix hashlib.md5 FIPS compliance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-08 - Use usedforsecurity=False with MD5
+**Vulnerability:** Use of hashlib.md5() without usedforsecurity=False causes FIPS-compliance crashes and triggers security scanners.
+**Learning:** Python 3.9+ supports usedforsecurity=False for non-cryptographic hashes. Since Keras uses Python >= 3.11, this is safe to use everywhere.
+**Prevention:** Always add usedforsecurity=False when using MD5 or SHA1 for non-security purposes (like file integrity checking or hashing tricks) to avoid FIPS issues.

--- a/keras/src/legacy/preprocessing/text.py
+++ b/keras/src/legacy/preprocessing/text.py
@@ -66,7 +66,7 @@ def hashing_trick(
     elif hash_function == "md5":
 
         def hash_function(w):
-            return int(hashlib.md5(w.encode()).hexdigest(), 16)
+            return int(hashlib.md5(w.encode(), usedforsecurity=False).hexdigest(), 16)
 
     if analyzer is None:
         seq = text_to_word_sequence(

--- a/keras/src/legacy/preprocessing/text.py
+++ b/keras/src/legacy/preprocessing/text.py
@@ -66,7 +66,9 @@ def hashing_trick(
     elif hash_function == "md5":
 
         def hash_function(w):
-            return int(hashlib.md5(w.encode(), usedforsecurity=False).hexdigest(), 16)
+            return int(
+                hashlib.md5(w.encode(), usedforsecurity=False).hexdigest(), 16
+            )
 
     if analyzer is None:
         seq = text_to_word_sequence(

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -433,7 +433,7 @@ def resolve_hasher(algorithm, file_hash=None):
         return hashlib.sha256()
 
     # This is used only for legacy purposes.
-    return hashlib.md5()
+    return hashlib.md5(usedforsecurity=False)
 
 
 def hash_file(fpath, algorithm="sha256", chunk_size=65535):

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -706,12 +706,12 @@ class ResolveHasherTest(test_case.TestCase):
     def test_resolve_hasher_auto_md5(self):
         """Auto-detect and resolve hasher for md5."""
         hasher = file_utils.resolve_hasher("auto", file_hash="a" * 32)
-        self.assertIsInstance(hasher, type(hashlib.md5()))
+        self.assertIsInstance(hasher, type(hashlib.md5(usedforsecurity=False)))
 
     def test_resolve_hasher_default(self):
         """Resolve hasher with a random algorithm value."""
         hasher = file_utils.resolve_hasher("random_value")
-        self.assertIsInstance(hasher, type(hashlib.md5()))
+        self.assertIsInstance(hasher, type(hashlib.md5(usedforsecurity=False)))
 
 
 class IsRemotePathTest(test_case.TestCase):


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix hashlib.md5 FIPS compliance

🚨 Severity: HIGH
💡 Vulnerability: Use of `hashlib.md5()` without `usedforsecurity=False` triggers security scanners (CWE-327) and causes crashes in FIPS-compliant environments.
🎯 Impact: Code crashes when run on FIPS-enabled systems. Security scanners flag these instances as false positive cryptographic weaknesses.
🔧 Fix: Added `usedforsecurity=False` to all `hashlib.md5()` calls in `file_utils.py` and `text.py`, as well as corresponding unit tests, explicitly declaring them as non-cryptographic (e.g., legacy or hashing tricks).
✅ Verification: Ran `bandit` scanner to confirm the warnings are suppressed or mitigated, and executed `pytest` to ensure no functionality is broken.

---
*PR created automatically by Jules for task [18261281406571143252](https://jules.google.com/task/18261281406571143252) started by @rni418*