### PR TITLE
Fix wrong parameter names in ops.select and ops.argpartition docstrings

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9493,7 +9493,7 @@ def select(condlist, choicelist, default=0):
         choicelist: List of tensors.
             The list of tensors from which the output elements are taken.
             This list has to be of the same length as `condlist`.
-        defaults: Optional scalar value.
+        default: Optional scalar value.
             The element inserted in the output
             when all conditions evaluate to `False`.
 
@@ -9599,7 +9599,7 @@ def argpartition(x, kth, axis=-1):
     in partitioned order.
 
     Args:
-        a: Array to sort.
+        x: Array to sort.
         kth: Element index to partition by.
             The k-th element will be in its final sorted position and all
             smaller elements will be moved before it and all larger elements


### PR DESCRIPTION
## Description

Two `keras.ops` functions document a parameter name that does not match their signature:

- **`ops.select(condlist, choicelist, default=0)`** — the `Args` section listed `defaults:` (plural), but the parameter is `default`.
- **`ops.argpartition(x, kth, axis=-1)`** — the `Args` section listed `a:` (carried over from NumPy's `argpartition` docs), but the parameter is `x`.

This corrects both names so the docstrings match the actual signatures. Documentation-only — no code or behaviour changes, no new tests needed.


## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.