### PR TITLE
Fix pad_sequences string dtype check (np.bytes_ instead of duplicate …

### DIFF
--- a/keras/src/utils/sequence_utils.py
+++ b/keras/src/utils/sequence_utils.py
@@ -101,7 +101,7 @@ def pad_sequences(
         maxlen = np.max(lengths)
 
     is_dtype_str = np.issubdtype(dtype, np.str_) or np.issubdtype(
-        dtype, np.str_
+        dtype, np.bytes_
     )
     if isinstance(value, str) and dtype is not object and not is_dtype_str:
         raise ValueError(


### PR DESCRIPTION
## Description

In `keras.utils.pad_sequences`, the string-dtype check tested `np.str_` twice:

```python
is_dtype_str = np.issubdtype(dtype, np.str_) or np.issubdtype(
    dtype, np.str_
)
```

The second clause is redundant (`or` of the same condition). NumPy has two string dtype kinds — unicode (`np.str_`, `<U`) and bytes (`np.bytes_`, `<S`) — so the intent was clearly to also accept bytes string dtypes. As written, a bytes string dtype was not recognised as a string dtype, so the subsequent `ValueError` guard could misfire.

This changes the second clause to `np.bytes_`:

```python
is_dtype_str = np.issubdtype(dtype, np.str_) or np.issubdtype(
    dtype, np.bytes_
)
```

If maintainers prefer the most conservative change instead, I'm happy to simply drop the redundant clause — just let me know. Happy to add a unit test for the bytes-dtype path as well.



## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.