### PR TITLE
Fix `cholesky` and `pinv` implementations in NumPy backend

### DIFF
--- a/keras/src/backend/numpy/linalg.py
+++ b/keras/src/backend/numpy/linalg.py
@@ -7,7 +7,10 @@ from keras.src.backend.numpy.core import convert_to_tensor
 
 
 def cholesky(a, upper=False):
-    return np.linalg.cholesky(a, upper=upper)
+    out = np.linalg.cholesky(a)
+    if upper:
+        return np.swapaxes(out, -1, -2).conj()
+    return out
 
 
 def cholesky_inverse(a, upper=False):
@@ -110,6 +113,8 @@ def matrix_rank(x, tol=None):
 
 def pinv(x, rcond=None):
     x = convert_to_tensor(x)
+    if rcond is None:
+        rcond = 1e-15
     return np.linalg.pinv(x, rcond=rcond)
 
 


### PR DESCRIPTION
## Description

This PR fixes two bugs in the `numpy` backend's linear algebra (`linalg.py`) operations, resolving failures in `keras/src/ops/linalg_test.py::LinalgOpsCorrectnessTest`.

## 0. Fix `cholesky` decomposition with `upper=True`
**Issue:** `np.linalg.cholesky` does not accept an `upper` keyword argument. Previously, calling `backend.numpy.linalg.cholesky(A, upper=True)` resulted in a `TypeError: cholesky() got an unexpected keyword argument 'upper'`.
**Fix:** The `cholesky` function now unconditionally calls `np.linalg.cholesky(a)`, which returns the lower triangular matrix by default. If `upper=True` is requested, it explicitly computes the upper triangular matrix by swapping the last two axes (transposing the matrix) and applying the complex conjugate (`.conj()`), successfully matching the required API behavior.

## 1. Fix `pinv` handling of `rcond=None`
**Issue:** `np.linalg.pinv` handles the `rcond` (cutoff for small singular values) argument differently than the Keras specification requires. When `rcond=None` is passed, `np.linalg.pinv` defaults to `1e-15`, but an explicit `None` argument could lead to a `TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'` during the underlying SVD calculation depending on NumPy versioning.
**Fix:** The `pinv` function now explicitly checks for `rcond is None` and safely defaults it to `1e-15` before forwarding the value to `np.linalg.pinv`, effectively aligning the backend logic with the expected numerical behavior.

These changes allow tests such as `test_cholesky_inverse_upper`, `test_pinv_batched`, `test_pinv_square_default_rcond`, `test_pinv_tall_default_rcond`, and `test_pinv_wide_default_rcond` to pass successfully.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
