### PR TITLE
[Fix] keras.ops.nancumprod returns float32 max instead of inf for NaN followed by Inf

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3252,7 +3252,11 @@ def nancumsum(x, axis=None, dtype=None):
 
 
 def nancumprod(x, axis=None, dtype=None):
-    return cumprod(nan_to_num(x, nan=1.0), axis=axis, dtype=dtype)
+    return cumprod(
+        nan_to_num(x, nan=1.0, posinf=float("inf"), neginf=float("-inf")),
+        axis=axis,
+        dtype=dtype,
+    )
 
 
 def nanmax(x, axis=None, keepdims=False):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3252,11 +3252,13 @@ def nancumsum(x, axis=None, dtype=None):
 
 
 def nancumprod(x, axis=None, dtype=None):
-    return cumprod(
-        nan_to_num(x, nan=1.0, posinf=float("inf"), neginf=float("-inf")),
-        axis=axis,
-        dtype=dtype,
-    )
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+    if not (x_type.is_integral() or x_type == Type.boolean):
+        nan_mask = ov_opset.is_nan(x).output(0)
+        one = ov_opset.constant(1.0, x_type).output(0)
+        x = ov_opset.select(nan_mask, one, x).output(0)
+    return cumprod(x, axis=axis, dtype=dtype)
 
 
 def nanmax(x, axis=None, keepdims=False):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2367,7 +2367,7 @@ def nancumsum(x, axis=None, dtype=None):
 
 
 def nancumprod(x, axis=None, dtype=None):
-    x = nan_to_num(x, nan=1.0)
+    x = nan_to_num(x, nan=1.0, posinf=float("inf"), neginf=float("-inf"))
     return cumprod(x, axis=axis, dtype=dtype)
 
 

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1406,7 +1406,7 @@ def nancumsum(x, axis=None, dtype=None):
 
 
 def nancumprod(x, axis=None, dtype=None):
-    x = nan_to_num(x, nan=1.0)
+    x = nan_to_num(x, nan=1.0, posinf=float("inf"), neginf=float("-inf"))
     return cumprod(x, axis=axis, dtype=dtype)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7214,6 +7214,13 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             np.nancumprod(x_all_nan, axis=1),
         )
 
+        x_with_inf = np.array(
+            [[np.nan, np.inf, -np.inf], [2.0, np.nan, -3.0]], dtype=np.float32
+        )
+        self.assertAllClose(
+            knp.nancumprod(x_with_inf), np.nancumprod(x_with_inf)
+        )
+
     def test_nanmax(self):
         x = np.array([[1.0, np.nan, 3.0], [np.nan, 2.0, -np.inf]])
 


### PR DESCRIPTION
## Description
Fixes: #23127 
nan_to_num(x, nan=1.0) used a buggy path, it converted inf values to floats as default. Fixed it such that nancumprod replaces only NaNs with 1.0 preserving inf and -inf. Added a regression test for the same. 
This was an issue in tensorflow, openvino and torch backend, did the changes on all 3.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
