### PR TITLE
[Bug-Fix] sklearn wrapper warm_start=True does not reuse model instance weights

### DIFF
--- a/keras/src/wrappers/sklearn_test.py
+++ b/keras/src/wrappers/sklearn_test.py
@@ -3,6 +3,7 @@
 import unittest
 from contextlib import contextmanager
 
+import numpy as np
 import pytest
 import sklearn
 from packaging.version import parse as parse_version
@@ -216,3 +217,26 @@ def test_sklearn_estimator_decision_function(estimator):
             pytest.xfail("Backend not implemented")
         else:
             raise
+
+
+@pytest.mark.requires_trainable_backend
+def test_sklearn_classifier_warm_start_reuses_model_instance():
+    inputs = Input(shape=(4,))
+    outputs = Dense(2, activation="softmax")(inputs)
+    model = Model(inputs, outputs)
+    model.compile(loss="categorical_crossentropy", optimizer="sgd")
+
+    X = np.ones((4, 4))
+    y = np.array([1, 2, 1, 2])
+    estimator = SKLearnClassifier(model=model, warm_start=True)
+
+    estimator.fit(X, y, epochs=0, verbose=0)
+    first_model = estimator.model_
+
+    if first_model is not model:
+        raise AssertionError("Expected warm_start to use the original model.")
+
+    estimator.fit(X, y, epochs=0, verbose=0)
+
+    if estimator.model_ is not first_model:
+        raise AssertionError("Expected warm_start to reuse the fitted model.")

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -142,10 +142,10 @@ class SKLBase(BaseEstimator):
         return self
 
     def _get_model(self, X, y):
+        if self.warm_start and hasattr(self, "model_"):
+            return self.model_
         if isinstance(self.model, Model):
             if self.warm_start:
-                if hasattr(self, "model_"):
-                    return self.model_
                 return self.model
             return clone_model(self.model)
         else:

--- a/keras/src/wrappers/sklearn_wrapper.py
+++ b/keras/src/wrappers/sklearn_wrapper.py
@@ -143,6 +143,10 @@ class SKLBase(BaseEstimator):
 
     def _get_model(self, X, y):
         if isinstance(self.model, Model):
+            if self.warm_start:
+                if hasattr(self, "model_"):
+                    return self.model_
+                return self.model
             return clone_model(self.model)
         else:
             args = self.model_kwargs or {}


### PR DESCRIPTION
## Description
Fixes: #23097 
Added an extra check in the `_get_model` function so now it uses previous model instead of cloning new one. Also added regression test for the same.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
