### PR TITLE
Delete temp files after loading model from remote path.

### DIFF
--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -378,7 +378,7 @@ class Sequential(Model):
             raise ValueError(
                 "A Sequential model configuration must be "
                 "a dictionary containing the 'name' and "
-                "'layers' keys. Received: config={config}"
+                f"'layers' keys. Received: config={config}"
             )
         model = cls(name=name)
         for layer_config in layer_configs:

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import zipfile
 
 from absl import logging
@@ -165,69 +166,73 @@ def load_model(filepath, custom_objects=None, compile=True, safe_mode=True):
     )
     is_hf = str(filepath).startswith("hf://")
 
-    # Support for remote zip files
-    if (
-        file_utils.is_remote_path(filepath)
-        and not file_utils.isdir(filepath)
-        and not is_keras_zip
-        and not is_hf
-    ):
-        local_path = file_utils.join(
-            saving_lib.get_temp_dir(), os.path.basename(filepath)
-        )
+    tmp_dir = None
+    try:
+        # Support for remote zip files
+        if (
+            file_utils.is_remote_path(filepath)
+            and not file_utils.isdir(filepath)
+            and not is_keras_zip
+            and not is_hf
+        ):
+            tmp_dir = saving_lib.get_temp_dir()
+            local_path = file_utils.join(tmp_dir, os.path.basename(filepath))
 
-        # Copy from remote to temporary local directory
-        file_utils.copy(filepath, local_path)
+            # Copy from remote to temporary local directory
+            file_utils.copy(filepath, local_path)
 
-        # Switch filepath to local zipfile for loading model
-        if zipfile.is_zipfile(local_path):
-            filepath = local_path
-            is_keras_zip = True
+            # Switch filepath to local zipfile for loading model
+            if zipfile.is_zipfile(local_path):
+                filepath = local_path
+                is_keras_zip = True
 
-    if is_keras_zip or is_keras_dir or is_hf:
-        return saving_lib.load_model(
-            filepath,
-            custom_objects=custom_objects,
-            compile=compile,
-            safe_mode=safe_mode,
-        )
-    if str(filepath).endswith((".h5", ".hdf5")):
-        return legacy_h5_format.load_model_from_hdf5(
-            filepath,
-            custom_objects=custom_objects,
-            compile=compile,
-            safe_mode=safe_mode,
-        )
+        if is_keras_zip or is_keras_dir or is_hf:
+            return saving_lib.load_model(
+                filepath,
+                custom_objects=custom_objects,
+                compile=compile,
+                safe_mode=safe_mode,
+            )
+        if str(filepath).endswith((".h5", ".hdf5")):
+            return legacy_h5_format.load_model_from_hdf5(
+                filepath,
+                custom_objects=custom_objects,
+                compile=compile,
+                safe_mode=safe_mode,
+            )
 
-    # Check for Orbax checkpoint directory using utility function
-    if is_orbax_checkpoint(filepath):
-        return _load_model_from_orbax_checkpoint(
-            filepath,
-            custom_objects=custom_objects,
-            compile=compile,
-            safe_mode=safe_mode,
-        )
+        # Check for Orbax checkpoint directory using utility function
+        if is_orbax_checkpoint(filepath):
+            return _load_model_from_orbax_checkpoint(
+                filepath,
+                custom_objects=custom_objects,
+                compile=compile,
+                safe_mode=safe_mode,
+            )
 
-    elif str(filepath).endswith(".keras"):
-        raise ValueError(
-            f"File not found: filepath={filepath}. "
-            "Please ensure the file is an accessible `.keras` "
-            "zip file."
-        )
-    else:
-        raise ValueError(
-            f"File format not supported: filepath={filepath}. "
-            "Keras 3 only supports V3 `.keras` files, "
-            "legacy H5 format files (`.h5` extension). "
-            "Note that the legacy SavedModel format is not "
-            "supported by `load_model()` in Keras 3. In "
-            "order to reload a TensorFlow SavedModel as an "
-            "inference-only layer in Keras 3, use "
-            "`keras.layers.TFSMLayer("
-            f"{filepath}, call_endpoint='serving_default')` "
-            "(note that your `call_endpoint` "
-            "might have a different name)."
-        )
+        elif str(filepath).endswith(".keras"):
+            raise ValueError(
+                f"File not found: filepath={filepath}. "
+                "Please ensure the file is an accessible `.keras` "
+                "zip file."
+            )
+        else:
+            raise ValueError(
+                f"File format not supported: filepath={filepath}. "
+                "Keras 3 only supports V3 `.keras` files, "
+                "legacy H5 format files (`.h5` extension). "
+                "Note that the legacy SavedModel format is not "
+                "supported by `load_model()` in Keras 3. In "
+                "order to reload a TensorFlow SavedModel as an "
+                "inference-only layer in Keras 3, use "
+                "`keras.layers.TFSMLayer("
+                f"{filepath}, call_endpoint='serving_default')` "
+                "(note that your `call_endpoint` "
+                "might have a different name)."
+            )
+    finally:
+        if tmp_dir is not None:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 @keras_export("keras.saving.save_weights")

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -605,7 +605,7 @@ def save_weights_only(
     finally:
         if tmp_dir is not None:
             file_utils.copy(filepath, remote_filepath)
-            shutil.rmtree(tmp_dir)
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def load_weights_only(
@@ -667,7 +667,7 @@ def load_weights_only(
             _raise_loading_failure(error_msgs, warn_only=skip_mismatch)
     finally:
         if tmp_dir is not None:
-            shutil.rmtree(tmp_dir)
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def _raise_loading_failure(error_msgs, warn_only=False):


### PR DESCRIPTION
The temporary files created after downloading the remote model were not deleted.

Note that this cleanup was already done correctly in `load_weights`.

Also ignore errors when deleting a temporary folder.

Tested locally.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
