### PR TITLE
[Bug-Fix] TorchDataLoaderAdapter corrupts dict and single-tensor batches on non-Torch backends

### DIFF
--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter.py
@@ -34,10 +34,8 @@ class TorchDataLoaderAdapter(DataAdapter):
     def get_numpy_iterator(self):
         for batch in self._dataloader:
             # shared memory using `np.asarray`
-            yield tuple(
-                tree.map_structure(
-                    lambda x: np.asarray(x.cpu()), batch, none_is_leaf=False
-                )
+            yield tree.map_structure(
+                lambda x: np.asarray(x.cpu()), batch, none_is_leaf=False
             )
 
     def get_jax_iterator(self):
@@ -47,6 +45,10 @@ class TorchDataLoaderAdapter(DataAdapter):
     def get_tf_dataset(self):
         from keras.src.utils.module_utils import tensorflow as tf
 
+        def get_tf_iterator():
+            for batch in self.get_numpy_iterator():
+                yield tree.lists_to_tuples(batch)
+
         if self._output_signature is None:
             batches = list(
                 itertools.islice(
@@ -54,11 +56,11 @@ class TorchDataLoaderAdapter(DataAdapter):
                     data_adapter_utils.NUM_BATCHES_FOR_TENSOR_SPEC,
                 )
             )
-            self._output_signature = tuple(
+            self._output_signature = tree.lists_to_tuples(
                 data_adapter_utils.get_tensor_spec(batches)
             )
         return tf.data.Dataset.from_generator(
-            self.get_numpy_iterator,
+            get_tf_iterator,
             output_signature=self._output_signature,
         )
 

--- a/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
+++ b/keras/src/trainers/data_adapters/torch_data_loader_adapter_test.py
@@ -53,6 +53,61 @@ class TestTorchDataLoaderAdapter(testing.TestCase):
                 self.assertEqual(bx.shape, (2, 4))
                 self.assertEqual(by.shape, (2, 2))
 
+    def test_dict_batch_preserves_structure(self):
+        class DictDataset(torch.utils.data.Dataset):
+            def __len__(self):
+                return 2
+
+            def __getitem__(self, idx):
+                return {
+                    "x": torch.tensor([idx, idx + 1], dtype=torch.float32),
+                    "y": torch.tensor(idx, dtype=torch.float32),
+                }
+
+        dataloader = torch.utils.data.DataLoader(DictDataset(), batch_size=2)
+        adapter = TorchDataLoaderAdapter(dataloader)
+
+        batch = next(adapter.get_numpy_iterator())
+        self.assertIsInstance(batch, dict)
+        self.assertEqual(set(batch), {"x", "y"})
+        self.assertIsInstance(batch["x"], np.ndarray)
+        self.assertIsInstance(batch["y"], np.ndarray)
+        self.assertEqual(batch["x"].shape, (2, 2))
+        self.assertEqual(batch["y"].shape, (2,))
+
+        if backend.backend() == "tensorflow":
+            ds = TorchDataLoaderAdapter(dataloader).get_tf_dataset()
+            self.assertIsInstance(ds.element_spec, dict)
+            self.assertEqual(set(ds.element_spec), {"x", "y"})
+            self.assertIsInstance(ds.element_spec["x"], tf.TensorSpec)
+            self.assertIsInstance(ds.element_spec["y"], tf.TensorSpec)
+            self.assertEqual(ds.element_spec["x"].shape, (None, 2))
+            self.assertEqual(ds.element_spec["y"].shape, (None,))
+
+    def test_single_tensor_batch_preserves_structure(self):
+        class TensorOnlyDataset(torch.utils.data.Dataset):
+            def __len__(self):
+                return 4
+
+            def __getitem__(self, idx):
+                return torch.tensor(
+                    [idx, idx + 1, idx + 2], dtype=torch.float32
+                )
+
+        dataloader = torch.utils.data.DataLoader(
+            TensorOnlyDataset(), batch_size=2
+        )
+        adapter = TorchDataLoaderAdapter(dataloader)
+
+        batch = next(adapter.get_numpy_iterator())
+        self.assertIsInstance(batch, np.ndarray)
+        self.assertEqual(batch.shape, (2, 3))
+
+        if backend.backend() == "tensorflow":
+            ds = TorchDataLoaderAdapter(dataloader).get_tf_dataset()
+            self.assertIsInstance(ds.element_spec, tf.TensorSpec)
+            self.assertEqual(ds.element_spec.shape, (None, 3))
+
     @parameterized.named_parameters(
         named_product(batch_size=[None, 3], implements_len=[True, False])
     )


### PR DESCRIPTION
## Description
Fixes: #23080 
Removed the force change of the dict and single tensor batches to tuple(...). Now tree utilities preserve the batch structure. Added a tf specific normalization so now nested lists to tuples without converting dicts or tensors accidentally. Added regression tests for the same.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
