### PR TITLE
[Bug-Fix] Torch divide_no_nan() produces NaN gradients

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2135,11 +2135,15 @@ def divide(x1, x2):
 
 
 def divide_no_nan(x1, x2):
-    if not isinstance(x1, (int, float)):
-        x1 = convert_to_tensor(x1)
-    if not isinstance(x2, (int, float)):
-        x2 = convert_to_tensor(x2)
-    return torch.where(x2 == 0, 0, torch.divide(x1, x2))
+    dtype = dtypes.result_type(
+        getattr(x1, "dtype", type(x1)),
+        getattr(x2, "dtype", type(x2)),
+        float,
+    )
+    x1 = convert_to_tensor(x1, dtype)
+    x2 = convert_to_tensor(x2, dtype)
+    safe_x2 = torch.where(x2 == 0, torch.ones_like(x2), x2)
+    return torch.where(x2 == 0, 0, torch.divide(x1, safe_x2))
 
 
 def true_divide(x1, x2):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3526,6 +3526,45 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.divide_no_nan(x, y), expected_result)
         self.assertAllClose(knp.DivideNoNan()(x, y), expected_result)
 
+    @pytest.mark.skipif(
+        backend.backend() not in ("tensorflow", "jax", "torch"),
+        reason=f"{backend.backend()} backend does not support gradients.",
+    )
+    def test_divide_no_nan_gradients(self):
+        expected_x1_grad = np.array([0.0, 0.5], dtype="float32")
+        expected_x2_grad = np.array([0.0, -0.5], dtype="float32")
+
+        if backend.backend() == "tensorflow":
+            import tensorflow as tf
+
+            x1 = tf.Variable([1.0, 2.0])
+            x2 = tf.Variable([0.0, 2.0])
+            with tf.GradientTape() as tape:
+                y = knp.divide_no_nan(x1, x2)
+                loss = tf.reduce_sum(y)
+            x1_grad, x2_grad = tape.gradient(loss, [x1, x2])
+        elif backend.backend() == "jax":
+            import jax
+            import jax.numpy as jnp
+
+            def f(x1, x2):
+                return jnp.sum(knp.divide_no_nan(x1, x2))
+
+            x1 = jnp.array([1.0, 2.0])
+            x2 = jnp.array([0.0, 2.0])
+            x1_grad, x2_grad = jax.grad(f, argnums=(0, 1))(x1, x2)
+        elif backend.backend() == "torch":
+            import torch
+
+            x1 = torch.tensor([1.0, 2.0], requires_grad=True)
+            x2 = torch.tensor([0.0, 2.0], requires_grad=True)
+            y = knp.divide_no_nan(x1, x2)
+            y.sum().backward()
+            x1_grad, x2_grad = x1.grad, x2.grad
+
+        self.assertAllClose(ops.convert_to_numpy(x1_grad), expected_x1_grad)
+        self.assertAllClose(ops.convert_to_numpy(x2_grad), expected_x2_grad)
+
     def test_true_divide(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         y = np.array([[4, 5, 6], [3, 2, 1]])


### PR DESCRIPTION
## Description
Fixes: #23063 
Changed keras/src/backend/torch/numpy.py (line 2137) so ```divide_no_nan``` now:
- promotes inputs to the correct result dtype
- converts scalar inputs to tensors
- replaces zero denominators with 1 before division
- still masks output to 0 where denominator is zero
Also added a regression test
## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
