### PR TITLE
[Bug-fix] Audio padded batching assumes scalar labels

### DIFF
--- a/keras/src/utils/audio_dataset_utils.py
+++ b/keras/src/utils/audio_dataset_utils.py
@@ -264,9 +264,7 @@ def prepare_dataset(
     dataset = dataset.prefetch(tf.data.AUTOTUNE)
     if batch_size is not None:
         if output_sequence_length is None and not ragged:
-            dataset = dataset.padded_batch(
-                batch_size, padded_shapes=([None, None], [])
-            )
+            dataset = dataset.padded_batch(batch_size)
         else:
             dataset = dataset.batch(batch_size)
 

--- a/keras/src/utils/audio_dataset_utils_test.py
+++ b/keras/src/utils/audio_dataset_utils_test.py
@@ -289,6 +289,50 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
         for seq_len in sequence_lengths:
             self.assertIn(seq_len, possible_sequence_lengths)
 
+    def test_audio_dataset_from_directory_variable_length_label_modes(self):
+        directory = self._prepare_directory(
+            num_classes=2, count=16, different_sequence_lengths=True
+        )
+
+        dataset = audio_dataset_utils.audio_dataset_from_directory(
+            directory,
+            batch_size=8,
+            label_mode=None,
+            shuffle=False,
+        )
+        batch = next(iter(dataset))
+        self.assertEqual(batch.shape.rank, 3)
+        self.assertEqual(batch.shape[0], 8)
+        self.assertEqual(batch.shape[-1], 1)
+
+        dataset = audio_dataset_utils.audio_dataset_from_directory(
+            directory,
+            batch_size=8,
+            label_mode="binary",
+            shuffle=False,
+        )
+        batch = next(iter(dataset))
+        self.assertLen(batch, 2)
+        self.assertEqual(batch[0].shape.rank, 3)
+        self.assertEqual(batch[0].shape[0], 8)
+        self.assertEqual(batch[0].shape[-1], 1)
+        self.assertEqual(batch[1].shape, (8, 1))
+        self.assertEqual(batch[1].dtype.name, "float32")
+
+        dataset = audio_dataset_utils.audio_dataset_from_directory(
+            directory,
+            batch_size=8,
+            label_mode="categorical",
+            shuffle=False,
+        )
+        batch = next(iter(dataset))
+        self.assertLen(batch, 2)
+        self.assertEqual(batch[0].shape.rank, 3)
+        self.assertEqual(batch[0].shape[0], 8)
+        self.assertEqual(batch[0].shape[-1], 1)
+        self.assertEqual(batch[1].shape, (8, 2))
+        self.assertEqual(batch[1].dtype.name, "float32")
+
     def test_audio_dataset_from_directory_no_output_sequence_length_same_lengths(  # noqa: E501
         self,
     ):


### PR DESCRIPTION
## Description
Fixes: #23061 
Did a simple one line fix in audio_dataset_utils.py so variable length audio batching uses:
```python
dataset = dataset.padded_batch(batch_size)
```
so TensorFlow derives the right padded structure for unlabeled audio, scalar int labels, binary (1,) labels, and categorical (num_classes,) labels.
Also added a regression test, same as the repro script in the original issue.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
