### PR TITLE
[OpenVINO] Use native opset17 erfinv op

### DIFF
--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -1,5 +1,6 @@
 import numpy as np
 import openvino.opset16 as ov_opset
+import openvino.opset17 as ov_opset17
 import scipy.signal
 from openvino import Type
 
@@ -928,55 +929,14 @@ def erfc(x):
 
 
 def erfinv(x):
-    # TODO: Float64 infinity values are clamped on CPU backend,
-    # breaking erfinv(±1) = ±inf
-    # See https://github.com/openvinotoolkit/openvino/issues/34138
-    # Tests excluded: test_erfinv_operation_basic, test_erfinv_operation_dtype
+    # OpenVINO opset17 ships a native `erfinv` op which produces correct
+    # `±inf` and `NaN` at the boundary / out-of-domain inputs on float32.
+    # The float64 path still hits the upstream CPU clamping bug — see
+    # https://github.com/openvinotoolkit/openvino/issues/34138 — so the
+    # excluded tests (test_erfinv_operation_basic / _dtype) remain gated
+    # on the upstream fix.
     x = get_ov_output(x)
-    dtype = x.get_element_type()
-
-    a = 0.147
-    two_over_pi_a = 2.0 / (np.pi * a)
-    two_over_sqrt_pi = 2.0 / np.sqrt(np.pi)
-
-    one = ov_opset.constant(1.0, dtype).output(0)
-    half = ov_opset.constant(0.5, dtype).output(0)
-
-    x_sq = ov_opset.multiply(x, x).output(0)
-    log_term = ov_opset.log(ov_opset.subtract(one, x_sq).output(0)).output(0)
-
-    k = ov_opset.add(
-        ov_opset.constant(two_over_pi_a, dtype).output(0),
-        ov_opset.multiply(half, log_term).output(0),
-    ).output(0)
-
-    inner = ov_opset.subtract(
-        ov_opset.multiply(k, k).output(0),
-        ov_opset.multiply(
-            ov_opset.constant(1.0 / a, dtype).output(0), log_term
-        ).output(0),
-    ).output(0)
-
-    y0 = ov_opset.multiply(
-        ov_opset.sign(x).output(0),
-        ov_opset.sqrt(
-            ov_opset.subtract(ov_opset.sqrt(inner).output(0), k).output(0)
-        ).output(0),
-    ).output(0)
-
-    erf_err = ov_opset.subtract(ov_opset.erf(y0).output(0), x).output(0)
-
-    y0_sq = ov_opset.multiply(y0, y0).output(0)
-    exp_term = ov_opset.exp(ov_opset.negative(y0_sq).output(0)).output(0)
-    deriv = ov_opset.multiply(
-        ov_opset.constant(two_over_sqrt_pi, dtype).output(0),
-        exp_term,
-    ).output(0)
-    y1 = ov_opset.subtract(
-        y0, ov_opset.divide(erf_err, deriv).output(0)
-    ).output(0)
-
-    return OpenVINOKerasTensor(y1)
+    return OpenVINOKerasTensor(ov_opset17.erfinv(x).output(0))
 
 
 def logdet(x):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -929,12 +929,6 @@ def erfc(x):
 
 
 def erfinv(x):
-    # OpenVINO opset17 ships a native `erfinv` op which produces correct
-    # `±inf` and `NaN` at the boundary / out-of-domain inputs on float32.
-    # The float64 path still hits the upstream CPU clamping bug — see
-    # https://github.com/openvinotoolkit/openvino/issues/34138 — so the
-    # excluded tests (test_erfinv_operation_basic / _dtype) remain gated
-    # on the upstream fix.
     x = get_ov_output(x)
     return OpenVINOKerasTensor(ov_opset17.erfinv(x).output(0))
 


### PR DESCRIPTION
## Description
OpenVINO opset17 ships a native `erfinv` op. This PR replaces the manual Winitzki+Newton approximation in the OpenVINO backend with a single call to `opset17.erfinv`, which is more accurate (matches `scipy.special.erfinv` exactly on float32, including ±inf at the boundaries) and significantly simpler.

The float64 path still hits the upstream CPU plugin issue ([openvinotoolkit/openvino#34138](https://github.com/openvinotoolkit/openvino/issues/34138)) that clamps infinity values to ±FLT_MAX, so the two excluded tests (`test_erfinv_operation_basic`, `test_erfinv_operation_dtype`) remain gated on that upstream fix.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
