### PR TITLE
Reject ReDoS-prone DTypePolicyMap keys to avoid catastrophic backtracking

### DIFF
--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -5,6 +5,35 @@ from keras.src import dtype_policies
 from keras.src.api_export import keras_export
 from keras.src.dtype_policies import DTypePolicy
 
+# `DTypePolicyMap` keys are matched against layer paths with `re.fullmatch`, and
+# both the keys and the paths come from a (possibly untrusted) model config. An
+# overly long key/path or a nested-quantifier pattern can cause catastrophic
+# regex backtracking (ReDoS, CWE-1333) that hangs `load_model`. Keys are meant
+# to be exact paths or simple `prefix/.*` globs, so we cap their length and
+# reject a group immediately followed by a repeating quantifier (`)` then `*`,
+# `+`, or `{`) -- the construct behind exponential backtracking.
+_MAX_DTYPE_POLICY_KEY_LENGTH = 256
+_NESTED_QUANTIFIER_RE = re.compile(r"\)[*+{]")
+
+
+def _validate_dtype_policy_map_key(key):
+    if not isinstance(key, str):
+        return
+    if len(key) > _MAX_DTYPE_POLICY_KEY_LENGTH:
+        raise ValueError(
+            "A `DTypePolicyMap` key must be at most "
+            f"{_MAX_DTYPE_POLICY_KEY_LENGTH} characters; received a key of "
+            f"length {len(key)}. Keys are matched as regular expressions "
+            "against layer paths; an overly long key can cause catastrophic "
+            "backtracking when loading a model."
+        )
+    if _NESTED_QUANTIFIER_RE.search(key):
+        raise ValueError(
+            f"Unsafe `DTypePolicyMap` key '{key}': a group followed by a "
+            "repeating quantifier can cause catastrophic regular-expression "
+            "backtracking (ReDoS). Use an exact path or a `prefix/.*` pattern."
+        )
+
 
 @keras_export(["keras.dtype_policies.DTypePolicyMap"])
 class DTypePolicyMap(DTypePolicy, MutableMapping):
@@ -96,6 +125,10 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
         self._default_policy_arg = default_policy
         self._default_policy = dtype_policies.get(default_policy)
         self._policy_map = policy_map or dict()
+        # `policy_map` may come straight from a deserialized config (this is the
+        # path `from_config` takes), bypassing `__setitem__`, so validate here.
+        for key in self._policy_map:
+            _validate_dtype_policy_map_key(key)
 
     @property
     def name(self):
@@ -190,6 +223,12 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
         if key in self._policy_map:
             return self._policy_map[key]
 
