### PR TITLE
fix `LambdaCallback` docs

### DIFF
--- a/keras/src/callbacks/lambda_callback.py
+++ b/keras/src/callbacks/lambda_callback.py
@@ -4,7 +4,7 @@ from keras.src.callbacks.callback import Callback
 
 @keras_export("keras.callbacks.LambdaCallback")
 class LambdaCallback(Callback):
-    """Callback for creating simple, custom callbacks on-the-fly.
+    r"""Callback for creating simple, custom callbacks on-the-fly.
 
     This callback is constructed with anonymous functions that will be called
     at the appropriate time (during `Model.{fit | evaluate | predict}`).


### PR DESCRIPTION
## Description
unescaped `\n` in `LambdaCallback` docstring at L47 is causing bad formatting, see https://keras.io/api/callbacks/lambda_callback/
https://github.com/keras-team/keras/blob/f0d77d56b366d5c45511995dce4159385d2fc383/keras/src/callbacks/lambda_callback.py#L47

=> fix it by turning docstring into a raw string

---

before:
<img width="1478" height="989" alt="before" src="https://github.com/user-attachments/assets/a358ab17-1696-4f56-a5e7-473f58c5aa15" />

after:
<img width="1480" height="991" alt="after" src="https://github.com/user-attachments/assets/0947a720-ca8a-4706-82ec-d12294db1cbc" />


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
