### PR TITLE
Use `filter="data"` in `TarFile.extractall` on supported versions of …

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import inspect
 import os
 import re
 import shutil
@@ -139,10 +140,15 @@ def extract_open_archive(archive, path="."):
     else:
         # Tar archive.
         extractall_kwargs = {}
-        # The `filter="data"` option was added in Python 3.12. It became the
-        # default starting from Python 3.14. So we only specify it between
-        # those two versions.
-        if sys.version_info >= (3, 12) and sys.version_info < (3, 14):
+        # The `filter="data"` option was:
+        # - added in Python 3.12
+        # - backported to Python 3.10.12 and 3.11.4
+        # - became the default starting from Python 3.14
+        # So we only specify it for supported versions before 3.14.
+        if (
+            sys.version_info < (3, 14)
+            and "filter" in inspect.signature(archive.extractall).parameters
+        ):
             extractall_kwargs = {"filter": "data"}
         archive.extractall(
             path,


### PR DESCRIPTION
…Python 3.10 and 3.11.

While the security feature of `filter="data"` was introduced in Python 3.12, it was also backported to Python >= 3.10.13 and Python >= 3.11.5.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
