### PR TITLE
[Fix] Torch random.shuffle(axis=-1) mishandles negative axes

### DIFF
--- a/keras/src/backend/torch/random.py
+++ b/keras/src/backend/torch/random.py
@@ -2,6 +2,7 @@ import torch
 import torch._dynamo as dynamo
 import torch.nn.functional as tnn
 
+from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.config import floatx
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import get_device
@@ -176,6 +177,8 @@ def dropout(inputs, rate, noise_shape=None, seed=None):
 def shuffle(x, axis=0, seed=None):
     # Ref: https://github.com/pytorch/pytorch/issues/71409
     x = convert_to_tensor(x)
+
+    axis = canonicalize_axis(axis, x.ndim)
 
     # Get permutation indices
     # Do not use generator during symbolic execution.

--- a/keras/src/random/random_test.py
+++ b/keras/src/random/random_test.py
@@ -185,6 +185,13 @@ class RandomCorrectnessTest(testing.TestCase):
         self.assertAllClose(np.sum(x, axis=1), ops.sum(y, axis=1))
         self.assertNotAllClose(np.sum(x, axis=0), ops.sum(y, axis=0))
 
+        # Test axis=-1
+        y = random.shuffle(x, axis=-1, seed=0)
+
+        self.assertFalse(np.all(x == ops.convert_to_numpy(y)))
+        self.assertAllClose(np.sum(x, axis=-1), ops.sum(y, axis=-1))
+        self.assertNotAllClose(np.sum(x, axis=0), ops.sum(y, axis=0))
+
     @parameterized.parameters(
         {"seed": 10, "shape": (5, 2), "alpha": 2.0, "dtype": "float16"},
         {"seed": 10, "shape": (2,), "alpha": 1.5, "dtype": "float32"},


### PR DESCRIPTION
## Description
Fixes: #23118 
axis now goes through canonicalize_axis(). Added a small test for axis=-1.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
