### PR TITLE
[Fix] keras.ops.isclose incorrectly returns False for matching positive and negative infinities

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -2340,6 +2340,11 @@ def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     abs_x2 = ov_opset.abs(x2)
     total_tolerance = ov_opset.add(atol, ov_opset.multiply(rtol, abs_x2))
     is_close = ov_opset.less_equal(abs_diff, total_tolerance)
+    finite = ov_opset.logical_and(
+        get_ov_output(isfinite(x1)), get_ov_output(isfinite(x2))
+    )
+    is_close = ov_opset.logical_and(finite, is_close)
+    is_close = ov_opset.logical_or(is_close, ov_opset.equal(x1, x2))
     if equal_nan:
         both_nan = ov_opset.logical_and(ov_opset.isnan(x1), ov_opset.isnan(x2))
         is_close = ov_opset.logical_or(is_close, both_nan)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -2331,25 +2331,30 @@ def inner(x1, x2):
 def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     dtype = OPENVINO_DTYPES[config.floatx()]
 
-    x1 = ov_opset.convert(get_ov_output(x1), dtype)
-    x2 = ov_opset.convert(get_ov_output(x2), dtype)
-    rtol = ov_opset.convert(get_ov_output(rtol), dtype)
-    atol = ov_opset.convert(get_ov_output(atol), dtype)
+    x1 = ov_opset.convert(get_ov_output(x1), dtype).output(0)
+    x2 = ov_opset.convert(get_ov_output(x2), dtype).output(0)
+    rtol = ov_opset.convert(get_ov_output(rtol), dtype).output(0)
+    atol = ov_opset.convert(get_ov_output(atol), dtype).output(0)
 
-    abs_diff = ov_opset.abs(ov_opset.subtract(x1, x2))
-    abs_x2 = ov_opset.abs(x2)
-    total_tolerance = ov_opset.add(atol, ov_opset.multiply(rtol, abs_x2))
-    is_close = ov_opset.less_equal(abs_diff, total_tolerance)
+    abs_diff = ov_opset.abs(ov_opset.subtract(x1, x2)).output(0)
+    abs_x2 = ov_opset.abs(x2).output(0)
+    total_tolerance = ov_opset.add(
+        atol, ov_opset.multiply(rtol, abs_x2)
+    ).output(0)
+    is_close = ov_opset.less_equal(abs_diff, total_tolerance).output(0)
     finite = ov_opset.logical_and(
-        get_ov_output(isfinite(x1)), get_ov_output(isfinite(x2))
-    )
-    is_close = ov_opset.logical_and(finite, is_close)
-    is_close = ov_opset.logical_or(is_close, ov_opset.equal(x1, x2))
+        isfinite(x1).output, isfinite(x2).output
+    ).output(0)
+    is_close = ov_opset.logical_and(finite, is_close).output(0)
+    equal = ov_opset.equal(x1, x2).output(0)
+    is_close = ov_opset.logical_or(is_close, equal).output(0)
     if equal_nan:
-        both_nan = ov_opset.logical_and(ov_opset.isnan(x1), ov_opset.isnan(x2))
-        is_close = ov_opset.logical_or(is_close, both_nan)
+        both_nan = ov_opset.logical_and(
+            ov_opset.isnan(x1).output(0), ov_opset.isnan(x2).output(0)
+        ).output(0)
+        is_close = ov_opset.logical_or(is_close, both_nan).output(0)
 
-    return OpenVINOKerasTensor(is_close.output(0))
+    return OpenVINOKerasTensor(is_close)
 
 
 def isfinite(x):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1792,7 +1792,9 @@ def isclose(x1, x2, rtol=1e-5, atol=1e-8, equal_nan=False):
     x1 = tf.cast(x1, dtype)
     x2 = tf.cast(x2, dtype)
     if "float" in dtype:
-        result = tf.abs(x1 - x2) <= (atol + rtol * tf.abs(x2))
+        finite = tf.math.is_finite(x1) & tf.math.is_finite(x2)
+        close = tf.abs(x1 - x2) <= (atol + rtol * tf.abs(x2))
+        result = (finite & close) | tf.equal(x1, x2)
         if equal_nan:
             result = result | (is_nan(x1) & is_nan(x2))
         return result

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3986,6 +3986,17 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.isclose(x, 2), np.isclose(x, 2))
         self.assertAllClose(knp.isclose(2, x), np.isclose(2, x))
 
+        special_x = np.array(
+            [np.nan, np.inf, -np.inf, 0.0, np.inf], dtype="float32"
+        )
+        special_y = np.array(
+            [np.nan, np.inf, -np.inf, np.inf, 0.0], dtype="float32"
+        )
+        self.assertAllClose(
+            knp.isclose(special_x, special_y),
+            np.isclose(special_x, special_y),
+        )
+
         self.assertAllClose(knp.Isclose()(x, y), np.isclose(x, y))
         self.assertAllClose(knp.Isclose()(x, 2), np.isclose(x, 2))
         self.assertAllClose(knp.Isclose()(2, x), np.isclose(2, x))

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3987,10 +3987,12 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.isclose(2, x), np.isclose(2, x))
 
         special_x = np.array(
-            [np.nan, np.inf, -np.inf, 0.0, np.inf], dtype="float32"
+            [np.nan, np.inf, -np.inf, 0.0, np.inf, np.inf, -np.inf],
+            dtype="float32",
         )
         special_y = np.array(
-            [np.nan, np.inf, -np.inf, np.inf, 0.0], dtype="float32"
+            [np.nan, np.inf, -np.inf, np.inf, 0.0, -np.inf, np.inf],
+            dtype="float32",
         )
         self.assertAllClose(
             knp.isclose(special_x, special_y),


### PR DESCRIPTION
## Description
Fixes: #23128 
TensorFlow and openvino backends computed abs(x1 - x2) <= tolerance; inf - inf becomes NaN, so it returned False. Now fixed it so it only checks finite values.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
