### PR TITLE
Add rsqrt dtype tests and fix dtype mismatches in the NumPy backend

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -282,6 +282,7 @@ def istft(
 
 
 def rsqrt(x):
+    x = convert_to_tensor(x)
     return jax.lax.rsqrt(x)
 
 

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -304,7 +304,8 @@ def istft(
 
 
 def rsqrt(x):
-    return 1.0 / np.sqrt(x)
+    dtype = dtypes.result_type(x.dtype)
+    return (1.0 / np.sqrt(x)).astype(dtype)
 
 
 def erf(x):

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -288,6 +288,7 @@ def istft(
 
 
 def rsqrt(x):
+    x = convert_to_tensor(x)
     return tf.math.rsqrt(x)
 
 

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -1124,7 +1124,6 @@ def rsqrt(x):
     """
     if any_symbolic_tensors((x,)):
         return Rsqrt().symbolic_call(x)
-    x = backend.convert_to_tensor(x)
     return backend.math.rsqrt(x)
 
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1145,6 +1145,24 @@ class MathDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_rsqrt(self, dtype):
+        import jax.lax as lax
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+
+        expected_dtype = standardize_dtype(lax.rsqrt(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(kmath.rsqrt(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(kmath.Rsqrt().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
 
 class ExtractSequencesOpTest(testing.TestCase):
     def test_extract_sequences_init_length_1_stride_1(self):


### PR DESCRIPTION
## Description
- Add dtype tests for rsqrt
- Fix dtype mismatches in the NumPy backend to ensure consistent rsqrt behavior across backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
