### PR TITLE
Add erfinv tests and TensorFlow CPU fallback for half precision

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -297,7 +297,7 @@ def erfc(x):
 
 def erfinv(x):
     x = convert_to_tensor(x)
-    return jax.lax.erf_inv(x)
+    return jax.scipy.special.erfinv(x)
 
 
 def logdet(x):

--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -296,6 +296,7 @@ def erfc(x):
 
 
 def erfinv(x):
+    x = convert_to_tensor(x)
     return jax.lax.erf_inv(x)
 
 

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -319,7 +319,8 @@ def erfc(x):
 
 
 def erfinv(x):
-    return np.array(scipy.special.erfinv(x))
+    dtype = dtypes.result_type(x.dtype, float)
+    return scipy.special.erfinv(x).astype(dtype)
 
 
 def logdet(x):

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -319,6 +319,7 @@ def erfc(x):
 
 
 def erfinv(x):
+    x = convert_to_tensor(x)
     dtype = dtypes.result_type(x.dtype, float)
     return scipy.special.erfinv(x).astype(dtype)
 

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -302,6 +302,15 @@ def erfc(x):
 
 
 def erfinv(x):
+    x = convert_to_tensor(x)
+    dtype = standardize_dtype(x.dtype)
+
+    if dtype in ["bfloat16", "float16"]:
+        return tf.cast(
+            tf.math.erfinv(tf.cast(x, tf.float32)),
+            dtype,
+        )
+
     return tf.math.erfinv(x)
 
 

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -1212,7 +1212,6 @@ def erfinv(x):
     """
     if any_symbolic_tensors((x,)):
         return Erfinv().symbolic_call(x)
-    x = backend.convert_to_tensor(x)
     return backend.math.erfinv(x)
 
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -155,6 +155,11 @@ class MathOpsDynamicShapeTest(testing.TestCase):
         y = kmath.erfc(x)
         self.assertEqual(y.shape, (None, 2, 3))
 
+    def test_erfinv(self):
+        x = KerasTensor((None, 2, 3))
+        y = kmath.erfinv(x)
+        self.assertEqual(y.shape, (None, 2, 3))
+
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     def test_segment_reduce(self, segment_reduce_op):
         # 1D case
@@ -356,6 +361,11 @@ class MathOpsStaticShapeTest(testing.TestCase):
     def test_erfc(self):
         x = KerasTensor((1, 2, 3))
         y = kmath.erfc(x)
+        self.assertEqual(y.shape, (1, 2, 3))
+
+    def test_erfinv(self):
+        x = KerasTensor((1, 2, 3))
+        y = kmath.erfinv(x)
         self.assertEqual(y.shape, (1, 2, 3))
 
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
@@ -1142,6 +1152,25 @@ class MathDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(kmath.Erfc().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_erfinv(self, dtype):
+        import jax.numpy as jnp
+        import jax.scipy.special as special
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+
+        expected_dtype = standardize_dtype(special.erfinv(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(kmath.erfinv(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(kmath.Erfinv().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
## Description
Adds missing tests for erfinv, including dtype and symbolic shape coverage. Also adds a TensorFlow CPU fallback for float16 and bfloat16 by computing erfinv in float32 and casting the result back to the original dtype.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
