### PR TITLE
On TF, don't request counts in `unique` unless needed.

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3893,32 +3893,34 @@ def unique(
 
     if is_flatten:
         x = tf.reshape(x, [-1])
-        dim = 0
-        y, inverse, counts = tf.unique_with_counts(x)
+        axis = 0
+        if return_counts:
+            y, inverse, counts = tf.unique_with_counts(x)
+        else:
+            y, inverse = tf.unique(x)
 
     else:
-        ndim = x.shape.rank
-        dim = axis + ndim if axis < 0 else axis
-        axis_to_use = tf.constant([dim], dtype=tf.int32)
-        y, inverse, counts = tf.raw_ops.UniqueWithCountsV2(
-            x=x, axis=axis_to_use, out_idx=tf.int32
-        )
+        axis = canonicalize_axis(axis, x.shape.rank)
+        if return_counts:
+            y, inverse, counts = tf.raw_ops.UniqueWithCountsV2(x=x, axis=[axis])
+        else:
+            y, inverse = tf.raw_ops.UniqueV2(x=x, axis=[axis])
 
     if return_index:
-        num_unique = tf.shape(y)[dim]
-        dim_size = tf.shape(x)[0] if is_flatten else original_shape[dim]
+        num_unique = tf.shape(y)[axis]
+        axis_dim = tf.shape(x)[0] if is_flatten else original_shape[axis]
         unique_indices = tf.math.unsorted_segment_min(
-            tf.range(dim_size, dtype=tf.int32), inverse, num_unique
+            tf.range(axis_dim, dtype=tf.int32), inverse, num_unique
         )
 
     if sorted:
-        num_unique = tf.shape(y)[dim]
+        num_unique = tf.shape(y)[axis]
         if is_flatten or y.shape.rank == 1:
             sort_order = tf.argsort(y)
         else:
             # Multi-D lexicographical sort
             perm = list(range(y.shape.rank))
-            perm[0], perm[dim] = perm[dim], perm[0]
+            perm[0], perm[axis] = perm[axis], perm[0]
             y_transposed = tf.transpose(y, perm)
             y_2d = tf.reshape(y_transposed, [num_unique, -1])
             num_cols = tf.shape(y_2d)[1]
@@ -3937,7 +3939,7 @@ def unique(
                 cond, body, [num_cols - 1, sort_order], parallel_iterations=1
             )
 
-        y = tf.gather(y, sort_order, axis=dim)
+        y = tf.gather(y, sort_order, axis=axis)
         if return_index:
             unique_indices = tf.gather(unique_indices, sort_order)
         if return_counts:
@@ -3949,11 +3951,11 @@ def unique(
 
     # Static size padding/truncation (branchless logic for graph mode safety)
     if size is not None:
-        values_count = tf.shape(y)[dim]
+        values_count = tf.shape(y)[axis]
 
         # 1. Truncate using gather
         truncate_size = tf.minimum(values_count, size)
-        y = tf.gather(y, tf.range(truncate_size), axis=dim)
+        y = tf.gather(y, tf.range(truncate_size), axis=axis)
         if return_index:
             unique_indices = tf.gather(unique_indices, tf.range(truncate_size))
         if return_counts:
@@ -3963,7 +3965,7 @@ def unique(
         pad_amount = tf.maximum(0, size - values_count)
         paddings = tf.zeros([tf.rank(y), 2], dtype=tf.int32)
         paddings = tf.tensor_scatter_nd_update(
-            paddings, [[dim, 1]], [pad_amount]
+            paddings, [[axis, 1]], [pad_amount]
         )
 
         fill = tf.cast(0 if fill_value is None else fill_value, y.dtype)
@@ -3980,7 +3982,7 @@ def unique(
         # 3. Enforce static shape for XLA compatibility
         if isinstance(size, int):
             static_shape = y.shape.as_list()
-            static_shape[dim] = size
+            static_shape[axis] = size
             y.set_shape(static_shape)
             if return_index:
                 unique_indices.set_shape([size])


### PR DESCRIPTION
With the TensorFlow backend, `unique` currently always computes counts even when not needed. This may have a performance impact.

Also, `tf.unique` is compilable on TPU vs. `tf.unique_with_counts` is not.

Additionally modify `axis` in place and rename `dim_size` to `axis_dim` for readability and consistency with the other ops.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