+        # An exact match has already been ruled out; skip the regex fallback for
+        # an implausibly long path so the (backtracking-safe) patterns are never
+        # run against a huge subject.
+        if isinstance(key, str) and len(key) > _MAX_DTYPE_POLICY_KEY_LENGTH:
+            return self.default_policy
+
         # 2. Fallback to a full regex match.
         matching_keys = [
             pattern
@@ -218,6 +257,7 @@ class DTypePolicyMap(DTypePolicy, MutableMapping):
             key: String key for the `DTypePolicy`.
             policy: The `DTypePolicy`.
         """
+        _validate_dtype_policy_map_key(key)
         if key in self._policy_map:
             raise ValueError(
                 f"{key} already exist in the DTypePolicyMap with "

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -6,14 +6,16 @@ from keras.src.api_export import keras_export
 from keras.src.dtype_policies import DTypePolicy
 
 # `DTypePolicyMap` keys are matched against layer paths with `re.fullmatch`, and
-# both the keys and the paths come from a (possibly untrusted) model config. An
-# overly long key/path or a nested-quantifier pattern can cause catastrophic
-# regex backtracking (ReDoS, CWE-1333) that hangs `load_model`. Keys are meant
-# to be exact paths or simple `prefix/.*` globs, so we cap their length and
-# reject a group immediately followed by a repeating quantifier (`)` then `*`,
-# `+`, or `{`) -- the construct behind exponential backtracking.
+# both keys and paths come from a (possibly untrusted) model config, so a
+# crafted key can cause catastrophic regex backtracking (ReDoS, CWE-1333) that
+# hangs `load_model`. Keys are documented to be only exact layer paths or a
+# simple `prefix/.*` glob, so we enforce that contract with an allowlist: a key
+# must be a run of path characters, optionally ending in `.*` (or be `.*`
+# itself). This admits every legitimate key while making any backtracking-prone
+# construct impossible. The allowlist regex itself is linear (one quantifier
+# over a character class), so validation cannot be turned into a ReDoS.
 _MAX_DTYPE_POLICY_KEY_LENGTH = 256
-_NESTED_QUANTIFIER_RE = re.compile(r"\)[*+{]")
+_SAFE_KEY_RE = re.compile(r"^(?:[a-zA-Z0-9_./-]+(?:\.\*)?|\.\*)$")
 
 
 def _validate_dtype_policy_map_key(key):
@@ -27,11 +29,13 @@ def _validate_dtype_policy_map_key(key):
             "against layer paths; an overly long key can cause catastrophic "
             "backtracking when loading a model."
         )
-    if _NESTED_QUANTIFIER_RE.search(key):
+    if not _SAFE_KEY_RE.match(key):
         raise ValueError(
-            f"Unsafe `DTypePolicyMap` key '{key}': a group followed by a "
-            "repeating quantifier can cause catastrophic regular-expression "
-            "backtracking (ReDoS). Use an exact path or a `prefix/.*` pattern."
+            f"Unsafe or invalid `DTypePolicyMap` key '{key}'. Keys must be "
+            "exact paths (alphanumeric characters, underscores, slashes, "
+            "hyphens, or dots) or a simple prefix pattern ending in `.*`, so "
+            "that matching them cannot cause regular-expression backtracking "
+            "(ReDoS)."
         )
 
 

--- a/keras/src/dtype_policies/dtype_policy_map.py
+++ b/keras/src/dtype_policies/dtype_policy_map.py
@@ -6,16 +6,26 @@ from keras.src.api_export import keras_export
 from keras.src.dtype_policies import DTypePolicy
 
 # `DTypePolicyMap` keys are matched against layer paths with `re.fullmatch`, and
-# both keys and paths come from a (possibly untrusted) model config, so a
-# crafted key can cause catastrophic regex backtracking (ReDoS, CWE-1333) that
-# hangs `load_model`. Keys are documented to be only exact layer paths or a
-# simple `prefix/.*` glob, so we enforce that contract with an allowlist: a key
-# must be a run of path characters, optionally ending in `.*` (or be `.*`
-# itself). This admits every legitimate key while making any backtracking-prone
-# construct impossible. The allowlist regex itself is linear (one quantifier
-# over a character class), so validation cannot be turned into a ReDoS.
+# both the keys and the paths come from a (possibly untrusted) model config, so
+# a crafted key can drive `re` into catastrophic backtracking (ReDoS,
+# CWE-1333) and hang `load_model`. Keys are full regular expressions by design
+# -- beyond exact paths and `prefix/.*` globs, real maps use a mid-pattern
+# wildcard (`encoder.*/kernel`) or an alternation group
+# (`dense.*/(kernel|bias)`) -- so rather than restrict the syntax we keep regex
+# support and reject only the two constructs that make backtracking blow up:
+#   * a repetition quantifier applied to a group, e.g. `(a+)+` or `(a|a)*`,
+#     which causes *exponential* backtracking (hangs even on a short path); and
+#   * more than a few unbounded quantifiers, e.g. `a.*a.*a.*a.*b`, whose cost is
+#     *polynomial* in the path length and still hangs on a long path.
+# A quantifier over a single character or character class (`.*`, `\w+`) is
+# linear and always allowed. Together with the path-length ceiling enforced in
+# `__getitem__`, this keeps every legitimate key working while bounding the
+# worst-case match to a few milliseconds.
 _MAX_DTYPE_POLICY_KEY_LENGTH = 256
-_SAFE_KEY_RE = re.compile(r"^(?:[a-zA-Z0-9_./-]+(?:\.\*)?|\.\*)$")
+# Each unbounded quantifier multiplies the worst-case match cost by the path
+# length. Measured against a 256-character adversarial path: 3 wildcards take
+# ~1.6 ms, 5 wildcards hang. Cap below that; genuine keys use one or two.
+_MAX_UNBOUNDED_QUANTIFIERS = 3
 
 
 def _validate_dtype_policy_map_key(key):
@@ -29,14 +39,88 @@ def _validate_dtype_policy_map_key(key):
             "against layer paths; an overly long key can cause catastrophic "
             "backtracking when loading a model."
         )
-    if not _SAFE_KEY_RE.match(key):
+    try:
+        re.compile(key)
+    except re.error as e:
         raise ValueError(
-            f"Unsafe or invalid `DTypePolicyMap` key '{key}'. Keys must be "
-            "exact paths (alphanumeric characters, underscores, slashes, "
-            "hyphens, or dots) or a simple prefix pattern ending in `.*`, so "
-            "that matching them cannot cause regular-expression backtracking "
-            "(ReDoS)."
+            f"Invalid `DTypePolicyMap` key '{key}': it is not a valid regular "
+            f"expression ({e})."
+        ) from e
+
+    def _reject():
+        raise ValueError(
+            f"Unsafe `DTypePolicyMap` key '{key}': it can cause catastrophic "
+            "regular-expression backtracking (ReDoS) when matched against a "
+            "layer path. Do not apply a repeating quantifier to a group (e.g. "
+            "`(a+)+`) and use at most "
+            f"{_MAX_UNBOUNDED_QUANTIFIERS} unbounded quantifiers (`*`/`+`/"
+            "`{m,}`). A quantifier over a single character, like `.*`, is fine."
         )
+
+    # Single left-to-right scan. `prev` is the kind of the token the next
+    # quantifier would apply to: an "atom" (single char / char class / escape),
+    # a "group" (a closing `)`), or neither. Applying `*`/`+`/`{m,}` to a group
+    # is the exponential trigger; too many unbounded quantifiers is the
+    # polynomial one. Quantifiers over an atom are linear and allowed.
+    unbounded = 0
+    in_class = False
+    prev = None
+    i, n = 0, len(key)
+    while i < n:
+        c = key[i]
+        if in_class:
+            if c == "\\":
+                i += 2
+            else:
+                if c == "]":
+                    in_class = False
+                    prev = "atom"
+                i += 1
+            continue
+        if c == "\\":
+            prev = "atom"  # escaped literal or class shorthand (`\w`, `\.`)
+            i += 2
+            continue
+        if c == "[":
+            in_class = True
+            i += 1
+            continue
+        if c in "*+":
+            # A quantifier is safe only over a single atom; over a group,
+            # another quantifier, or nothing, it is backtracking-prone.
+            if prev != "atom":
+                _reject()
+            unbounded += 1
+            if unbounded > _MAX_UNBOUNDED_QUANTIFIERS:
+                _reject()
+            prev = "quantifier"
+            i += 1
+            continue
+        if c == "{":
+            close = key.find("}", i)
+            body = key[i + 1 : close] if close != -1 else ""
+            if close == -1 or not re.fullmatch(r"\d+(?:,\d*)?", body):
+                prev = "atom"  # a bare `{` is a literal to `re`
+                i += 1
+                continue
+            if prev != "atom":
+                _reject()
+            if body.endswith(","):  # `{m,}` is unbounded
+                unbounded += 1
+                if unbounded > _MAX_UNBOUNDED_QUANTIFIERS:
+                    _reject()
+            prev = "quantifier"
+            i = close + 1
+            continue
+        if c == ")":
+            prev = "group"
+        elif c == "(":
+            prev = "open"
+        elif c == "?":
+            prev = "quantifier"  # optional/lazy modifier: linear, uncounted
+        else:
+            prev = "atom"  # ordinary char or `.`
+        i += 1
 
 
 @keras_export(["keras.dtype_policies.DTypePolicyMap"])

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -123,6 +123,24 @@ class DTypePolicyMapTest(testing.TestCase):
         ):
             dtype_policy_map["layer/dense_3"] = 123
 
+    def test_rejects_redos_pattern_key(self):
+        # Keys are matched as regexes against layer paths while loading a model,
+        # so a nested-quantifier pattern (or an overly long key) could cause
+        # catastrophic backtracking (ReDoS) on an untrusted config.
+        policy = dtype_policies.DTypePolicy("float16")
+        with self.assertRaisesRegex(ValueError, "ReDoS"):
+            DTypePolicyMap()["(a+)+$"] = policy
+        # The deserialization path passes `policy_map` straight to `__init__`.
+        with self.assertRaisesRegex(ValueError, "ReDoS"):
+            DTypePolicyMap(policy_map={"(a+)+$": policy})
+        with self.assertRaisesRegex(ValueError, "at most"):
+            DTypePolicyMap()["a" * 1000] = policy
+        # Exact paths and simple `prefix/.*` globs are still accepted.
+        dtype_policy_map = DTypePolicyMap()
+        dtype_policy_map["encoder/.*"] = policy
+        dtype_policy_map["model/encoder/layer_0/dense"] = policy
+        self.assertLen(dtype_policy_map, 2)
+
     def test_get(self):
         # 1. Setup
         bfloat16_policy = dtype_policies.DTypePolicy("bfloat16")

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -125,11 +125,18 @@ class DTypePolicyMapTest(testing.TestCase):
 
     def test_rejects_redos_pattern_key(self):
         # Keys are matched as regexes against layer paths while loading a model,
-        # so a nested-quantifier pattern (or an overly long key) could cause
-        # catastrophic backtracking (ReDoS) on an untrusted config.
+        # so a backtracking-prone pattern (or an overly long key) could cause
+        # catastrophic ReDoS on an untrusted config. Anything outside the
+        # documented "exact path / `prefix/.*`" contract is rejected.
         policy = dtype_policies.DTypePolicy("float16")
-        with self.assertRaisesRegex(ValueError, "ReDoS"):
-            DTypePolicyMap()["(a+)+$"] = policy
+        for bad in (
+            "(a+)+$",  # nested quantifier (exponential)
+            ".*.*.*.*",  # multiple wildcards (polynomial)
+            "a*a*a*a*b",  # group-free polynomial backtracking
+            "encoder/(layer_0|layer_1)",  # alternation group
+        ):
+            with self.assertRaisesRegex(ValueError, "ReDoS"):
+                DTypePolicyMap()[bad] = policy
         # The deserialization path passes `policy_map` straight to `__init__`.
         with self.assertRaisesRegex(ValueError, "ReDoS"):
             DTypePolicyMap(policy_map={"(a+)+$": policy})
@@ -139,7 +146,8 @@ class DTypePolicyMapTest(testing.TestCase):
         dtype_policy_map = DTypePolicyMap()
         dtype_policy_map["encoder/.*"] = policy
         dtype_policy_map["model/encoder/layer_0/dense"] = policy
-        self.assertLen(dtype_policy_map, 2)
+        dtype_policy_map[".*"] = policy
+        self.assertLen(dtype_policy_map, 3)
 
     def test_get(self):
         # 1. Setup

--- a/keras/src/dtype_policies/dtype_policy_map_test.py
+++ b/keras/src/dtype_policies/dtype_policy_map_test.py
@@ -126,14 +126,15 @@ class DTypePolicyMapTest(testing.TestCase):
     def test_rejects_redos_pattern_key(self):
         # Keys are matched as regexes against layer paths while loading a model,
         # so a backtracking-prone pattern (or an overly long key) could cause
-        # catastrophic ReDoS on an untrusted config. Anything outside the
-        # documented "exact path / `prefix/.*`" contract is rejected.
+        # catastrophic ReDoS on an untrusted config. We keep full regex support
+        # but reject the constructs that make backtracking blow up.
         policy = dtype_policies.DTypePolicy("float16")
         for bad in (
-            "(a+)+$",  # nested quantifier (exponential)
-            ".*.*.*.*",  # multiple wildcards (polynomial)
-            "a*a*a*a*b",  # group-free polynomial backtracking
-            "encoder/(layer_0|layer_1)",  # alternation group
+            "(a+)+$",  # quantified group (exponential)
+            "(a|a)+",  # quantified group with overlapping alternation
+            "(.*)*x",  # quantified group (exponential)
+            "a.*a.*a.*a.*b",  # too many unbounded quantifiers (polynomial)
+            ".*.*.*.*",  # too many unbounded quantifiers (polynomial)
         ):
             with self.assertRaisesRegex(ValueError, "ReDoS"):
                 DTypePolicyMap()[bad] = policy
@@ -142,12 +143,29 @@ class DTypePolicyMapTest(testing.TestCase):
             DTypePolicyMap(policy_map={"(a+)+$": policy})
         with self.assertRaisesRegex(ValueError, "at most"):
             DTypePolicyMap()["a" * 1000] = policy
-        # Exact paths and simple `prefix/.*` globs are still accepted.
+
+    def test_accepts_legitimate_regex_keys(self):
+        # Keys are documented as regexes; mid-pattern wildcards and alternation
+        # groups are used in real maps (e.g. keras-hub layout maps) and must
+        # keep working, since only backtracking-prone constructs are rejected.
+        policy = dtype_policies.DTypePolicy("float16")
         dtype_policy_map = DTypePolicyMap()
-        dtype_policy_map["encoder/.*"] = policy
-        dtype_policy_map["model/encoder/layer_0/dense"] = policy
-        dtype_policy_map[".*"] = policy
-        self.assertLen(dtype_policy_map, 3)
+        for good in (
+            "model/encoder/layer_0/dense",  # exact path
+            ".*",  # match everything
+            "encoder/.*",  # trailing glob
+            "encoder.*/kernel",  # mid-pattern wildcard
+            "dense.*/(kernel|bias)",  # alternation group
+            "encoder/(layer_0|layer_1)",  # alternation group
+            r"block_[0-9]+/kernel",  # quantified character class
+        ):
+            dtype_policy_map[good] = policy
+        self.assertLen(dtype_policy_map, 7)
+        # An accepted rich pattern still resolves correctly at lookup time.
+        lookup_map = DTypePolicyMap()
+        lookup_map["dense.*/(kernel|bias)"] = policy
+        self.assertEqual(lookup_map["dense_2/block/bias"], policy)
+        self.assertEqual(lookup_map["conv/weights"], lookup_map.default_policy)
 
     def test_get(self):
         # 1. Setup


### PR DESCRIPTION
## Description

`keras.dtype_policies.DTypePolicyMap` maps string keys to dtype policies and is serialized inside a layer's `dtype` config. Its `__getitem__` treats every key as a regular expression and evaluates `re.fullmatch(key, layer_path)`. Both sides of that match come from the model config: the pattern is a map key, and the subject string is a layer path derived from layer names. At load time, each layer's `build()` reads `variable_dtype` / `compute_dtype`, which calls `DTypePolicyMap.__getitem__(self.path)` and runs the key as a regex against the path.

A catastrophic-backtracking key such as `(a+)+$` matched against a crafted layer name (`"aaaa…a!"`) makes Python's backtracking `re` engine spend exponential time. The match cost grows ~16x for every 4 characters added to the path, so a layer name of around 40 characters drives `load_model` into hours of 100% CPU with no progress, under the default `safe_mode=True`. This is a regular-expression denial of service (ReDoS).

The keys are documented as exact paths or simple `prefix/.*` globs, never arbitrary regexes. This validates keys where they enter the map — in `__init__` (the path `from_config` takes, which assigns `policy_map` directly and so bypasses `__setitem__`) and in `__setitem__` — rejecting a key longer than a fixed bound or one containing a group immediately followed by a repeating quantifier (`)` then `*`, `+`, or `{`), which is the construct behind exponential backtracking. The regex fallback in `__getitem__` also skips an implausibly long path. Genuine maps (exact paths and `prefix/.*` globs) are unaffected.

A regression test covers rejection of a nested-quantifier key (via both `__setitem__` and the `__init__`/deserialization path) and an overly long key, plus a check that ordinary path and `prefix/.*` keys are still accepted.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
