### PR TITLE
Replace `np.prod` and `np.sum` with `math.prod` and `sum`...

### DIFF
--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -1,3 +1,5 @@
+import math
+
 import jax
 import numpy as np
 from jax import lax
@@ -327,7 +329,7 @@ def average_pool(
     pooled = _pool(inputs, 0.0, lax.add, pool_size, strides, padding)
     if padding == "valid":
         # Avoid the extra reduce_window.
-        return pooled / np.prod(pool_size)
+        return pooled / math.prod(pool_size)
     else:
         # Count the number of valid entries at each input point, then use that
         # for computing average. Assumes that any two arrays of same shape will

--- a/keras/src/backend/numpy/random.py
+++ b/keras/src/backend/numpy/random.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 
 from keras.src.backend.config import floatx
@@ -48,7 +50,7 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     lower_bound = mean - 2 * stddev
     upper_bound = mean + 2 * stddev
 
-    flat_shape = np.prod(shape)
+    flat_shape = math.prod(shape)
     random_numbers = np.empty(0)
 
     # loop until we have enough valid numbers to fill our desired shape

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import openvino as ov
 import openvino.opset16 as ov_opset
@@ -5038,7 +5040,7 @@ def unravel_index(indices, shape):
         shape = list(shape)
 
     # Handle negative indices
-    total_size = np.prod(shape)
+    total_size = math.prod(shape)
     total_size_const = ov_opset.constant(total_size, indices_dtype).output(0)
 
     zero = ov_opset.constant(0, indices_dtype).output(0)

--- a/keras/src/backend/openvino/random.py
+++ b/keras/src/backend/openvino/random.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import openvino.opset16 as ov_opset
 from openvino import Type
@@ -191,7 +193,7 @@ def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
     lower_bound = mean - 2 * stddev
     upper_bound = mean + 2 * stddev
 
-    flat_shape = np.prod(shape)
+    flat_shape = math.prod(shape)
     random_numbers = np.empty(0)
 
     # loop until we have enough valid numbers to fill our desired shape

--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -2,6 +2,7 @@
 
 import collections
 import contextlib
+import math
 import os
 import re
 import warnings
@@ -193,7 +194,7 @@ class DeviceMesh:
         if devices is None:
             devices = list_devices()
         devices = np.array(devices)
-        if np.prod(shape) != np.prod(devices.shape):
+        if math.prod(shape) != math.prod(devices.shape):
             raise ValueError(
                 "Shape does not match the number of devices. "
                 f"Received: shape={shape}; devices.shape="

--- a/keras/src/export/tf2onnx_lib.py
+++ b/keras/src/export/tf2onnx_lib.py
@@ -1,6 +1,7 @@
 import copy
 import functools
 import logging
+import math
 import traceback
 
 import numpy as np
@@ -148,14 +149,8 @@ def patch_tf2onnx():
         if external_tensor_storage is None or a.type != AttributeProto.TENSOR:
             return a
 
-        def prod(x):
-            if hasattr(np, "product"):
-                return np.product(x)
-            else:
-                return np.prod(x)
-
         if (
-            prod(a.t.dims)
+            math.prod(a.t.dims)
             > external_tensor_storage.external_tensor_size_threshold
         ):
             a = copy.deepcopy(a)

--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -1,3 +1,4 @@
+import math
 import os
 
 import numpy as np
@@ -744,7 +745,7 @@ class ConvBasicTest(testing.TestCase):
 
         # Set the base kernel to known, deterministic values.
         base_kernel = np.linspace(
-            0, 1, num=np.prod(layer.kernel.shape), dtype=np.float32
+            0, 1, num=math.prod(layer.kernel.shape), dtype=np.float32
         )
         base_kernel = base_kernel.reshape(layer.kernel.shape)
         layer.kernel.assign(base_kernel)

--- a/keras/src/legacy/backend.py
+++ b/keras/src/legacy/backend.py
@@ -1,6 +1,7 @@
 """Legacy Keras 1/2 backend functions."""
 
 import itertools
+import math
 
 import numpy as np
 
@@ -634,7 +635,7 @@ def cos(x):
 @keras_export("keras._legacy.backend.count_params")
 def count_params(x):
     """DEPRECATED."""
-    return np.prod(x.shape.as_list())
+    return math.prod(x.shape.as_list())
 
 
 @keras_export("keras._legacy.backend.ctc_batch_cost")

--- a/keras/src/legacy/preprocessing/image.py
+++ b/keras/src/legacy/preprocessing/image.py
@@ -1,6 +1,7 @@
 """Deprecated image preprocessing APIs from Keras 1."""
 
 import collections
+import math
 import multiprocessing
 import os
 import threading
@@ -1277,7 +1278,7 @@ class ImageDataGenerator:
                 )
         if self.zca_whitening:
             if self.zca_whitening_matrix is not None:
-                flat_x = x.reshape(-1, np.prod(x.shape[-3:]))
+                flat_x = x.reshape(-1, math.prod(x.shape[-3:]))
                 white_x = flat_x @ self.zca_whitening_matrix
                 x = np.reshape(white_x, x.shape)
             else:

--- a/keras/src/metrics/metrics_utils.py
+++ b/keras/src/metrics/metrics_utils.py
@@ -1,3 +1,4 @@
+import math
 from enum import Enum
 
 import numpy as np
@@ -508,7 +509,7 @@ def update_confusion_matrix_variables(
         if len(y_pred.shape) == 1:
             num_labels = 1
         else:
-            num_labels = np.prod(pred_shape[1:], axis=0).astype("int32")
+            num_labels = math.prod(pred_shape[1:])
         thresh_label_tile = np.where(one_thresh, num_labels, 1)
 
     # Reshape predictions and labels, adding a dim for thresholding.

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1,4 +1,5 @@
 import builtins
+import math as python_math
 import re
 
 import numpy as np
@@ -630,9 +631,11 @@ class Append(Operation):
         )
         if self.axis is None:
             if None in x1_shape or None in x2_shape:
-                output_shape = [None]
+                output_shape = (None,)
             else:
-                output_shape = [int(np.prod(x1_shape) + np.prod(x2_shape))]
+                output_shape = (
+                    python_math.prod(x1_shape) + python_math.prod(x2_shape),
+                )
             return KerasTensor(output_shape, dtype=dtype)
 
         if not shape_equal(x1_shape, x2_shape, [self.axis]):
@@ -1141,7 +1144,9 @@ class Argsort(Operation):
 
     def compute_output_spec(self, x):
         if self.axis is None:
-            return KerasTensor([int(np.prod(x.shape))], dtype="int32")
+            if None in x.shape:
+                return KerasTensor((None,), dtype="int32")
+            return KerasTensor((python_math.prod(x.shape),), dtype="int32")
         canonicalize_axis(self.axis, len(x.shape))
         return KerasTensor(x.shape, dtype="int32")
 
@@ -2401,7 +2406,7 @@ class Cumprod(Operation):
             if None in x.shape:
                 output_shape = (None,)
             else:
-                output_shape = (int(np.prod(x.shape)),)
+                output_shape = (python_math.prod(x.shape),)
         else:
             canonicalize_axis(self.axis, len(x.shape))
             output_shape = x.shape
@@ -2448,7 +2453,7 @@ class Cumsum(Operation):
             if None in x.shape:
                 output_shape = (None,)
             else:
-                output_shape = (int(np.prod(x.shape)),)
+                output_shape = (python_math.prod(x.shape),)
         else:
             canonicalize_axis(self.axis, len(x.shape))
             output_shape = x.shape
@@ -5299,7 +5304,7 @@ class Meshgrid(Operation):
                 if None in xi.shape:
                     size = None
                 else:
-                    size = int(np.prod(xi.shape))
+                    size = python_math.prod(xi.shape)
             output_shape.append(size)
         if self.indexing == "ij":
             return [KerasTensor(output_shape) for _ in range(len(x))]
@@ -5744,7 +5749,7 @@ class Nancumsum(Operation):
             if None in x.shape:
                 output_shape = (None,)
             else:
-                output_shape = (int(np.prod(x.shape)),)
+                output_shape = (python_math.prod(x.shape),)
         else:
             output_shape = x.shape
 
@@ -5805,7 +5810,7 @@ class Nancumprod(Operation):
             if None in x.shape:
                 output_shape = (None,)
             else:
-                output_shape = (int(np.prod(x.shape)),)
+                output_shape = (python_math.prod(x.shape),)
         else:
             output_shape = x.shape
 
@@ -6683,12 +6688,12 @@ class Outer(Operation):
         if None in x1_shape:
             x1_flatten_shape = None
         else:
-            x1_flatten_shape = int(np.prod(x1_shape))
+            x1_flatten_shape = python_math.prod(x1_shape)
         if None in x2_shape:
             x2_flatten_shape = None
         else:
-            x2_flatten_shape = int(np.prod(x2_shape))
-        output_shape = [x1_flatten_shape, x2_flatten_shape]
+            x2_flatten_shape = python_math.prod(x2_shape)
+        output_shape = (x1_flatten_shape, x2_flatten_shape)
         output_dtype = backend.result_type(
             getattr(x1, "dtype", type(x1)),
             getattr(x2, "dtype", type(x2)),
@@ -7104,11 +7109,9 @@ class Ravel(Operation):
 
     def compute_output_spec(self, x):
         if None in x.shape:
-            output_shape = [
-                None,
-            ]
+            output_shape = (None,)
         else:
-            output_shape = [int(np.prod(x.shape))]
+            output_shape = (python_math.prod(x.shape),)
         return KerasTensor(output_shape, dtype=x.dtype)
 
 
@@ -7255,9 +7258,9 @@ class Repeat(Operation):
             if None in x_shape:
                 return KerasTensor([None], dtype=x.dtype)
 
-            x_flatten_size = int(np.prod(x_shape))
+            x_flatten_size = python_math.prod(x_shape)
             if broadcast:
-                output_shape = [x_flatten_size * repeats[0]]
+                output_shape = (x_flatten_size * repeats[0],)
             elif repeats_size != x_flatten_size:
                 raise ValueError(
                     "Size of `repeats` and "
@@ -7265,7 +7268,7 @@ class Repeat(Operation):
                     f"Received: {repeats_size} and {x_flatten_size}"
                 )
             else:
-                output_shape = [int(np.sum(repeats))]
+                output_shape = (builtins.sum(repeats),)
             return KerasTensor(output_shape, dtype=x.dtype)
 
         size_on_ax = x_shape[self.axis]
@@ -7282,7 +7285,7 @@ class Repeat(Operation):
                 f"Received: {repeats_size} and {x_shape}"
             )
         else:
-            output_shape[self.axis] = int(np.sum(repeats))
+            output_shape[self.axis] = builtins.sum(repeats)
         return KerasTensor(output_shape, dtype=x.dtype)
 
 
@@ -7644,7 +7647,7 @@ class Sort(Operation):
             if None in x.shape:
                 output_shape = (None,)
             else:
-                output_shape = (int(np.prod(x.shape)),)
+                output_shape = (python_math.prod(x.shape),)
             return KerasTensor(output_shape, x.dtype)
         canonicalize_axis(self.axis, len(x.shape))
         return KerasTensor(x.shape, x.dtype)

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -423,7 +423,7 @@ def compute_take_along_axis_output_shape(input_shape, indices_shape, axis):
     indices_shape = list(indices_shape)
     if axis is None:
         input_shape = (
-            [None] if None in input_shape else [int(np.prod(input_shape))]
+            [None] if None in input_shape else [math.prod(input_shape)]
         )
 
     if len(input_shape) != len(indices_shape):

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -1,5 +1,6 @@
 import collections
 import json
+import math
 import os.path
 import pprint
 import zipfile
@@ -556,7 +557,7 @@ class KerasFileEditor:
                 )
 
             # Safe product computation (Python int is unbounded)
-            num_elems = int(np.prod(shape))
+            num_elems = math.prod(shape)
 
             # ------------------------------------------------------
             # Validate TOTAL memory size


### PR DESCRIPTION
 when handling shapes.

- `np.prod` and `np.sum` are subject to overflows, `math.prod` and `sum` are not
- `math.prod` and `sum` will support custom objects, in particular symbolic dimensions, whereas `np.prod` and `np.sum` require numbers

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
