### PR TITLE
[bug-fix] enter `tf.init_scope` when adding optimizer variables with TF backend

### DIFF
--- a/keras/src/backend/tensorflow/optimizer.py
+++ b/keras/src/backend/tensorflow/optimizer.py
@@ -21,6 +21,10 @@ class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
         super().__init__(*args, **kwargs)
         self._distribution_strategy = tf.distribute.get_strategy()
 
+    def add_variable(self, *args, **kwargs):
+        with tf.init_scope():
+            return super().add_variable(*args, **kwargs)
+
     def add_variable_from_reference(
         self, reference_variable, name=None, initializer="zeros"
     ):

--- a/keras/src/backend/tensorflow/optimizer.py
+++ b/keras/src/backend/tensorflow/optimizer.py
@@ -21,9 +21,24 @@ class TFOptimizer(KerasAutoTrackable, base_optimizer.BaseOptimizer):
         super().__init__(*args, **kwargs)
         self._distribution_strategy = tf.distribute.get_strategy()
 
-    def add_variable(self, *args, **kwargs):
+    def add_variable(
+        self,
+        shape,
+        initializer="zeros",
+        dtype=None,
+        aggregation="none",
+        layout=None,
+        name=None,
+    ):
         with tf.init_scope():
-            return super().add_variable(*args, **kwargs)
+            return super().add_variable(
+                shape,
+                initializer=initializer,
+                dtype=dtype,
+                aggregation=aggregation,
+                layout=layout,
+                name=name,
+            )
 
     def add_variable_from_reference(
         self, reference_variable, name=None, initializer="zeros"


### PR DESCRIPTION
## Description

As discussed in #23085 (thank you @maitry63 for taking the time to respond), this fixes a tracing error in TF distributed training with stateful optimizers by entering a `tf.init_scope()` when creating optimizer variables.

Fixes #23085.

AI use: to help go through the optimizers code + it proposed the use of `tf.init_scope()`

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
