### PR TITLE
fix: Remove unnecessary np.object check & assignment

### DIFF
--- a/keras/src/export/tf2onnx_lib.py
+++ b/keras/src/export/tf2onnx_lib.py
@@ -18,9 +18,6 @@ def patch_tf2onnx():
 
     logger = logging.getLogger(tf2onnx.__name__)
 
-    if not hasattr(np, "object"):
-        np.object = object
-
     def patched_rewrite_constant_fold(g, ops):
         """
         We call tensorflow transform with constant folding but in some cases


### PR DESCRIPTION
## Description
When using `tf2onnx`, keras is patching `np.object` since older versions of `tf2onnx` still relied on it. This changed 4 years ago in https://github.com/onnx/tensorflow-onnx/pull/1990. Patching `np.object` isn't necessary anymore, and as mentioned in another MR, touching `np.object` actually triggers a spurious warning that's pretty much counter productive now.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
