### PR TITLE
fix(security): Reject cumulative HDF5 shape bombs that evade the per-dataset size floor

### DIFF
--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -12,6 +12,7 @@ from keras.src.legacy.saving import saving_options
 from keras.src.legacy.saving import saving_utils
 from keras.src.saving import object_registration
 from keras.src.saving import serialization_lib
+from keras.src.saving.saving_lib import reject_h5_shape_bomb
 from keras.src.saving.saving_lib import safe_get_h5_dataset
 from keras.src.saving.saving_lib import safe_get_h5_group
 from keras.src.utils import io_utils
@@ -342,6 +343,7 @@ def load_weights_from_hdf5_group(group, model, skip_mismatch=False):
         ValueError: in case of mismatch between provided layers
             and weights file.
     """
+    reject_h5_shape_bomb(group.file)
     if "keras_version" in group.attrs:
         original_keras_version = group.attrs["keras_version"]
         if hasattr(original_keras_version, "decode"):
@@ -486,6 +488,7 @@ def load_weights_from_hdf5_group_by_name(group, model, skip_mismatch=False):
         ValueError: in case of mismatch between provided layers
             and weights file and skip_match=False.
     """
+    reject_h5_shape_bomb(group.file)
     if "keras_version" in group.attrs:
         original_keras_version = group.attrs["keras_version"]
         if hasattr(original_keras_version, "decode"):

--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -122,6 +122,10 @@ def load_model_from_hdf5(
     else:
         f = filepath
 
+    # Reject a cumulative shape bomb once, at the single point where the file is
+    # opened, so the weight loaders below don't each re-walk the whole file.
+    reject_h5_shape_bomb(f)
+
     model = None
     try:
         # instantiate model
@@ -343,7 +347,6 @@ def load_weights_from_hdf5_group(group, model, skip_mismatch=False):
         ValueError: in case of mismatch between provided layers
             and weights file.
     """
-    reject_h5_shape_bomb(group.file)
     if "keras_version" in group.attrs:
         original_keras_version = group.attrs["keras_version"]
         if hasattr(original_keras_version, "decode"):
@@ -488,7 +491,6 @@ def load_weights_from_hdf5_group_by_name(group, model, skip_mismatch=False):
         ValueError: in case of mismatch between provided layers
             and weights file and skip_match=False.
     """
-    reject_h5_shape_bomb(group.file)
     if "keras_version" in group.attrs:
         original_keras_version = group.attrs["keras_version"]
         if hasattr(original_keras_version, "decode"):

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -314,6 +314,9 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
                 "You can install it via `pip install h5py`"
             )
         with h5py.File(filepath, "r") as f:
+            # Reject a cumulative shape bomb once, right after opening, so the
+            # legacy weight loaders below don't each re-walk the whole file.
+            saving_lib.reject_h5_shape_bomb(f)
             if "layer_names" not in f.attrs and "model_weights" in f:
                 f = saving_lib.safe_get_h5_group(f, "model_weights")
             if by_name:

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1235,6 +1235,12 @@ def safe_get_h5_group(parent, name):
 # this; shape/decompression bombs, which store next to nothing, do not.
 _H5_DATASET_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
 _H5_DATASET_MAX_EXPANSION = 1000
+# Floor for the *cumulative* (whole-file) guard below. Genuine HDF5 weight
+# files store their arrays uncompressed, so their total declared size tracks
+# the on-disk size (ratio ~1); only a bomb declares far more than is stored.
+# A much lower floor than the per-dataset one lets the cumulative guard also
+# catch a single sub-4 GiB dataset that the per-dataset floor would miss.
+_H5_CUMULATIVE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
 
 
 def safe_get_h5_dataset(group, name):
@@ -1295,8 +1301,9 @@ def reject_h5_shape_bomb(h5_file):
     `load_subset_weights_from_hdf5_group` materializes every weight of a layer
     at once). This bounds the *cumulative* in-memory size of all datasets in
     the file against the bytes actually stored on disk, using the same
