### PR TITLE
[OpenVINO] Implement sobel_edges op

### DIFF
--- a/keras/src/backend/openvino/image.py
+++ b/keras/src/backend/openvino/image.py
@@ -2072,6 +2072,56 @@ def scale_and_translate(
 
 
 def sobel_edges(images, data_format=None):
-    raise NotImplementedError(
-        "`sobel_edges` is not supported with openvino backend"
-    )
+    images = get_ov_output(images)
+    data_format = backend.standardize_data_format(data_format)
+    if images.get_partial_shape().rank.get_length() != 4:
+        raise ValueError(
+            "Invalid images rank: expected rank 4 (batch of images). "
+            f"Received input with shape: images.shape={images.shape}"
+        )
+    # Move to NCHW for depthwise convolution, then move back at the end.
+    if data_format == "channels_last":
+        images = ov_opset.transpose(
+            images, ov_opset.constant([0, 3, 1, 2], Type.i32)
+        ).output(0)
+
+    channels = images.shape[1]
+    elem_type = images.get_element_type()
+
+    # Depthwise Sobel kernels in (groups, out_per_group, in_per_group, kH, kW)
+    # = (C, 1, 1, 3, 3). The same Sobel kernel is applied to every channel.
+    sobel_y = np.array(
+        [[[[[-1.0, -2.0, -1.0], [0.0, 0.0, 0.0], [1.0, 2.0, 1.0]]]]]
+    ).repeat(channels, axis=0)
+    sobel_x = np.array(
+        [[[[[-1.0, 0.0, 1.0], [-2.0, 0.0, 2.0], [-1.0, 0.0, 1.0]]]]]
+    ).repeat(channels, axis=0)
+    kernel_y = ov_opset.constant(sobel_y, dtype=elem_type).output(0)
+    kernel_x = ov_opset.constant(sobel_x, dtype=elem_type).output(0)
+
+    strides = [1, 1]
+    pads = [1, 1]
+    dilations = [1, 1]
+    edges_y = ov_opset.group_convolution(
+        images, kernel_y, strides, pads, pads, dilations, "explicit"
+    ).output(0)
+    edges_x = ov_opset.group_convolution(
+        images, kernel_x, strides, pads, pads, dilations, "explicit"
+    ).output(0)
+
+    # Stack along a new trailing axis: [dy, dx]. Output is (N, C, H, W, 2).
+    edges_y = ov_opset.unsqueeze(
+        edges_y, ov_opset.constant(-1, Type.i32)
+    ).output(0)
+    edges_x = ov_opset.unsqueeze(
+        edges_x, ov_opset.constant(-1, Type.i32)
+    ).output(0)
+    edges = ov_opset.concat([edges_y, edges_x], axis=-1).output(0)
+
+    # Move channels back to last if the user asked for channels_last; result
+    # shape goes (N, C, H, W, 2) -> (N, H, W, C, 2).
+    if data_format == "channels_last":
+        edges = ov_opset.transpose(
+            edges, ov_opset.constant([0, 2, 3, 1, 4], Type.i32)
+        ).output(0)
+    return OpenVINOKerasTensor(edges)

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -3257,10 +3257,6 @@ class ExtractPatches3DTest(testing.TestCase):
 
 
 class SobelEdgesTest(testing.TestCase):
-    def setUp(self):
-        if backend.backend() == "openvino":
-            self.skipTest("sobel_edges is not supported with openvino backend")
-
     def test_sobel_edges_shape_channels_last(self):
         image = np.random.random((2, 16, 16, 3)).astype("float32")
         edges = kimage.sobel_edges(image, data_format="channels_last")


### PR DESCRIPTION
## Description
`sobel_edges` was added to `keras.ops.image` but raised `NotImplementedError` on the OpenVINO backend. This PR implements it via two depthwise convolutions with the standard Sobel kernels, using OpenVINO's `group_convolution` op, and removes the backend-specific `skipTest` from `SobelEdgesTest` so the full test class now runs against OpenVINO.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
