### PR TITLE
Reject decompression-bomb members on the .keras asset extraction path

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -471,6 +471,36 @@ def _safe_zip_read(archive, name):
         return f.read()
 
 
+# Extracting the asset store decompresses *every* archive member to disk via
+# `ZipFile.extractall`, which `_reject_zip_bomb` (used only for the in-memory
+# reads) never sees. Apply the same per-member declared-vs-stored ratio to every
+# member before extraction. Keras writes `.keras` members uncompressed
+# (ratio ~1), so the ratio is false-positive-free; the lower floor reflects that
+# this fills the disk rather than allocating a single in-memory buffer.
+_ZIP_EXTRACT_BOMB_FLOOR_BYTES = 1 << 28  # 256 MiB
+
+
+def _reject_zip_extract_bomb(archive):
+    """Raise if any ZIP member decompresses to far more than stored (CWE-409).
+
+    Uses the per-member ratio (not the aggregate) so a bomb member cannot be
+    diluted below the threshold by genuine weights stored alongside it.
+    """
+    if not isinstance(archive, zipfile.ZipFile):
+        return
+    for info in archive.infolist():
+        if (
+            info.file_size > _ZIP_EXTRACT_BOMB_FLOOR_BYTES
+            and info.file_size > _ZIP_MEMBER_MAX_EXPANSION * info.compress_size
+        ):
+            raise ValueError(
+                f"Not allowed: archive member '{info.filename}' declares "
+                f"{readable_memory_size(info.file_size)} but only "
+                f"{readable_memory_size(info.compress_size)} are stored on "
+                "disk; refusing to extract a potential decompression bomb."
+            )
+
+
 def _load_model_from_fileobj(fileobj, custom_objects, compile, safe_mode):
     with zipfile.ZipFile(fileobj, "r") as zf:
         config_json = _safe_zip_read(zf, _CONFIG_FILENAME)
@@ -1066,6 +1096,9 @@ class DiskIOStore:
         if self.archive:
             self.tmp_dir = get_temp_dir()
             if self.mode == "r":
+                # Reject a decompression bomb before extracting every member to
+                # disk (`_reject_zip_bomb` only guards the in-memory reads).
+                _reject_zip_extract_bomb(self.archive)
                 file_utils.extract_open_archive(self.archive, self.tmp_dir)
             self.working_dir = file_utils.join(
                 self.tmp_dir, self.root_path

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -471,12 +471,7 @@ def _safe_zip_read(archive, name):
         return f.read()
 
 
-# Extracting the asset store decompresses *every* archive member to disk via
-# `ZipFile.extractall`, which `_reject_zip_bomb` (used only for the in-memory
-# reads) never sees. Apply the same per-member declared-vs-stored ratio to every
-# member before extraction. Keras writes `.keras` members uncompressed
-# (ratio ~1), so the ratio is false-positive-free; the lower floor reflects that
-# this fills the disk rather than allocating a single in-memory buffer.
+# Lower floor than the in-memory guard: extraction fills the disk cumulatively.
 _ZIP_EXTRACT_BOMB_FLOOR_BYTES = 1 << 28  # 256 MiB
 
 
@@ -1096,8 +1091,6 @@ class DiskIOStore:
         if self.archive:
             self.tmp_dir = get_temp_dir()
             if self.mode == "r":
-                # Reject a decompression bomb before extracting every member to
-                # disk (`_reject_zip_bomb` only guards the in-memory reads).
                 _reject_zip_extract_bomb(self.archive)
                 file_utils.extract_open_archive(self.archive, self.tmp_dir)
             self.working_dir = file_utils.join(

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1714,6 +1714,31 @@ class SafeZipReadTest(testing.TestCase):
             with self.assertRaisesRegex(ValueError, "decompression bomb"):
                 saving_lib.load_model(evil)
 
+    def test_load_model_rejects_extraction_bomb(self):
+        # A >3-member archive triggers the disk-backed asset store, which
+        # extracts *every* member via `extractall`. `_reject_zip_bomb` only
+        # guards the in-memory reads, so a bomb member added here would be
+        # decompressed to disk unchecked; it must be rejected before extraction.
+        import keras
+
+        model = keras.Sequential([keras.Input((4,)), keras.layers.Dense(3)])
+        good = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(good)
+        with zipfile.ZipFile(good) as zf:
+            base = {n: zf.read(n) for n in zf.namelist()}
+
+        evil = os.path.join(self.get_temp_dir(), "evil.keras")
+        with zipfile.ZipFile(evil, "w") as zf:
+            for name, data in base.items():
+                zf.writestr(name, data)  # genuine members stored (ratio ~1)
+            info = zipfile.ZipInfo("assets/bomb.bin")
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, b"\x00" * 200_000)  # 4th member, deflated bomb
+
+        with mock.patch.object(saving_lib, "_ZIP_EXTRACT_BOMB_FLOOR_BYTES", 64):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                saving_lib.load_model(evil)
+
 
 class SafeGetH5DatasetTest(testing.TestCase):
     def _shape_bomb_file(self):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1715,12 +1715,6 @@ class SafeZipReadTest(testing.TestCase):
                 saving_lib.load_model(evil)
 
     def test_load_model_rejects_extraction_bomb(self):
-        # A >3-member archive triggers the disk-backed asset store, which
-        # extracts *every* member via `extractall`. `_reject_zip_bomb` only
-        # guards the in-memory reads, so a bomb member added here would be
-        # decompressed to disk unchecked; it must be rejected before extraction.
-        import keras
-
         model = keras.Sequential([keras.Input((4,)), keras.layers.Dense(3)])
         good = os.path.join(self.get_temp_dir(), "good.keras")
         model.save(good)


### PR DESCRIPTION
## Description

`keras.saving.load_model` guards `.keras` archives against decompression bombs with `_reject_zip_bomb`, but only on the three in-memory reads: `config.json`, `model.weights.h5`, and the sharded weight map. The asset-extraction path is not covered.

When a `.keras` archive has more than three members, the loader creates a disk-backed asset store (`DiskIOStore(..., archive=zf, mode="r")`). Its constructor calls `file_utils.extract_open_archive`, which runs `ZipFile.extractall` and decompresses **every** member of the archive to disk — including any attacker-added member — guarded only by a path-traversal filter, with no decompression-ratio check. A member that decompresses ~1000x its stored size (DEFLATE allows roughly that) therefore lands on disk in full. A few-hundred-KB archive can write hundreds of MB (scaling to hundreds of GB) to the victim's disk under the default `safe_mode=True`, exhausting it and taking down the host or co-located services. This is the extract-to-disk sibling of the in-memory decompression-bomb guard, on the path that guard did not reach.

This adds `_reject_zip_extract_bomb`, applied in `DiskIOStore.__init__` before extraction. It uses the same declared-vs-stored ratio as `_reject_zip_bomb`, checked **per member** (not on the aggregate, so a bomb member cannot be diluted below the threshold by genuine weights stored alongside it). Keras writes `.keras` members uncompressed (ratio ~1), so the ratio is false-positive-free; the floor is lower than the in-memory guard's because this fills the disk cumulatively rather than allocating a single buffer.

A regression test loads a `.keras` whose extra member decompresses far beyond its stored size and asserts it is rejected before extraction; the existing asset round-trip test confirms genuine models still load.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