-    expansion ratio, so a tiny file cannot force an unbounded allocation
-    (CWE-789 / CWE-409).
+    expansion ratio. Because genuine weight files are uncompressed (declared
+    size ~= file size), this also catches a single dataset that declares just
+    under the per-dataset 4 GiB floor (CWE-789 / CWE-409).
     """
     try:
         file_size = h5_file.id.get_filesize()
@@ -1304,21 +1311,24 @@ def reject_h5_shape_bomb(h5_file):
         # If we cannot determine the on-disk size, skip the cumulative check
         # rather than break loading; the per-dataset guard still applies.
         return
-    limit = max(
-        _H5_DATASET_BOMB_FLOOR_BYTES,
-        _H5_DATASET_MAX_EXPANSION * file_size,
-    )
+    if file_size <= 0:
+        return
     total_declared = 0
 
     def _accumulate(_name, obj):
         nonlocal total_declared
-        if isinstance(obj, h5py.Dataset):
+        # A null-dataspace dataset has `shape is None`; skip it (`math.prod`
+        # would raise on `None`).
+        if isinstance(obj, h5py.Dataset) and obj.shape is not None:
             total_declared += math.prod(obj.shape) * obj.dtype.itemsize
 
     # `visititems` only walks hard-linked datasets; external/soft links are
     # rejected separately by `safe_get_h5_dataset` when they are accessed.
     h5_file.visititems(_accumulate)
-    if total_declared > limit:
+    if (
+        total_declared > _H5_CUMULATIVE_BOMB_FLOOR_BYTES
+        and total_declared > _H5_DATASET_MAX_EXPANSION * file_size
+    ):
         raise ValueError(
             "Not allowed: the HDF5 file declares "
             f"{readable_memory_size(total_declared)} of array data but only "
@@ -1364,13 +1374,10 @@ class H5IOStore:
         self.archive = archive
         self.io_file = None
 
-        # Init H5 file.
+        # Init H5 file. `_get_h5_file` applies `reject_h5_shape_bomb` on every
+        # read-mode open, so it also covers `ShardedH5IOStore`'s lazily opened
+        # shards (which never call this `__init__`).
         self.h5_file = self._get_h5_file(self.path_or_io)
-
-        # Reject a file whose datasets jointly declare far more than is stored
-        # (a cumulative shape bomb that evades the per-dataset floor).
-        if self.mode == "r":
-            reject_h5_shape_bomb(self.h5_file)
 
         # Init H5 entry group.
         self._h5_entry_path = None
@@ -1394,9 +1401,14 @@ class H5IOStore:
                 self.io_file = io.BytesIO()
             else:
                 self.io_file = self.archive.open(str(path_or_io), "r")
-            return h5py.File(self.io_file, mode=mode)
+            h5_file = h5py.File(self.io_file, mode=mode)
         else:
-            return h5py.File(path_or_io, mode=mode)
+            h5_file = h5py.File(path_or_io, mode=mode)
+        if mode == "r":
+            # Guard every read-mode open (covers `H5IOStore`, sharded shards
+            # opened lazily by `ShardedH5IOStore`, and shard switching).
+            reject_h5_shape_bomb(h5_file)
+        return h5_file
 
     def make(self, path, metadata=None):
         """Make a new H5 entry group.

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1317,9 +1317,17 @@ def reject_h5_shape_bomb(h5_file):
 
     def _accumulate(_name, obj):
         nonlocal total_declared
+        if not isinstance(obj, h5py.Dataset):
+            return
+        if obj.is_virtual:
+            # A virtual dataset maps to data outside this file, so its declared
+            # size is not backed by the on-disk bytes we measure here. Reject it
+            # outright, exactly as `safe_get_h5_dataset` does on access, instead
+            # of letting it slip through the cumulative accounting.
+            raise ValueError("Not allowed: H5 file with virtual Dataset")
         # A null-dataspace dataset has `shape is None`; skip it (`math.prod`
         # would raise on `None`).
-        if isinstance(obj, h5py.Dataset) and obj.shape is not None:
+        if obj.shape is not None:
             total_declared += math.prod(obj.shape) * obj.dtype.itemsize
 
     # `visititems` only walks hard-linked datasets; external/soft links are

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1286,6 +1286,47 @@ def safe_get_h5_dataset(group, name):
     return dataset
 
 
