### PR TITLE
Support native Grouped-Query Attention (GQA) Key/Value head broadcast.

### DIFF
--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -1754,6 +1754,19 @@ def dot_product_attention(
     query = cast(query, compute_dtype)
     key = cast(key, compute_dtype)
     value = cast(value, compute_dtype)
+
+    num_query_heads = query.shape[2]
+    num_kv_heads = key.shape[2]
+    if (
+        num_query_heads is not None
+        and num_kv_heads is not None
+        and num_query_heads > num_kv_heads
+        and num_kv_heads > 1
+    ):
+        groups = num_query_heads // num_kv_heads
+        key = tf.repeat(key, repeats=groups, axis=2)
+        value = tf.repeat(value, repeats=groups, axis=2)
+
     if bias is not None:
         bias = convert_to_tensor(bias, dtype=compute_dtype)
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1485,6 +1485,13 @@ def dot_product_attention(
     key = torch.transpose(key, axis0, axis1)
     value = torch.transpose(value, axis0, axis1)
 
+    num_query_heads = query.shape[1]
+    num_kv_heads = key.shape[1]
+    if num_query_heads > num_kv_heads and num_kv_heads > 1:
+        groups = num_query_heads // num_kv_heads
+        key = torch.repeat_interleave(key, repeats=groups, dim=1)
+        value = torch.repeat_interleave(value, repeats=groups, dim=1)
+
     if flash_attention is None:
         flash_attention = _can_use_flash_attention(
             query, key, value, mask, is_causal

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -3961,6 +3961,12 @@ class NNOpsBehaviorTest(testing.TestCase):
             knn.space_to_depth(x, block_size=-1)
 
 
+@pytest.mark.skipif(
+    backend.backend() in ("numpy", "openvino"),
+    reason="""
+    Key/Value broadcasting is not supported on numpy and openvino backends.
+    """,
+)
 class DotProductAttentionGQATest(testing.TestCase):
     def test_gqa_broadcasting(self):
         batch_size = 2

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -3959,3 +3959,29 @@ class NNOpsBehaviorTest(testing.TestCase):
             ValueError, "`block_size` must be at least 2"
         ):
             knn.space_to_depth(x, block_size=-1)
+
+
+class DotProductAttentionGQATest(testing.TestCase):
+    def test_gqa_broadcasting(self):
+        batch_size = 2
+        q_len, kv_len = 16, 16
+        num_q_heads = 4
+        num_kv_heads = 2
+        head_dim = 32
+
+        query = ops.ones(
+            (batch_size, q_len, num_q_heads, head_dim), dtype="float32"
+        )
+        key = ops.ones(
+            (batch_size, kv_len, num_kv_heads, head_dim), dtype="float32"
+        )
+        value = ops.ones(
+            (batch_size, kv_len, num_kv_heads, head_dim), dtype="float32"
+        )
+
+        # Should execute successfully without raising any
+        # shape mismatch RuntimeError/InvalidArgumentError
+        output = knn.dot_product_attention(query, key, value)
+        self.assertEqual(
+            output.shape, (batch_size, q_len, num_q_heads, head_dim)
+        )


### PR DESCRIPTION
Currently, when downstream models utilizing Grouped-Query Attention (GQA), such as Gemma 3, Gemma 2, or Gemma call `keras.ops.dot_product_attention` where num_query_heads > num_key_value_heads (and num_kv_heads > 1), Keras Core encounters a fatal runtime shape mismatch across both PyTorch and TensorFlow backends:

**PyTorch Backend:** _RuntimeError: The size of tensor a (8) must match the size of tensor b (4) at non-singleton dimension 1_
**TensorFlow Backend:** _InvalidArgumentError: Expected dimension 4 at axis 2 of the input but got dimension 2 [Op:Einsum]_


In `GQA`, multiple Query heads share a smaller number of Key/Value heads. When executing `dot_product_attention`, Keras Core delegates the mathematical blending to backend-specific routines. In the PyTorch backend (torch/nn.py), it hands the tensors to `torch.nn.functional.scaled_dot_product_attention` (SDPA). In the TensorFlow backend (tensorflow/nn.py), it hands them to an XLA-optimized tf.einsum("BTNH,BSNH->BNTS"). Both underlying operations rigidly expect the Query and Key tensors to have either equal head dimensions or be automatically broadcastable (which only works for Multi-Query Attention where num_kv_heads == 1). Because num_kv_heads > 1 in GQA configurations, both PyTorch and TensorFlow fail to broadcast and throw explicit shape mismatch crashes.

This PR updates GQA Key/Value head replication in the `dot_product_attention` for successful GQA execution on the affected backends. 

## Description
<!-- Describe your changes here -->

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
