### PR TITLE
[Bug-Fix] Empty Python generator passed to model.fit raises raw IndexError

### DIFF
--- a/keras/src/trainers/data_adapters/generator_data_adapter.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter.py
@@ -13,6 +13,12 @@ class GeneratorDataAdapter(DataAdapter):
         self.generator = generator
         self._first_batches = first_batches
         self._output_signature = None
+        if not first_batches:
+            raise ValueError(
+                "When passing a py generator to a Keras model, "
+                "the generator must yield at least one batch. "
+                "Received an empty generator."
+            )
         if not isinstance(first_batches[0], tuple):
             raise ValueError(
                 "When passing a Python generator to a Keras model, "

--- a/keras/src/trainers/data_adapters/generator_data_adapter.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter.py
@@ -15,7 +15,7 @@ class GeneratorDataAdapter(DataAdapter):
         self._output_signature = None
         if not first_batches:
             raise ValueError(
-                "When passing a py generator to a Keras model, "
+                "When passing a Python generator to a Keras model, "
                 "the generator must yield at least one batch. "
                 "Received an empty generator."
             )

--- a/keras/src/trainers/data_adapters/generator_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/generator_data_adapter_test.py
@@ -104,6 +104,17 @@ class GeneratorDataAdapterTest(testing.TestCase):
                 sample_order.append(backend.convert_to_numpy(by[j, 0]))
         self.assertAllClose(sample_order, list(range(34)))
 
+    def test_empty_generator_raises_clear_error(self):
+        def generator():
+            if False:
+                yield
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "the generator must yield at least one batch",
+        ):
+            generator_data_adapter.GeneratorDataAdapter(generator())
+
     def test_with_different_shapes(self):
         def generator():
             yield np.ones([16, 4], "float32"), np.ones([16, 2], "float32")


### PR DESCRIPTION
## Description
Fixes: #23072 
Updated `generator_data_adapter.py` to check not `first_batches` before indexing and raising a clear ValueError for empty generators. Also added a regression test.
## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
