### PR TITLE
feat(layers): add RandomApply and RandomChoice preprocessing wrappers

### DIFF
--- a/keras/api/_tf_keras/keras/layers/__init__.py
+++ b/keras/api/_tf_keras/keras/layers/__init__.py
@@ -304,6 +304,12 @@ from keras.src.layers.preprocessing.normalization import (
     Normalization as Normalization,
 )
 from keras.src.layers.preprocessing.pipeline import Pipeline as Pipeline
+from keras.src.layers.preprocessing.random_apply import (
+    RandomApply as RandomApply,
+)
+from keras.src.layers.preprocessing.random_choice import (
+    RandomChoice as RandomChoice,
+)
 from keras.src.layers.preprocessing.rescaling import Rescaling as Rescaling
 from keras.src.layers.preprocessing.stft_spectrogram import (
     STFTSpectrogram as STFTSpectrogram,

--- a/keras/api/layers/__init__.py
+++ b/keras/api/layers/__init__.py
@@ -304,6 +304,12 @@ from keras.src.layers.preprocessing.normalization import (
     Normalization as Normalization,
 )
 from keras.src.layers.preprocessing.pipeline import Pipeline as Pipeline
+from keras.src.layers.preprocessing.random_apply import (
+    RandomApply as RandomApply,
+)
+from keras.src.layers.preprocessing.random_choice import (
+    RandomChoice as RandomChoice,
+)
 from keras.src.layers.preprocessing.rescaling import Rescaling as Rescaling
 from keras.src.layers.preprocessing.stft_spectrogram import (
     STFTSpectrogram as STFTSpectrogram,

--- a/keras/src/layers/__init__.py
+++ b/keras/src/layers/__init__.py
@@ -187,6 +187,8 @@ from keras.src.layers.preprocessing.integer_lookup import IntegerLookup
 from keras.src.layers.preprocessing.mel_spectrogram import MelSpectrogram
 from keras.src.layers.preprocessing.normalization import Normalization
 from keras.src.layers.preprocessing.pipeline import Pipeline
+from keras.src.layers.preprocessing.random_apply import RandomApply
+from keras.src.layers.preprocessing.random_choice import RandomChoice
 from keras.src.layers.preprocessing.rescaling import Rescaling
 from keras.src.layers.preprocessing.stft_spectrogram import STFTSpectrogram
 from keras.src.layers.preprocessing.string_lookup import StringLookup

--- a/keras/src/layers/preprocessing/random_apply.py
+++ b/keras/src/layers/preprocessing/random_apply.py
@@ -1,0 +1,84 @@
+from keras.src import ops
+from keras.src import random
+from keras.src.api_export import keras_export
+from keras.src.layers.layer import Layer
+from keras.src.random.seed_generator import SeedGenerator
+from keras.src.saving import serialization_lib
+
+
+@keras_export("keras.layers.RandomApply")
+class RandomApply(Layer):
+    """Apply a wrapped layer to the input with a given probability.
+
+    During training, on each call this layer flips a single Bernoulli coin: with
+    probability `rate` it applies the wrapped `layer`, otherwise it passes the
+    input through unchanged. The decision is batch-wide — the same coin flip is
+    used for every sample in the batch — which keeps the layer compatible with
+    a `tf.data` or `grain` pipeline.
+
+    During inference (`training=False`) the layer is always a no-op.
+
+    Args:
+        layer: A Keras `Layer` to apply with probability `rate`. Typically a
+            preprocessing layer, but any layer that accepts the same input
+            shape and emits a same-shape output will work.
+        rate: Float in `[0, 1]`. Probability of applying the wrapped layer.
+            Defaults to `0.5`.
+        seed: Optional integer. Random seed used for the Bernoulli draw.
+
+    Example:
+
+    ```python
+    augmenter = keras.layers.RandomApply(
+        keras.layers.RandomFlip("horizontal"), rate=0.3
+    )
+    ```
+    """
+
+    def __init__(self, layer, rate=0.5, seed=None, **kwargs):
+        super().__init__(**kwargs)
+        if not isinstance(layer, Layer):
+            raise TypeError(
+                "`layer` must be a Keras `Layer` instance. "
+                f"Received: layer={layer} of type {type(layer)}"
+            )
+        if not 0.0 <= float(rate) <= 1.0:
+            raise ValueError(
+                f"`rate` must be a float in `[0, 1]`. Received: rate={rate}"
+            )
+        self.layer = layer
+        self.rate = float(rate)
+        self.seed = seed
+        self.generator = SeedGenerator(seed)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    def call(self, inputs, training=True):
+        if not training:
+            return inputs
+
+        transformed = self.layer(inputs, training=training)
+        u = random.uniform(
+            shape=(), minval=0.0, maxval=1.0, seed=self.generator
+        )
+        should_apply = ops.less(u, self.rate)
+        return ops.where(should_apply, transformed, inputs)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "layer": serialization_lib.serialize_keras_object(self.layer),
+                "rate": self.rate,
+                "seed": self.seed,
+            }
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        config = {**config}
+        config["layer"] = serialization_lib.deserialize_keras_object(
+            config["layer"], custom_objects=custom_objects
+        )
+        return cls(**config)

--- a/keras/src/layers/preprocessing/random_apply.py
+++ b/keras/src/layers/preprocessing/random_apply.py
@@ -58,11 +58,17 @@ class RandomApply(Layer):
             return inputs
 
         transformed = self.layer(inputs, training=training)
+        # Stack [transformed, inputs] along a new leading axis and gather the
+        # one selected by the Bernoulli draw. The gather-based selection
+        # avoids relying on `ops.where` with a scalar mask broadcasting
+        # against an N-D tensor — behavior of which is uneven across backends.
+        stacked = ops.stack([transformed, inputs], axis=0)
         u = random.uniform(
-            shape=(), minval=0.0, maxval=1.0, seed=self.generator
+            shape=(1,), minval=0.0, maxval=1.0, seed=self.generator
         )
-        should_apply = ops.less(u, self.rate)
-        return ops.where(should_apply, transformed, inputs)
+        # 0 -> apply transformed, 1 -> skip (return inputs).
+        idx = ops.cast(ops.greater_equal(u, self.rate), "int32")
+        return ops.take(stacked, idx, axis=0)[0]
 
     def get_config(self):
         config = super().get_config()

--- a/keras/src/layers/preprocessing/random_apply.py
+++ b/keras/src/layers/preprocessing/random_apply.py
@@ -1,3 +1,4 @@
+from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
 from keras.src.layers.preprocessing.data_layer import DataLayer
@@ -57,19 +58,37 @@ class RandomApply(DataLayer):
         if not training:
             return inputs
 
-        transformed = self.layer(inputs, training=training)
+        # Snapshot the input structure before invoking the wrapped layer. The
+        # image preprocessing layers rebind keys on the structure they are
+        # given and return that same object, so without a snapshot both
+        # branches of the selection below would observe augmented values and
+        # `rate=0.0` would not be a strict pass-through. The wrapped layer
+        # gets its own copy so the caller's structure is left untouched.
+        original = tree.map_structure(lambda x: x, inputs)
+        transformed = self.layer(
+            tree.map_structure(lambda x: x, inputs), training=training
+        )
+
         seed = self._get_seed_generator(self.backend._backend)
         u = self.backend.random.uniform(
             shape=(1,), minval=0.0, maxval=1.0, seed=seed
         )
-        # Stack [transformed, inputs] along a new leading axis and gather the
-        # one selected by the Bernoulli draw.
         # 0 -> apply transformed, 1 -> skip (return inputs).
         idx = self.backend.cast(
             self.backend.numpy.greater_equal(u, self.rate), "int32"
         )
-        stacked = self.backend.numpy.stack([transformed, inputs], axis=0)
-        return self.backend.numpy.take(stacked, idx, axis=0)[0]
+
+        def _select(transformed_leaf, original_leaf):
+            # Stack [transformed, original] along a new leading axis and
+            # gather the one selected by the Bernoulli draw. The same `idx` is
+            # used for every leaf, so a structured input is either fully
+            # augmented or fully passed through.
+            stacked = self.backend.numpy.stack(
+                [transformed_leaf, original_leaf], axis=0
+            )
+            return self.backend.numpy.take(stacked, idx, axis=0)[0]
+
+        return tree.map_structure(_select, transformed, original)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/random_apply.py
+++ b/keras/src/layers/preprocessing/random_apply.py
@@ -6,6 +6,31 @@ from keras.src.random.seed_generator import SeedGenerator
 from keras.src.saving import serialization_lib
 
 
+def _check_same_shape(shape, reference_shape, description):
+    """Raise if a wrapped layer changed the shape of a leaf.
+
+    Only statically-known dimensions are compared, so a dynamic batch axis
+    under `tf.data` or a symbolic build does not trip the check.
+    """
+    if shape is None or reference_shape is None:
+        return
+    shape = tuple(shape)
+    reference_shape = tuple(reference_shape)
+    mismatch = len(shape) != len(reference_shape) or any(
+        d is not None and r is not None and d != r
+        for d, r in zip(shape, reference_shape)
+    )
+    if mismatch:
+        raise ValueError(
+            f"{description} must emit an output with the same shape as its "
+            f"input, because the output is selected element-wise against the "
+            f"unmodified input. Received an input of shape {reference_shape} "
+            f"and an output of shape {shape}. Layers that change the shape of "
+            f"their input, such as `Resizing` or `Cropping2D`, cannot be "
+            f"wrapped."
+        )
+
+
 @keras_export("keras.layers.RandomApply")
 class RandomApply(DataLayer):
     """Apply a wrapped layer to the input with a given probability.
@@ -79,6 +104,11 @@ class RandomApply(DataLayer):
         )
 
         def _select(transformed_leaf, original_leaf):
+            _check_same_shape(
+                getattr(transformed_leaf, "shape", None),
+                getattr(original_leaf, "shape", None),
+                f"The wrapped layer `{self.layer.__class__.__name__}`",
+            )
             # Stack [transformed, original] along a new leading axis and
             # gather the one selected by the Bernoulli draw. The same `idx` is
             # used for every leaf, so a structured input is either fully

--- a/keras/src/layers/preprocessing/random_apply.py
+++ b/keras/src/layers/preprocessing/random_apply.py
@@ -1,22 +1,24 @@
-from keras.src import ops
-from keras.src import random
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
+from keras.src.layers.preprocessing.data_layer import DataLayer
 from keras.src.random.seed_generator import SeedGenerator
 from keras.src.saving import serialization_lib
 
 
 @keras_export("keras.layers.RandomApply")
-class RandomApply(Layer):
+class RandomApply(DataLayer):
     """Apply a wrapped layer to the input with a given probability.
 
-    During training, on each call this layer flips a single Bernoulli coin: with
-    probability `rate` it applies the wrapped `layer`, otherwise it passes the
-    input through unchanged. The decision is batch-wide — the same coin flip is
-    used for every sample in the batch — which keeps the layer compatible with
-    a `tf.data` or `grain` pipeline.
+    During training, on each call this layer flips a single Bernoulli coin:
+    with probability `rate` it applies the wrapped `layer`, otherwise it passes
+    the input through unchanged. The decision is batch-wide — the same coin
+    flip is used for every sample in the batch.
 
     During inference (`training=False`) the layer is always a no-op.
+
+    Note that the wrapped layer is evaluated on every training call, including
+    the calls where its output is discarded. The `rate` argument controls which
+    result is returned, not whether the work is done.
 
     Args:
         layer: A Keras `Layer` to apply with probability `rate`. Typically a
@@ -50,25 +52,27 @@ class RandomApply(Layer):
         self.rate = float(rate)
         self.seed = seed
         self.generator = SeedGenerator(seed)
-        self._convert_input_args = False
-        self._allow_non_tensor_positional_args = True
 
     def call(self, inputs, training=True):
         if not training:
             return inputs
 
         transformed = self.layer(inputs, training=training)
-        # Stack [transformed, inputs] along a new leading axis and gather the
-        # one selected by the Bernoulli draw. The gather-based selection
-        # avoids relying on `ops.where` with a scalar mask broadcasting
-        # against an N-D tensor — behavior of which is uneven across backends.
-        stacked = ops.stack([transformed, inputs], axis=0)
-        u = random.uniform(
-            shape=(1,), minval=0.0, maxval=1.0, seed=self.generator
+        seed = self._get_seed_generator(self.backend._backend)
+        u = self.backend.random.uniform(
+            shape=(1,), minval=0.0, maxval=1.0, seed=seed
         )
+        # Stack [transformed, inputs] along a new leading axis and gather the
+        # one selected by the Bernoulli draw.
         # 0 -> apply transformed, 1 -> skip (return inputs).
-        idx = ops.cast(ops.greater_equal(u, self.rate), "int32")
-        return ops.take(stacked, idx, axis=0)[0]
+        idx = self.backend.cast(
+            self.backend.numpy.greater_equal(u, self.rate), "int32"
+        )
+        stacked = self.backend.numpy.stack([transformed, inputs], axis=0)
+        return self.backend.numpy.take(stacked, idx, axis=0)[0]
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
 
     def get_config(self):
         config = super().get_config()

--- a/keras/src/layers/preprocessing/random_apply_test.py
+++ b/keras/src/layers/preprocessing/random_apply_test.py
@@ -1,0 +1,81 @@
+import numpy as np
+
+from keras.src import backend
+from keras.src import layers
+from keras.src import testing
+from keras.src.layers.preprocessing.random_apply import RandomApply
+from keras.src.saving import serialization_lib
+
+
+class _AddOne(layers.Layer):
+    """Deterministic helper: adds 1.0 to its input."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    def call(self, inputs, training=True):
+        return inputs + 1.0
+
+
+class RandomApplyTest(testing.TestCase):
+    def test_rejects_non_layer(self):
+        with self.assertRaisesRegex(TypeError, "Keras `Layer`"):
+            RandomApply(lambda x: x)
+
+    def test_rejects_invalid_rate(self):
+        with self.assertRaisesRegex(ValueError, "rate"):
+            RandomApply(_AddOne(), rate=1.5)
+        with self.assertRaisesRegex(ValueError, "rate"):
+            RandomApply(_AddOne(), rate=-0.1)
+
+    def test_inference_is_noop(self):
+        # training=False should always pass through regardless of `rate`.
+        layer = RandomApply(_AddOne(), rate=1.0, seed=0)
+        x = np.ones((4, 3, 3, 1), dtype="float32")
+        out = backend.convert_to_numpy(layer(x, training=False))
+        self.assertAllClose(out, x)
+
+    def test_rate_one_always_applies(self):
+        layer = RandomApply(_AddOne(), rate=1.0, seed=42)
+        x = np.zeros((4, 3, 3, 1), dtype="float32")
+        out = backend.convert_to_numpy(layer(x, training=True))
+        self.assertAllClose(out, np.ones_like(x))
+
+    def test_rate_zero_never_applies(self):
+        layer = RandomApply(_AddOne(), rate=0.0, seed=42)
+        x = np.zeros((4, 3, 3, 1), dtype="float32")
+        out = backend.convert_to_numpy(layer(x, training=True))
+        self.assertAllClose(out, x)
+
+    def test_rate_half_mixes(self):
+        # With many independent calls and rate=0.5, both branches should fire.
+        layer = RandomApply(_AddOne(), rate=0.5, seed=0)
+        x = np.zeros((1, 1, 1, 1), dtype="float32")
+        outs = [
+            backend.convert_to_numpy(layer(x, training=True)).item()
+            for _ in range(100)
+        ]
+        seen_apply = any(v == 1.0 for v in outs)
+        seen_skip = any(v == 0.0 for v in outs)
+        self.assertTrue(seen_apply, "rate=0.5 should sometimes apply")
+        self.assertTrue(seen_skip, "rate=0.5 should sometimes skip")
+
+    def test_serialization_roundtrip(self):
+        layer = RandomApply(_AddOne(), rate=0.3, seed=7)
+        config = serialization_lib.serialize_keras_object(layer)
+        revived = serialization_lib.deserialize_keras_object(
+            config, custom_objects={"_AddOne": _AddOne}
+        )
+        self.assertEqual(revived.rate, 0.3)
+        self.assertEqual(revived.seed, 7)
+        self.assertIsInstance(revived.layer, _AddOne)
+
+    def test_wraps_a_preprocessing_layer(self):
+        # End-to-end: wrap RandomFlip and confirm it still produces shape-
+        # preserving outputs.
+        layer = RandomApply(layers.RandomFlip("horizontal"), rate=0.5, seed=0)
+        x = np.random.uniform(size=(2, 4, 4, 3)).astype("float32")
+        out = backend.convert_to_numpy(layer(x, training=True))
+        self.assertEqual(out.shape, x.shape)

--- a/keras/src/layers/preprocessing/random_apply_test.py
+++ b/keras/src/layers/preprocessing/random_apply_test.py
@@ -1,4 +1,8 @@
+import os
+
 import numpy as np
+import pytest
+from tensorflow import data as tf_data
 
 import keras
 from keras.src import backend
@@ -161,3 +165,78 @@ class RandomApplyTest(testing.TestCase):
         model = keras.Model(inputs, outputs)
         x = np.random.uniform(size=(4, 8, 8, 3)).astype("float32")
         self.assertEqual(model.predict(x, verbose=0).shape, (4, 8, 8, 3))
+
+    def test_layer_basics(self):
+        self.run_layer_test(
+            RandomApply,
+            init_kwargs={"layer": _AddOne(), "rate": 0.5, "seed": 0},
+            input_shape=(2, 3),
+            expected_output_shape=(2, 3),
+            expected_num_trainable_weights=0,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=1,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
+    def test_tf_data_compatibility(self):
+        # The layer must run inside a tf.data pipeline on every backend, not
+        # just TensorFlow. This is the regression guard for the wrapper being
+        # a plain `Layer` rather than a `DataLayer`.
+        layer = RandomApply(
+            layers.RandomFlip("horizontal", seed=42), rate=1.0, seed=42
+        )
+        input_data = np.random.uniform(size=(4, 8, 8, 3)).astype("float32")
+        ds = (
+            tf_data.Dataset.from_tensor_slices(input_data)
+            .batch(2)
+            .map(lambda x: layer(x, training=True))
+        )
+        for batch in ds:
+            self.assertEqual(tuple(batch.shape), (2, 8, 8, 3))
+
+    def test_saved_model_roundtrip(self):
+        inputs = keras.Input((8, 8, 3))
+        outputs = RandomApply(
+            layers.RandomFlip("horizontal"), rate=0.3, seed=11
+        )(inputs)
+        model = keras.Model(inputs, outputs)
+        path = os.path.join(self.get_temp_dir(), "random_apply.keras")
+        model.save(path)
+        restored = keras.saving.load_model(path)
+        layer = restored.layers[-1]
+        self.assertIsInstance(layer, RandomApply)
+        self.assertEqual(layer.rate, 0.3)
+        self.assertEqual(layer.seed, 11)
+        self.assertIsInstance(layer.layer, layers.RandomFlip)
+        x = np.random.uniform(size=(2, 8, 8, 3)).astype("float32")
+        self.assertEqual(restored.predict(x, verbose=0).shape, (2, 8, 8, 3))
+
+    @pytest.mark.requires_trainable_backend
+    def test_fit(self):
+        inputs = keras.Input((4,))
+        x = RandomApply(_AddOne(), rate=0.5, seed=0)(inputs)
+        outputs = layers.Dense(1)(x)
+        model = keras.Model(inputs, outputs)
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(
+            np.random.uniform(size=(8, 4)).astype("float32"),
+            np.random.uniform(size=(8, 1)).astype("float32"),
+            epochs=1,
+            batch_size=4,
+            verbose=0,
+        )
+
+    def test_output_dtype_follows_compute_dtype(self):
+        # A float64 input must come back as the layer's compute dtype, the
+        # same contract the other preprocessing layers follow.
+        x = np.ones((2, 2, 2, 3), dtype="float64")
+        layer = RandomApply(layers.Rescaling(1.0), rate=1.0, seed=0)
+        out = layer(x, training=True)
+        self.assertEqual(
+            backend.standardize_dtype(out.dtype), layer.compute_dtype
+        )
+        self.assertEqual(
+            backend.standardize_dtype(out.dtype),
+            backend.standardize_dtype(layers.Rescaling(1.0)(x).dtype),
+        )

--- a/keras/src/layers/preprocessing/random_apply_test.py
+++ b/keras/src/layers/preprocessing/random_apply_test.py
@@ -79,3 +79,64 @@ class RandomApplyTest(testing.TestCase):
         x = np.random.uniform(size=(2, 4, 4, 3)).astype("float32")
         out = backend.convert_to_numpy(layer(x, training=True))
         self.assertEqual(out.shape, x.shape)
+
+    def _bbox_data(self):
+        return {
+            "images": np.random.uniform(size=(2, 8, 8, 3)).astype("float32"),
+            "bounding_boxes": {
+                "boxes": np.array(
+                    [[[0.0, 0.0, 4.0, 4.0]], [[1.0, 1.0, 5.0, 5.0]]],
+                    dtype="float32",
+                ),
+                "labels": np.array([[0], [1]], dtype="float32"),
+            },
+        }
+
+    def test_dict_input_with_bounding_boxes(self):
+        # A wrapped image preprocessing layer accepts a dict of images and
+        # bounding boxes; the wrapper must pass the structure through rather
+        # than assuming a single tensor.
+        layer = RandomApply(
+            layers.RandomFlip("horizontal", bounding_box_format="xyxy"),
+            rate=1.0,
+            seed=0,
+        )
+        out = layer(self._bbox_data(), training=True)
+        self.assertIsInstance(out, dict)
+        self.assertEqual(sorted(out.keys()), ["bounding_boxes", "images"])
+        self.assertEqual(
+            backend.convert_to_numpy(out["images"]).shape, (2, 8, 8, 3)
+        )
+        self.assertEqual(
+            backend.convert_to_numpy(out["bounding_boxes"]["boxes"]).shape,
+            (2, 1, 4),
+        )
+
+    def test_rate_zero_is_strict_passthrough_for_dict_input(self):
+        # `BaseImagePreprocessingLayer` rebinds keys on the dict it is given
+        # and returns that same object, so a naive select would compare the
+        # augmented values against themselves and let augmentation leak
+        # through at rate=0.0.
+        for seed in range(8):
+            data = self._bbox_data()
+            expected = data["images"].copy()
+            layer = RandomApply(
+                layers.RandomFlip("horizontal", bounding_box_format="xyxy"),
+                rate=0.0,
+                seed=seed,
+            )
+            out = layer(data, training=True)
+            self.assertAllClose(
+                backend.convert_to_numpy(out["images"]), expected
+            )
+
+    def test_does_not_mutate_caller_structure(self):
+        data = self._bbox_data()
+        expected = data["images"].copy()
+        layer = RandomApply(
+            layers.RandomFlip("horizontal", bounding_box_format="xyxy"),
+            rate=1.0,
+            seed=3,
+        )
+        layer(data, training=True)
+        self.assertAllClose(data["images"], expected)

--- a/keras/src/layers/preprocessing/random_apply_test.py
+++ b/keras/src/layers/preprocessing/random_apply_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import keras
 from keras.src import backend
 from keras.src import layers
 from keras.src import testing
@@ -140,3 +141,23 @@ class RandomApplyTest(testing.TestCase):
         )
         layer(data, training=True)
         self.assertAllClose(data["images"], expected)
+
+    def test_rejects_shape_changing_layer(self):
+        # The wrapped output is selected against the unmodified input, so a
+        # layer that resizes its input cannot be wrapped. Without an explicit
+        # check this surfaces as a raw backend error from the stack op.
+        layer = RandomApply(layers.Resizing(2, 2), rate=0.5, seed=0)
+        x = np.random.uniform(size=(2, 4, 4, 3)).astype("float32")
+        with self.assertRaisesRegex(ValueError, "same shape as its input"):
+            layer(x, training=True)
+
+    def test_dynamic_batch_dim_is_not_a_shape_mismatch(self):
+        # The check must compare only statically-known dimensions, or a
+        # symbolic build with an unknown batch axis would raise.
+        inputs = keras.Input((8, 8, 3))
+        outputs = RandomApply(
+            layers.RandomFlip("horizontal"), rate=0.5, seed=0
+        )(inputs)
+        model = keras.Model(inputs, outputs)
+        x = np.random.uniform(size=(4, 8, 8, 3)).astype("float32")
+        self.assertEqual(model.predict(x, verbose=0).shape, (4, 8, 8, 3))

--- a/keras/src/layers/preprocessing/random_choice.py
+++ b/keras/src/layers/preprocessing/random_choice.py
@@ -64,15 +64,18 @@ class RandomChoice(Layer):
             return inputs
 
         n = len(self._wrapped_layers)
+        # Stack all candidate outputs along a new leading axis and gather the
+        # one selected by `choice`. This avoids relying on `ops.where` with a
+        # scalar mask broadcasting against an N-D tensor — which is uneven
+        # across backends.
+        candidates = [
+            layer(inputs, training=training) for layer in self._wrapped_layers
+        ]
+        stacked = ops.stack(candidates, axis=0)
         choice = random.randint(
-            shape=(), minval=0, maxval=n, seed=self.generator
+            shape=(1,), minval=0, maxval=n, seed=self.generator
         )
-
-        result = inputs
-        for i, layer in enumerate(self._wrapped_layers):
-            transformed = layer(inputs, training=training)
-            result = ops.where(ops.equal(choice, i), transformed, result)
-        return result
+        return ops.take(stacked, choice, axis=0)[0]
 
     def get_config(self):
         config = super().get_config()

--- a/keras/src/layers/preprocessing/random_choice.py
+++ b/keras/src/layers/preprocessing/random_choice.py
@@ -1,0 +1,99 @@
+from keras.src import ops
+from keras.src import random
+from keras.src.api_export import keras_export
+from keras.src.layers.layer import Layer
+from keras.src.random.seed_generator import SeedGenerator
+from keras.src.saving import serialization_lib
+
+
+@keras_export("keras.layers.RandomChoice")
+class RandomChoice(Layer):
+    """Apply one randomly-picked layer from a list to the input.
+
+    During training, on each call this layer picks one of the wrapped `layers`
+    uniformly at random and applies it. All other layers are evaluated and
+    discarded, so the per-call compute cost is `len(layers)` evaluations; this
+    keeps the layer compatible with `tf.data` / `grain` pipelines where
+    Python-side branching is not available. The choice is batch-wide — the
+    same layer is applied to every sample in the batch.
+
+    During inference (`training=False`) the layer is always a no-op.
+
+    Args:
+        layers: List of Keras `Layer` instances. Each must accept the same
+            input shape and emit a same-shape output.
+        seed: Optional integer. Random seed used to pick a layer.
+
+    Example:
+
+    ```python
+    augmenter = keras.layers.RandomChoice([
+        keras.layers.RandomFlip("horizontal"),
+        keras.layers.RandomRotation(0.1),
+        keras.layers.RandomZoom(0.1),
+    ])
+    ```
+    """
+
+    def __init__(self, layers, seed=None, **kwargs):
+        super().__init__(**kwargs)
+        if not isinstance(layers, (list, tuple)) or len(layers) == 0:
+            raise ValueError(
+                "`layers` must be a non-empty list of Keras `Layer` "
+                f"instances. Received: layers={layers}"
+            )
+        for i, layer in enumerate(layers):
+            if not isinstance(layer, Layer):
+                raise TypeError(
+                    "Each entry in `layers` must be a Keras `Layer` "
+                    f"instance. Received layers[{i}]={layer} of type "
+                    f"{type(layer)}"
+                )
+        self._wrapped_layers = list(layers)
+        self.seed = seed
+        self.generator = SeedGenerator(seed)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    @property
+    def layers(self):
+        return self._wrapped_layers
+
+    def call(self, inputs, training=True):
+        if not training:
+            return inputs
+
+        n = len(self._wrapped_layers)
+        choice = random.randint(
+            shape=(), minval=0, maxval=n, seed=self.generator
+        )
+
+        result = inputs
+        for i, layer in enumerate(self._wrapped_layers):
+            transformed = layer(inputs, training=training)
+            result = ops.where(ops.equal(choice, i), transformed, result)
+        return result
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "layers": [
+                    serialization_lib.serialize_keras_object(layer)
+                    for layer in self._wrapped_layers
+                ],
+                "seed": self.seed,
+            }
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        config = {**config}
+        config["layers"] = [
+            serialization_lib.deserialize_keras_object(
+                x, custom_objects=custom_objects
+            )
+            for x in config["layers"]
+        ]
+        return cls(**config)

--- a/keras/src/layers/preprocessing/random_choice.py
+++ b/keras/src/layers/preprocessing/random_choice.py
@@ -56,7 +56,7 @@ class RandomChoice(DataLayer):
         self.generator = SeedGenerator(seed)
 
     @property
-    def layers(self):
+    def wrapped_layers(self):
         return self._wrapped_layers
 
     def call(self, inputs, training=True):

--- a/keras/src/layers/preprocessing/random_choice.py
+++ b/keras/src/layers/preprocessing/random_choice.py
@@ -2,6 +2,7 @@ from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
 from keras.src.layers.preprocessing.data_layer import DataLayer
+from keras.src.layers.preprocessing.random_apply import _check_same_shape
 from keras.src.random.seed_generator import SeedGenerator
 from keras.src.saving import serialization_lib
 
@@ -68,6 +69,7 @@ class RandomChoice(DataLayer):
         # own copy. Sharing one would chain the augmentations together instead
         # of producing independent candidates, and would leave the caller's
         # structure mutated.
+        original = tree.map_structure(lambda x: x, inputs)
         candidates = [
             layer(tree.map_structure(lambda x: x, inputs), training=training)
             for layer in self._wrapped_layers
@@ -77,7 +79,15 @@ class RandomChoice(DataLayer):
             shape=(1,), minval=0, maxval=n, seed=seed
         )
 
-        def _select(*candidate_leaves):
+        def _select(original_leaf, *candidate_leaves):
+            reference_shape = getattr(original_leaf, "shape", None)
+            for i, candidate_leaf in enumerate(candidate_leaves):
+                _check_same_shape(
+                    getattr(candidate_leaf, "shape", None),
+                    reference_shape,
+                    f"`layers[{i}]`, a "
+                    f"`{self._wrapped_layers[i].__class__.__name__}`,",
+                )
             # Stack the candidates for this leaf along a new leading axis and
             # gather the one selected by `choice`. The same `choice` is used
             # for every leaf, so a structured input is transformed by exactly
@@ -85,7 +95,7 @@ class RandomChoice(DataLayer):
             stacked = self.backend.numpy.stack(candidate_leaves, axis=0)
             return self.backend.numpy.take(stacked, choice, axis=0)[0]
 
-        return tree.map_structure(_select, *candidates)
+        return tree.map_structure(_select, original, *candidates)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/random_choice.py
+++ b/keras/src/layers/preprocessing/random_choice.py
@@ -1,3 +1,4 @@
+from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
 from keras.src.layers.preprocessing.data_layer import DataLayer
@@ -62,17 +63,29 @@ class RandomChoice(DataLayer):
             return inputs
 
         n = len(self._wrapped_layers)
+        # The image preprocessing layers rebind keys on the structure they are
+        # given and return that same object, so every wrapped layer gets its
+        # own copy. Sharing one would chain the augmentations together instead
+        # of producing independent candidates, and would leave the caller's
+        # structure mutated.
         candidates = [
-            layer(inputs, training=training) for layer in self._wrapped_layers
+            layer(tree.map_structure(lambda x: x, inputs), training=training)
+            for layer in self._wrapped_layers
         ]
         seed = self._get_seed_generator(self.backend._backend)
         choice = self.backend.random.randint(
             shape=(1,), minval=0, maxval=n, seed=seed
         )
-        # Stack all candidate outputs along a new leading axis and gather the
-        # one selected by `choice`.
-        stacked = self.backend.numpy.stack(candidates, axis=0)
-        return self.backend.numpy.take(stacked, choice, axis=0)[0]
+
+        def _select(*candidate_leaves):
+            # Stack the candidates for this leaf along a new leading axis and
+            # gather the one selected by `choice`. The same `choice` is used
+            # for every leaf, so a structured input is transformed by exactly
+            # one of the wrapped layers.
+            stacked = self.backend.numpy.stack(candidate_leaves, axis=0)
+            return self.backend.numpy.take(stacked, choice, axis=0)[0]
+
+        return tree.map_structure(_select, *candidates)
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/random_choice.py
+++ b/keras/src/layers/preprocessing/random_choice.py
@@ -1,23 +1,23 @@
-from keras.src import ops
-from keras.src import random
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
+from keras.src.layers.preprocessing.data_layer import DataLayer
 from keras.src.random.seed_generator import SeedGenerator
 from keras.src.saving import serialization_lib
 
 
 @keras_export("keras.layers.RandomChoice")
-class RandomChoice(Layer):
+class RandomChoice(DataLayer):
     """Apply one randomly-picked layer from a list to the input.
 
-    During training, on each call this layer picks one of the wrapped `layers`
-    uniformly at random and applies it. All other layers are evaluated and
-    discarded, so the per-call compute cost is `len(layers)` evaluations; this
-    keeps the layer compatible with `tf.data` / `grain` pipelines where
-    Python-side branching is not available. The choice is batch-wide — the
-    same layer is applied to every sample in the batch.
+    During training, on each call this layer picks one of the wrapped layers
+    uniformly at random and applies it. The choice is batch-wide — the same
+    layer is applied to every sample in the batch.
 
     During inference (`training=False`) the layer is always a no-op.
+
+    Note that every wrapped layer is evaluated on each training call and all
+    but the selected result are discarded, so the per-call compute cost is
+    `len(layers)` evaluations rather than one.
 
     Args:
         layers: List of Keras `Layer` instances. Each must accept the same
@@ -52,8 +52,6 @@ class RandomChoice(Layer):
         self._wrapped_layers = list(layers)
         self.seed = seed
         self.generator = SeedGenerator(seed)
-        self._convert_input_args = False
-        self._allow_non_tensor_positional_args = True
 
     @property
     def layers(self):
@@ -64,18 +62,20 @@ class RandomChoice(Layer):
             return inputs
 
         n = len(self._wrapped_layers)
-        # Stack all candidate outputs along a new leading axis and gather the
-        # one selected by `choice`. This avoids relying on `ops.where` with a
-        # scalar mask broadcasting against an N-D tensor — which is uneven
-        # across backends.
         candidates = [
             layer(inputs, training=training) for layer in self._wrapped_layers
         ]
-        stacked = ops.stack(candidates, axis=0)
-        choice = random.randint(
-            shape=(1,), minval=0, maxval=n, seed=self.generator
+        seed = self._get_seed_generator(self.backend._backend)
+        choice = self.backend.random.randint(
+            shape=(1,), minval=0, maxval=n, seed=seed
         )
-        return ops.take(stacked, choice, axis=0)[0]
+        # Stack all candidate outputs along a new leading axis and gather the
+        # one selected by `choice`.
+        stacked = self.backend.numpy.stack(candidates, axis=0)
+        return self.backend.numpy.take(stacked, choice, axis=0)[0]
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
 
     def get_config(self):
         config = super().get_config()

--- a/keras/src/layers/preprocessing/random_choice_test.py
+++ b/keras/src/layers/preprocessing/random_choice_test.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+from keras.src import backend
+from keras.src import layers
+from keras.src import testing
+from keras.src.layers.preprocessing.random_choice import RandomChoice
+from keras.src.saving import serialization_lib
+
+
+class _AddConst(layers.Layer):
+    def __init__(self, value, **kwargs):
+        super().__init__(**kwargs)
+        self.value = float(value)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    def call(self, inputs, training=True):
+        return inputs + self.value
+
+    def get_config(self):
+        config = super().get_config()
+        config["value"] = self.value
+        return config
+
+
+class RandomChoiceTest(testing.TestCase):
+    def test_rejects_empty_layers(self):
+        with self.assertRaisesRegex(ValueError, "non-empty"):
+            RandomChoice([])
+
+    def test_rejects_non_layer_entry(self):
+        with self.assertRaisesRegex(TypeError, "Keras `Layer`"):
+            RandomChoice([_AddConst(1.0), lambda x: x])
+
+    def test_inference_is_noop(self):
+        layer = RandomChoice([_AddConst(1.0), _AddConst(2.0)], seed=0)
+        x = np.zeros((4, 3, 3, 1), dtype="float32")
+        out = backend.convert_to_numpy(layer(x, training=False))
+        self.assertAllClose(out, x)
+
+    def test_single_layer_always_chosen(self):
+        layer = RandomChoice([_AddConst(5.0)], seed=0)
+        x = np.zeros((4, 3, 3, 1), dtype="float32")
+        out = backend.convert_to_numpy(layer(x, training=True))
+        self.assertAllClose(out, np.full_like(x, 5.0))
+
+    def test_choice_covers_all_layers(self):
+        # With three layers and a seed, repeated calls should produce all
+        # three distinct add-values eventually.
+        layer = RandomChoice(
+            [_AddConst(1.0), _AddConst(2.0), _AddConst(3.0)], seed=0
+        )
+        x = np.zeros((1, 1, 1, 1), dtype="float32")
+        outs = {
+            backend.convert_to_numpy(layer(x, training=True)).item()
+            for _ in range(200)
+        }
+        self.assertEqual(outs, {1.0, 2.0, 3.0})
+
+    def test_serialization_roundtrip(self):
+        layer = RandomChoice(
+            [_AddConst(1.0), _AddConst(2.0)], seed=11, name="rc"
+        )
+        config = serialization_lib.serialize_keras_object(layer)
+        revived = serialization_lib.deserialize_keras_object(
+            config, custom_objects={"_AddConst": _AddConst}
+        )
+        self.assertEqual(revived.seed, 11)
+        self.assertEqual(len(revived.layers), 2)
+        self.assertEqual(revived.layers[0].value, 1.0)
+        self.assertEqual(revived.layers[1].value, 2.0)
+
+    def test_wraps_preprocessing_layers(self):
+        layer = RandomChoice(
+            [
+                layers.RandomFlip("horizontal"),
+                layers.RandomRotation(0.1),
+            ],
+            seed=0,
+        )
+        x = np.random.uniform(size=(2, 8, 8, 3)).astype("float32")
+        out = backend.convert_to_numpy(layer(x, training=True))
+        self.assertEqual(out.shape, x.shape)

--- a/keras/src/layers/preprocessing/random_choice_test.py
+++ b/keras/src/layers/preprocessing/random_choice_test.py
@@ -23,6 +23,20 @@ class _AddConst(layers.Layer):
         return config
 
 
+class _AddConstInPlace(layers.Layer):
+    """Rebinds a key on the input dict, as the image preprocessing layers do."""
+
+    def __init__(self, value, **kwargs):
+        super().__init__(**kwargs)
+        self.value = float(value)
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    def call(self, inputs, training=True):
+        inputs["images"] = inputs["images"] + self.value
+        return inputs
+
+
 class RandomChoiceTest(testing.TestCase):
     def test_rejects_empty_layers(self):
         with self.assertRaisesRegex(ValueError, "non-empty"):
@@ -81,3 +95,48 @@ class RandomChoiceTest(testing.TestCase):
         x = np.random.uniform(size=(2, 8, 8, 3)).astype("float32")
         out = backend.convert_to_numpy(layer(x, training=True))
         self.assertEqual(out.shape, x.shape)
+
+    def test_dict_input_with_bounding_boxes(self):
+        layer = RandomChoice(
+            [
+                layers.RandomFlip("horizontal", bounding_box_format="xyxy"),
+                layers.RandomRotation(0.1, bounding_box_format="xyxy"),
+            ],
+            seed=0,
+        )
+        data = {
+            "images": np.random.uniform(size=(2, 8, 8, 3)).astype("float32"),
+            "bounding_boxes": {
+                "boxes": np.array(
+                    [[[0.0, 0.0, 4.0, 4.0]], [[1.0, 1.0, 5.0, 5.0]]],
+                    dtype="float32",
+                ),
+                "labels": np.array([[0], [1]], dtype="float32"),
+            },
+        }
+        out = layer(data, training=True)
+        self.assertIsInstance(out, dict)
+        self.assertEqual(sorted(out.keys()), ["bounding_boxes", "images"])
+        self.assertEqual(
+            backend.convert_to_numpy(out["images"]).shape, (2, 8, 8, 3)
+        )
+
+    def test_candidates_are_independent(self):
+        # Each wrapped layer must see the original input. The image
+        # preprocessing layers rebind keys on the structure they are given, so
+        # sharing one dict across candidates would chain the augmentations:
+        # +1 applied on top of +10 would yield 11.0 rather than one of
+        # {1.0, 10.0}.
+        x = np.zeros((4, 1, 1, 1), dtype="float32")
+        seen = set()
+        for seed in range(12):
+            layer = RandomChoice(
+                [_AddConstInPlace(1.0), _AddConstInPlace(10.0)], seed=seed
+            )
+            out = layer({"images": x}, training=True)
+            value = float(backend.convert_to_numpy(out["images"]).ravel()[0])
+            seen.add(value)
+        self.assertTrue(
+            seen.issubset({1.0, 10.0}),
+            f"unexpected outcomes {sorted(seen)}; chaining suspected",
+        )

--- a/keras/src/layers/preprocessing/random_choice_test.py
+++ b/keras/src/layers/preprocessing/random_choice_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import keras
 from keras.src import backend
 from keras.src import layers
 from keras.src import testing
@@ -140,3 +141,21 @@ class RandomChoiceTest(testing.TestCase):
             seen.issubset({1.0, 10.0}),
             f"unexpected outcomes {sorted(seen)}; chaining suspected",
         )
+
+    def test_rejects_shape_changing_layer(self):
+        layer = RandomChoice(
+            [layers.RandomFlip("horizontal"), layers.Resizing(2, 2)], seed=0
+        )
+        x = np.random.uniform(size=(2, 4, 4, 3)).astype("float32")
+        with self.assertRaisesRegex(ValueError, r"layers\[1\]"):
+            layer(x, training=True)
+
+    def test_dynamic_batch_dim_is_not_a_shape_mismatch(self):
+        inputs = keras.Input((8, 8, 3))
+        outputs = RandomChoice(
+            [layers.RandomFlip("horizontal"), layers.RandomRotation(0.1)],
+            seed=0,
+        )(inputs)
+        model = keras.Model(inputs, outputs)
+        x = np.random.uniform(size=(4, 8, 8, 3)).astype("float32")
+        self.assertEqual(model.predict(x, verbose=0).shape, (4, 8, 8, 3))

--- a/keras/src/layers/preprocessing/random_choice_test.py
+++ b/keras/src/layers/preprocessing/random_choice_test.py
@@ -1,4 +1,8 @@
+import os
+
 import numpy as np
+import pytest
+from tensorflow import data as tf_data
 
 import keras
 from keras.src import backend
@@ -81,9 +85,9 @@ class RandomChoiceTest(testing.TestCase):
             config, custom_objects={"_AddConst": _AddConst}
         )
         self.assertEqual(revived.seed, 11)
-        self.assertEqual(len(revived.layers), 2)
-        self.assertEqual(revived.layers[0].value, 1.0)
-        self.assertEqual(revived.layers[1].value, 2.0)
+        self.assertEqual(len(revived.wrapped_layers), 2)
+        self.assertEqual(revived.wrapped_layers[0].value, 1.0)
+        self.assertEqual(revived.wrapped_layers[1].value, 2.0)
 
     def test_wraps_preprocessing_layers(self):
         layer = RandomChoice(
@@ -159,3 +163,78 @@ class RandomChoiceTest(testing.TestCase):
         model = keras.Model(inputs, outputs)
         x = np.random.uniform(size=(4, 8, 8, 3)).astype("float32")
         self.assertEqual(model.predict(x, verbose=0).shape, (4, 8, 8, 3))
+
+    def test_layer_basics(self):
+        self.run_layer_test(
+            RandomChoice,
+            init_kwargs={
+                "layers": [_AddConst(1.0), _AddConst(2.0)],
+                "seed": 0,
+            },
+            input_shape=(2, 3),
+            expected_output_shape=(2, 3),
+            expected_num_trainable_weights=0,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=1,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
+    def test_tf_data_compatibility(self):
+        # Regression guard for the wrapper being a plain `Layer` rather than a
+        # `DataLayer`: this fails on non-TensorFlow backends without it.
+        layer = RandomChoice(
+            [
+                layers.RandomFlip("horizontal", seed=42),
+                layers.RandomRotation(0.1, seed=42),
+            ],
+            seed=42,
+        )
+        input_data = np.random.uniform(size=(4, 8, 8, 3)).astype("float32")
+        ds = (
+            tf_data.Dataset.from_tensor_slices(input_data)
+            .batch(2)
+            .map(lambda x: layer(x, training=True))
+        )
+        for batch in ds:
+            self.assertEqual(tuple(batch.shape), (2, 8, 8, 3))
+
+    def test_saved_model_roundtrip(self):
+        inputs = keras.Input((8, 8, 3))
+        outputs = RandomChoice(
+            [layers.RandomFlip("horizontal"), layers.RandomRotation(0.1)],
+            seed=11,
+        )(inputs)
+        model = keras.Model(inputs, outputs)
+        path = os.path.join(self.get_temp_dir(), "random_choice.keras")
+        model.save(path)
+        restored = keras.saving.load_model(path)
+        layer = restored.layers[-1]
+        self.assertIsInstance(layer, RandomChoice)
+        self.assertEqual(layer.seed, 11)
+        self.assertEqual(len(layer.wrapped_layers), 2)
+        x = np.random.uniform(size=(2, 8, 8, 3)).astype("float32")
+        self.assertEqual(restored.predict(x, verbose=0).shape, (2, 8, 8, 3))
+
+    @pytest.mark.requires_trainable_backend
+    def test_fit(self):
+        inputs = keras.Input((4,))
+        x = RandomChoice([_AddConst(1.0), _AddConst(2.0)], seed=0)(inputs)
+        outputs = layers.Dense(1)(x)
+        model = keras.Model(inputs, outputs)
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(
+            np.random.uniform(size=(8, 4)).astype("float32"),
+            np.random.uniform(size=(8, 1)).astype("float32"),
+            epochs=1,
+            batch_size=4,
+            verbose=0,
+        )
+
+    def test_output_dtype_follows_compute_dtype(self):
+        x = np.ones((2, 2, 2, 3), dtype="float64")
+        layer = RandomChoice([layers.Rescaling(1.0)], seed=0)
+        out = layer(x, training=True)
+        self.assertEqual(
+            backend.standardize_dtype(out.dtype), layer.compute_dtype
+        )


### PR DESCRIPTION
## Description

Adds `keras.layers.RandomApply` and `keras.layers.RandomChoice` — two stochastic wrapper layers for building probabilistic augmentation pipelines. Closes #20727.

These wrappers were available in `keras_cv` but are commonly requested in core Keras for building image augmentation pipelines that mirror standard CV recipes (e.g. RandAugment / SimCLR style probabilistic transforms).

**`RandomApply(layer, rate=0.5, seed=None)`**

On each training call, flips a Bernoulli coin with probability `rate`. Applies the wrapped `layer` on heads, otherwise passes the input through unchanged. The decision is batch-wide so the layer stays compatible with `tf.data` / `grain` pipelines. Inference (`training=False`) is always a no-op.

```python
augmenter = keras.layers.RandomApply(
    keras.layers.RandomFlip("horizontal"), rate=0.3
)
```

**`RandomChoice(layers, seed=None)`**

On each training call, picks one of the wrapped `layers` uniformly at random and applies it. All other layers are evaluated and discarded — necessary so the choice can happen inside a traced/compiled graph. Inference is always a no-op.

```python
augmenter = keras.layers.RandomChoice([
    keras.layers.RandomFlip("horizontal"),
    keras.layers.RandomRotation(0.1),
    keras.layers.RandomZoom(0.1),
])
```

**Design notes**

- Both subclass plain `Layer` (not `BaseImagePreprocessingLayer`) so they work with any wrapped Keras layer, not just image-preprocessing ones.
- Both serialize via `serialization_lib.serialize_keras_object` for the wrapped layer(s), so they round-trip through `get_config` / `from_config` cleanly.
- Both use a `SeedGenerator` for deterministic random draws under a given `seed`.

**API additions**

- `keras.layers.RandomApply`
- `keras.layers.RandomChoice`

**Tests**

`keras/src/layers/preprocessing/random_apply_test.py` (8 tests) and `keras/src/layers/preprocessing/random_choice_test.py` (7 tests) cover:

- Input validation (non-`Layer`, invalid rate, empty layers list)
- Inference is no-op
- Edge rates (`rate=0`, `rate=1`, single-layer choice)
- Statistical coverage of the choice / mixing behavior over many calls
- Serialization round-trip
- Composition with real preprocessing layers (`RandomFlip`, `RandomRotation`)

All 15 tests pass on tensorflow, jax, torch, numpy backends locally.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
