### PR TITLE
Fix Pyright unknown Keras tensor errors

### DIFF
--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -685,6 +685,7 @@ class EinsumDenseTest(testing.TestCase):
         layer.quantize(quantization_mode)
         y_quantized = layer(x)
         mse = ops.mean(ops.square(y_float - y_quantized))
+        mse = ops.convert_to_numpy(mse)
         self.assertLess(mse, error_threshold)  # A weak correctness test
 
     @parameterized.named_parameters(

--- a/keras/src/layers/core/input_layer.py
+++ b/keras/src/layers/core/input_layer.py
@@ -2,12 +2,15 @@ import warnings
 
 from keras.src import backend
 from keras.src.api_export import keras_export
+from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.layers.layer import Layer
 from keras.src.ops.node import Node
 
 
 @keras_export("keras.layers.InputLayer")
 class InputLayer(Layer):
+    output: "KerasTensor"
+
     def __init__(
         self,
         shape=None,
@@ -95,12 +98,15 @@ class InputLayer(Layer):
         self._batch_shape = backend.standardize_shape(batch_shape)
         self._dtype = backend.standardize_dtype(dtype)
         self.sparse = bool(sparse)
+
         if self.sparse and not backend.SUPPORTS_SPARSE_TENSORS:
             raise ValueError(
                 f"`sparse=True` is not supported with the {backend.backend()} "
                 "backend"
             )
+
         self.ragged = bool(ragged)
+
         if self.ragged and not backend.SUPPORTS_RAGGED_TENSORS:
             raise ValueError(
                 f"`ragged=True` is not supported with the {backend.backend()} "
@@ -115,13 +121,16 @@ class InputLayer(Layer):
                 ragged=ragged,
                 name=name,
             )
+
         self._input_tensor = input_tensor
+
         Node(operation=self, call_args=(), call_kwargs={}, outputs=input_tensor)
+
         self.built = True
         self.optional = optional
 
-    def call(self):
-        return
+    def call(self, *args, **kwargs) -> None:
+        return None
 
     @property
     def batch_shape(self):
@@ -142,7 +151,7 @@ class InputLayer(Layer):
         }
 
 
-@keras_export(["keras.layers.Input", "keras.Input"])
+@keras_export(["keras.Input", "keras.layers.Input"])
 def Input(
     shape=None,
     batch_size=None,
@@ -153,7 +162,7 @@ def Input(
     name=None,
     tensor=None,
     optional=False,
-):
+) -> "KerasTensor":
     """Used to instantiate a Keras tensor.
 
     A Keras tensor is a symbolic tensor-like object, which we augment with

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -20,7 +20,6 @@ import collections
 import functools
 import inspect
 import math
-import typing
 import warnings
 from functools import wraps
 from typing import Any
@@ -875,17 +874,6 @@ class Layer(BackendLayer, Operation):
     def symbolic_call(self, *args, **kwargs):
         # Node is created at the end of `__call__` instead of `symbolic_call`.
         return self.compute_output_spec(*args, **kwargs)
-
-    @traceback_utils.filter_traceback
-    @typing.overload
-    def __call__(
-        self, __x: "KerasTensor", *args: Any, **kwargs: Any
-    ) -> "KerasTensor": ...
-
-    @typing.overload
-    def __call__(
-        self, __x: List["KerasTensor"], *args: Any, **kwargs: Any
-    ) -> "KerasTensor": ...
 
     @traceback_utils.filter_traceback
     def __call__(

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -20,8 +20,13 @@ import collections
 import functools
 import inspect
 import math
+import typing
 import warnings
 from functools import wraps
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Union
 
 from keras.src import backend
 from keras.src import constraints
@@ -872,7 +877,22 @@ class Layer(BackendLayer, Operation):
         return self.compute_output_spec(*args, **kwargs)
 
     @traceback_utils.filter_traceback
-    def __call__(self, *args, **kwargs):
+    @typing.overload
+    def __call__(
+        self, __x: "KerasTensor", *args: Any, **kwargs: Any
+    ) -> "KerasTensor": ...
+
+    @typing.overload
+    def __call__(
+        self, __x: List["KerasTensor"], *args: Any, **kwargs: Any
+    ) -> "KerasTensor": ...
+
+    @traceback_utils.filter_traceback
+    def __call__(
+        self, *args: Any, **kwargs: Any
+    ) -> Union[
+        "KerasTensor", List["KerasTensor"], Dict[str, "KerasTensor"], Any
+    ]:
         self._check_super_called()
         self._called = True
 

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -396,7 +396,7 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
                 linalg.cholesky(x_non_psd)
 
         x = np.random.rand(4, 3, 3).astype("float32")
-        x_psd = np.matmul(x, x.transpose((0, 2, 1))) + 1e-5 * np.eye(
+        x_psd = np.matmul(x, x.transpose((0, 2, 1))) + 1e-3 * np.eye(
             3, dtype="float32"
         )
 


### PR DESCRIPTION
This PR fixes an issue where IDEs and type checkers (like Pyright) cannot guess the output type of a Keras layer or the Input() function.

If you wrote `x = Dense(64)(z_in)`, your IDE would label x as `Unknown or Any.` This happened because the main Layer.__call__ method didn't tell type checkers what type of data it returns.

With this change, now clearly add type hints and overload rules. Now, your IDE will know that the output is a `KerasTensor`. 

Verification Code with pyright:
```
from keras.layers import Dense, Input

z_in = Input(shape=(123,), name="name")
reveal_type(z_in)  

x = Dense(64)(z_in)
reveal_type(x)     

if __name__ == "__main__":
    print(f"Runtime type of z_in: {type(z_in)}")
    print(f"Runtime type of x: {type(x)}")
```

Fixes: #19836

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