+def reject_h5_shape_bomb(h5_file):
+    """Guard against an HDF5 file that is a cumulative shape bomb.
+
+    `safe_get_h5_dataset` bounds a *single* dataset, but its per-dataset floor
+    can be evaded by many datasets that each declare just under the floor while
+    storing almost nothing, and that are then read into memory together (e.g.
+    `load_subset_weights_from_hdf5_group` materializes every weight of a layer
+    at once). This bounds the *cumulative* in-memory size of all datasets in
+    the file against the bytes actually stored on disk, using the same
+    expansion ratio, so a tiny file cannot force an unbounded allocation
+    (CWE-789 / CWE-409).
+    """
+    try:
+        file_size = h5_file.id.get_filesize()
+    except Exception:
+        # If we cannot determine the on-disk size, skip the cumulative check
+        # rather than break loading; the per-dataset guard still applies.
+        return
+    limit = max(
+        _H5_DATASET_BOMB_FLOOR_BYTES,
+        _H5_DATASET_MAX_EXPANSION * file_size,
+    )
+    total_declared = 0
+
+    def _accumulate(_name, obj):
+        nonlocal total_declared
+        if isinstance(obj, h5py.Dataset):
+            total_declared += math.prod(obj.shape) * obj.dtype.itemsize
+
+    # `visititems` only walks hard-linked datasets; external/soft links are
+    # rejected separately by `safe_get_h5_dataset` when they are accessed.
+    h5_file.visititems(_accumulate)
+    if total_declared > limit:
+        raise ValueError(
+            "Not allowed: the HDF5 file declares "
+            f"{readable_memory_size(total_declared)} of array data but only "
+            f"{readable_memory_size(file_size)} are stored on disk; "
+            "refusing to load a potential decompression/shape bomb."
+        )
+
+
 class H5IOStore:
     """Numerical variable store backed by HDF5.
 
@@ -1325,6 +1366,11 @@ class H5IOStore:
 
         # Init H5 file.
         self.h5_file = self._get_h5_file(self.path_or_io)
+
+        # Reject a file whose datasets jointly declare far more than is stored
+        # (a cumulative shape bomb that evades the per-dataset floor).
+        if self.mode == "r":
+            reject_h5_shape_bomb(self.h5_file)
 
         # Init H5 entry group.
         self._h5_entry_path = None

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1887,6 +1887,22 @@ class SafeGetH5DatasetTest(testing.TestCase):
             self.assertIsNone(f["empty"].shape)
             saving_lib.reject_h5_shape_bomb(f)  # must not raise
 
+    def test_rejects_virtual_dataset(self):
+        # A virtual dataset can declare a huge shape backed by data outside the
+        # file, so the guard must reject it instead of counting its bytes.
+        path = os.path.join(self.get_temp_dir(), "virtual.h5")
+        layout = h5py.VirtualLayout(shape=(1 << 30,), dtype="float32")
+        source_path = os.path.join(self.get_temp_dir(), "source.h5")
+        with h5py.File(source_path, "w") as src:
+            src.create_dataset("data", data=np.zeros((8,), dtype="float32"))
+        layout[:8] = h5py.VirtualSource(source_path, "data", shape=(8,))
+        with h5py.File(path, "w") as f:
+            f.create_virtual_dataset("vds", layout)
+        with h5py.File(path, "r") as f:
+            self.assertTrue(f["vds"].is_virtual)
+            with self.assertRaisesRegex(ValueError, "virtual Dataset"):
+                saving_lib.reject_h5_shape_bomb(f)
+
     def test_load_sharded_weights_rejects_shape_bomb(self):
         # Sharded weights open each shard via `_get_h5_file` (never
         # `H5IOStore.__init__`), so a bomb planted in a shard must still be

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1857,6 +1857,69 @@ class SafeGetH5DatasetTest(testing.TestCase):
         with h5py.File(path, "r") as f:
             saving_lib.reject_h5_shape_bomb(f)  # must not raise
 
+    def test_rejects_single_sub_floor_shape_bomb(self):
+        # A single dataset declaring just under the 4 GiB per-dataset floor with
+        # ~0 stored still declares far more than the file holds, so the
+        # cumulative guard must reject it.
+        path = os.path.join(self.get_temp_dir(), "single_bomb.h5")
+        with h5py.File(path, "w") as f:
+            f.create_dataset(
+                "d",
+                shape=((3 << 30) // 4,),  # 3 GiB float32, below the 4 GiB floor
+                dtype="float32",
+                chunks=(1 << 20,),
+                compression="gzip",
+                fillvalue=0.0,
+            )
+        self.assertLess(os.path.getsize(path), 1 << 20)
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "shape bomb"):
+                saving_lib.reject_h5_shape_bomb(f)
+
+    def test_ignores_null_dataspace_dataset(self):
+        # A null-dataspace dataset has `shape is None`; the guard must skip it
+        # instead of crashing in `math.prod(None)`.
+        path = os.path.join(self.get_temp_dir(), "null.h5")
+        with h5py.File(path, "w") as f:
+            f.create_dataset("empty", data=h5py.Empty("float32"))
+            f.create_dataset("real", shape=(8,), dtype="float32")
+        with h5py.File(path, "r") as f:
+            self.assertIsNone(f["empty"].shape)
+            saving_lib.reject_h5_shape_bomb(f)  # must not raise
+
+    def test_load_sharded_weights_rejects_shape_bomb(self):
+        # Sharded weights open each shard via `_get_h5_file` (never
+        # `H5IOStore.__init__`), so a bomb planted in a shard must still be
+        # rejected when that shard is opened.
+        model = keras.Sequential(
+            [keras.Input((256,))] + [keras.layers.Dense(256) for _ in range(8)]
+        )
+        temp_dir = self.get_temp_dir()
+        path = os.path.join(temp_dir, "sharded.weights.json")
+        saving_lib.save_weights_only(model, path, max_shard_size=0.0005)
+        shards = [
+            name
+            for name in os.listdir(temp_dir)
+            if name.endswith(".weights.h5")
+        ]
+        self.assertGreater(len(shards), 1)
+        # The first shard is opened by `ShardedH5IOStore.__init__`.
+        first_shard = os.path.join(temp_dir, "sharded_00000.weights.h5")
+        with h5py.File(first_shard, "a") as f:
+            f.create_group("bomb").create_dataset(
+                "w",
+                shape=((3 << 30) // 4,),
+                dtype="float32",
+                chunks=(1 << 20,),
+                compression="gzip",
+                fillvalue=0.0,
+            )
+        reloaded = keras.Sequential(
+            [keras.Input((256,))] + [keras.layers.Dense(256) for _ in range(8)]
+        )
+        with self.assertRaisesRegex(ValueError, "shape bomb"):
+            saving_lib.load_weights_only(reloaded, path)
+
 
 class SavingDiskIOStoreTest(testing.TestCase):
     def test_disk_io_store_rejects_path_traversal(self):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1819,6 +1819,44 @@ class SafeGetH5DatasetTest(testing.TestCase):
         with self.assertRaises(ValueError):
             reloaded.load_weights(good_path)
 
+    def _cumulative_bomb_file(self):
+        """Several datasets, each just under the 4 GiB per-dataset floor and
+        storing ~nothing, that jointly declare far more than is stored."""
+        path = os.path.join(self.get_temp_dir(), "cumulative_bomb.h5")
+        elems = (3 << 30) // 4  # 3 GiB of float32 each, below the 4 GiB floor
+        with h5py.File(path, "w") as f:
+            g = f.create_group("layer")
+            for i in range(3):  # 9 GiB declared total
+                g.create_dataset(
+                    f"w{i}",
+                    shape=(elems,),
+                    dtype="float32",
+                    chunks=(1 << 20,),
+                    compression="gzip",
+                    fillvalue=0.0,
+                )
+        return path
+
+    def test_rejects_cumulative_shape_bomb_under_floor(self):
+        path = self._cumulative_bomb_file()
+        self.assertLess(os.path.getsize(path), 1 << 20)  # tiny file on disk
+        with h5py.File(path, "r") as f:
+            # Each dataset is below the per-dataset floor, so the per-dataset
+            # guard passes; the cumulative guard must still reject the file.
+            for name in ("w0", "w1", "w2"):
+                saving_lib.safe_get_h5_dataset(f["layer"], name)
+            with self.assertRaisesRegex(ValueError, "shape bomb"):
+                saving_lib.reject_h5_shape_bomb(f)
+
+    def test_does_not_reject_genuine_weights(self):
+        model = keras.Sequential(
+            [keras.Input((16,)), keras.layers.Dense(64), keras.layers.Dense(8)]
+        )
+        path = os.path.join(self.get_temp_dir(), "good.weights.h5")
+        model.save_weights(path)
+        with h5py.File(path, "r") as f:
+            saving_lib.reject_h5_shape_bomb(f)  # must not raise
+
 
 class SavingDiskIOStoreTest(testing.TestCase):
     def test_disk_io_store_rejects_path_traversal(self):


### PR DESCRIPTION
## Description

`keras.models.load_model` / `Model.load_weights` guard against an HDF5 "shape bomb" via `safe_get_h5_dataset`, which rejects a dataset that declares a huge in-memory size while storing almost nothing on disk. That guard only fires for a **single** dataset that declares more than a 4 GiB floor (and more than 1000x its stored size), which leaves two gaps:

- A dataset that declares just **under** 4 GiB while storing almost nothing passes unconditionally, regardless of how extreme the amplification, because the declared-over-floor half of the condition is false.
- `load_subset_weights_from_hdf5_group` reads **every** weight dataset of a layer group into one list before any count/shape check, so many sub-floor datasets allocate that many times just-under-4 GiB simultaneously, which is unbounded.

A few-KB crafted `.h5` / `.weights.h5` can therefore force an arbitrarily large allocation at load time under the default `safe_mode=True` and get the process OOM-killed, the same impact class the original guard was meant to prevent.

This adds `reject_h5_shape_bomb`, which bounds the **cumulative** declared size of all datasets in an HDF5 file against the bytes actually stored on disk, using the same expansion ratio as the per-dataset guard. It runs when opening a file for reading in `H5IOStore` (the `.keras` path) and in the legacy topological and by-name weight loaders. Genuine weights, whose declared size is proportional to what is stored, are unaffected; a tiny file that declares gigabytes of array data is refused.

A regression test covers a file of several sub-floor datasets that each pass the per-dataset guard but are rejected cumulatively, plus a check that genuine saved weights are not rejected.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
