### PR TITLE
[Fix] keras.ops.nancumsum returns finite values instead of inf/nan for inputs containing NaN and infinities

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3248,11 +3248,13 @@ def nanargmin(x, axis=None, keepdims=False):
 
 
 def nancumsum(x, axis=None, dtype=None):
-    return cumsum(
-        nan_to_num(x, nan=0.0, posinf=float("inf"), neginf=float("-inf")),
-        axis=axis,
-        dtype=dtype,
-    )
+    x = get_ov_output(x)
+    x_type = x.get_element_type()
+    if not (x_type.is_integral() or x_type == Type.boolean):
+        nan_mask = ov_opset.is_nan(x).output(0)
+        zero = ov_opset.constant(0.0, x_type).output(0)
+        x = ov_opset.select(nan_mask, zero, x).output(0)
+    return cumsum(x, axis=axis, dtype=dtype)
 
 
 def nancumprod(x, axis=None, dtype=None):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -3248,7 +3248,11 @@ def nanargmin(x, axis=None, keepdims=False):
 
 
 def nancumsum(x, axis=None, dtype=None):
-    return cumsum(nan_to_num(x, nan=0.0), axis=axis, dtype=dtype)
+    return cumsum(
+        nan_to_num(x, nan=0.0, posinf=float("inf"), neginf=float("-inf")),
+        axis=axis,
+        dtype=dtype,
+    )
 
 
 def nancumprod(x, axis=None, dtype=None):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2362,7 +2362,7 @@ def nanargmin(x, axis=None, keepdims=False):
 
 
 def nancumsum(x, axis=None, dtype=None):
-    x = nan_to_num(x)
+    x = nan_to_num(x, posinf=float("inf"), neginf=float("-inf"))
     return cumsum(x, axis=axis, dtype=dtype)
 
 

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1401,7 +1401,7 @@ def nanargmin(x, axis=None, keepdims=False):
 
 
 def nancumsum(x, axis=None, dtype=None):
-    x = nan_to_num(x)
+    x = nan_to_num(x, posinf=float("inf"), neginf=float("-inf"))
     return cumsum(x, axis=axis, dtype=dtype)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7183,6 +7183,14 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.nancumsum(x_all_nan, axis=1), np.nancumsum(x_all_nan, axis=1)
         )
 
+        x_with_inf = np.array(
+            [[np.nan, np.inf, 1.0], [np.nan, -np.inf, -1.0]], dtype=np.float32
+        )
+        self.assertAllClose(
+            knp.nancumsum(x_with_inf, axis=1),
+            np.nancumsum(x_with_inf, axis=1),
+        )
+
     def test_nancumprod(self):
         x = np.array([[1.0, np.nan, 3.0], [np.nan, 2.0, -1.0]])
 


### PR DESCRIPTION
## Description
Fixes: #23130 
Same changes done in #23134 
namcumsum suffers the same bug as nancumprod
## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
