### PR TITLE
[Bug-Fix] Sparse TensorFlow wrapper drops trailing all-zero rows

### DIFF
--- a/keras/src/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter_test.py
@@ -2,6 +2,7 @@ import jax
 import jax.experimental.sparse as jax_sparse
 import numpy as np
 import pandas
+import pytest
 import scipy
 import tensorflow as tf
 import torch
@@ -137,6 +138,33 @@ class TestArrayDataAdapter(testing.TestCase):
             self.assertNotAllClose(x_order, list(range(34)))
         else:
             self.assertAllClose(x_order, list(range(34)))
+
+    @pytest.mark.skipif(backend.backend() != "tensorflow", reason="tf only")
+    def test_tf_sparse_trailing_empty_rows(self):
+        x = tf.SparseTensor(
+            indices=[[0, 0], [1, 2]],
+            values=[1.0, 2.0],
+            dense_shape=(4, 3),
+        )
+
+        adapter = array_data_adapter.ArrayDataAdapter(
+            x,
+            batch_size=4,
+            shuffle=False,
+        )
+        batch = next(iter(adapter.get_tf_dataset()))
+
+        self.assertIsInstance(batch, tf.SparseTensor)
+        self.assertEqual(batch.shape, (4, 3))
+        self.assertAllClose(
+            tf.sparse.to_dense(batch),
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 2.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+            ],
+        )
 
     def test_multi_inputs_and_outputs(self):
         x1 = np.random.random((34, 1))

--- a/keras/src/trainers/data_adapters/array_slicing.py
+++ b/keras/src/trainers/data_adapters/array_slicing.py
@@ -295,7 +295,7 @@ def to_tensorflow_sparse_wrapper(sparse):
 
     row_ids = sparse.indices[:, 0]
     row_splits = tf.experimental.RowPartition.from_value_rowids(
-        row_ids
+        row_ids, nrows=sparse.dense_shape[0]
     ).row_splits()
 
     ragged_indices = tf.cast(


### PR DESCRIPTION
## Description
Fixes: #23059 
Did a simple fix so ```RowPartition.from_value_rowids()``` now gets ```nrows=sparse.dense_shape[0]``` so it preserves trailing all-zero rows in the ragged sparse wrapper.
Also added a regression test, same as the repro script in issue that was failing.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
