### PR TITLE
[Bug-Fix] Audio resampling truncates before resampling

### DIFF
--- a/keras/src/utils/audio_dataset_utils.py
+++ b/keras/src/utils/audio_dataset_utils.py
@@ -76,7 +76,8 @@ def audio_dataset_from_directory(
             (the dataset will yield individual samples).
         sampling_rate: Audio sampling rate (in samples per second).
         output_sequence_length: Maximum length of an audio sequence. Audio files
-            longer than this will be truncated to `output_sequence_length`.
+            longer than this will be truncated to `output_sequence_length`,
+            after resampling if `sampling_rate` is set.
             If set to `None`, then all sequences in the same batch will
             be padded to the
             length of the longest sequence in the batch.
@@ -379,11 +380,13 @@ def read_and_decode_audio(
     """Reads and decodes audio file."""
     audio = tf.io.read_file(path)
 
-    if output_sequence_length is None:
-        output_sequence_length = -1
+    if output_sequence_length is not None and sampling_rate is None:
+        desired_samples = output_sequence_length
+    else:
+        desired_samples = -1
 
     audio, default_audio_rate = tf.audio.decode_wav(
-        contents=audio, desired_samples=output_sequence_length
+        contents=audio, desired_samples=desired_samples
     )
     if sampling_rate is not None:
         # default_audio_rate should have dtype=int64
@@ -391,6 +394,16 @@ def read_and_decode_audio(
         audio = tfio.audio.resample(
             input=audio, rate_in=default_audio_rate, rate_out=sampling_rate
         )
+        if output_sequence_length is not None:
+            audio = _trim_and_pad_audio(audio, output_sequence_length)
+    return audio
+
+
+def _trim_and_pad_audio(audio, output_sequence_length):
+    audio = audio[:output_sequence_length]
+    padding = output_sequence_length - tf.shape(audio)[0]
+    audio = tf.pad(audio, [[0, padding], [0, 0]])
+    audio.set_shape((output_sequence_length, None))
     return audio
 
 

--- a/keras/src/utils/audio_dataset_utils_test.py
+++ b/keras/src/utils/audio_dataset_utils_test.py
@@ -351,6 +351,51 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
         sequence_lengths = list(set([batch[0].shape[1] for batch in dataset]))
         self.assertEqual(len(sequence_lengths), 1)
 
+    def test_output_sequence_length_applied_after_resampling(self):
+        class FakeAudio:
+            @staticmethod
+            def resample(input, rate_in, rate_out):
+                output_length = tf.cast(
+                    tf.math.round(
+                        tf.cast(tf.shape(input)[0], "float32")
+                        * tf.cast(rate_out, "float32")
+                        / tf.cast(rate_in, "float32")
+                    ),
+                    "int32",
+                )
+                output_shape = tf.stack([output_length, tf.shape(input)[1]])
+                return tf.zeros(output_shape, dtype=input.dtype)
+
+        class FakeTensorflowIO:
+            audio = FakeAudio
+
+        original_tfio = audio_dataset_utils.tfio
+        audio_dataset_utils.tfio = FakeTensorflowIO()
+        try:
+            source_sampling_rate = 48000
+            target_sampling_rate = 16000
+            output_sequence_length = 16000
+            directory = self.get_temp_dir()
+            filename = os.path.join(directory, "audio.wav")
+            audio = np.random.random((source_sampling_rate, 1))
+            encoded_audio = tf.audio.encode_wav(audio, source_sampling_rate)
+            with open(filename, "wb") as f:
+                f.write(encoded_audio.numpy())
+
+            @tf.function
+            def read_audio(path):
+                return audio_dataset_utils.read_and_decode_audio(
+                    path,
+                    sampling_rate=target_sampling_rate,
+                    output_sequence_length=output_sequence_length,
+                )
+
+            sample = read_audio(tf.constant(filename))
+
+            self.assertEqual(sample.shape, (output_sequence_length, 1))
+        finally:
+            audio_dataset_utils.tfio = original_tfio
+
     def test_audio_dataset_from_directory_errors(self):
         directory = self._prepare_directory(num_classes=3, count=5)
 


### PR DESCRIPTION
## Description
Fixes: #23068 
When sampling_rate is set, WAV decode no longer truncates with desired_samples=output_sequence_length before resampling.
After resampling `_trim_and_pad_audio()` applies output_sequence_length to the returned audio. Updated the doc to account for this fix too and also added a regression test similar to the repro.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
