### PR TITLE
[OpenVINO] Implement lstsq op via QR

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -5,7 +5,6 @@ EqualizationTest::test_input_dtypes_int64
 EqualizationTest::test_output_range_0_1
 EqualizationTest::test_output_range_0_255
 LinalgOpsCorrectnessTest::test_eig
-LinalgOpsCorrectnessTest::test_lstsq
 LinalgOpsCorrectnessTest::test_matrix_rank
 LinalgOpsCorrectnessTest::test_norm_2_-2
 LinalgOpsCorrectnessTest::test_norm_2_2

--- a/keras/src/backend/openvino/linalg.py
+++ b/keras/src/backend/openvino/linalg.py
@@ -1,5 +1,6 @@
 import warnings
 
+import numpy as np
 import openvino as ov
 import openvino.opset16 as ov_opset
 from openvino import Model
@@ -1636,7 +1637,91 @@ def svd(x, full_matrices=True, compute_uv=True):
 
 
 def lstsq(a, b, rcond=None):
-    raise NotImplementedError("`lstsq` is not supported with openvino backend")
+    # OpenVINO has no SVD op, so the symbolic path is QR-based. For
+    # full-rank `a` this matches `numpy.linalg.lstsq` (including the
+    # minimum-norm solution in the under-determined case). `rcond` is
+    # accepted for API parity but ignored — it only affects the SVD-based
+    # rank truncation that this implementation cannot do.
+    a = convert_to_tensor(a)
+    b = convert_to_tensor(b)
+    if a.ndim != 2:
+        raise TypeError(
+            f"{a.ndim}-dimensional array given. Array must be two-dimensional"
+        )
+    if b.ndim not in (1, 2):
+        raise TypeError(
+            f"{b.ndim}-dimensional array given. "
+            "Array must be one or two-dimensional"
+        )
+    if a.shape[0] != b.shape[0]:
+        raise ValueError("Leading dimensions of input arrays must match")
+
+    a_ov = get_ov_output(a)
+    b_ov = get_ov_output(b)
+
+    # Constant-folding fast path: chained Transpose + Inverse + MatMul on
+    # constants triggers a CPU plugin folding bug that returns zeros, so
+    # fall back to numpy whenever both inputs are constant. The symbolic
+    # OpenVINO graph below is correct at runtime (with Parameter inputs).
+    a_node = a_ov.get_node()
+    b_node = b_ov.get_node()
+    if (
+        a_node.get_type_name() == "Constant"
+        and b_node.get_type_name() == "Constant"
+    ):
+        x_np = np.linalg.lstsq(
+            np.asarray(a_node.data), np.asarray(b_node.data), rcond=rcond
+        )[0]
+        return OpenVINOKerasTensor(ov_opset.constant(x_np).output(0))
+
+    del rcond  # Ignored on the symbolic path; see note above.
+
+    m, n = a.shape
+    squeeze_out = b.ndim == 1
+    if squeeze_out:
+        b_ov = ov_opset.unsqueeze(
+            b_ov, ov_opset.constant([-1], Type.i32)
+        ).output(0)
+
+    orig_type = a_ov.get_element_type()
+    if orig_type == Type.f64:
+        a_ov = ov_opset.convert(a_ov, Type.f32).output(0)
+        b_ov = ov_opset.convert(b_ov, Type.f32).output(0)
+
+    if m >= n:
+        # Over-determined / square: A = Q R (Q is (M, N), R is (N, N)).
+        # Solve `R x = Q^T b` with an upper-triangular solve.
+        q, r = qr(OpenVINOKerasTensor(a_ov), mode="reduced")
+        q_ov = get_ov_output(q)
+        rhs = OpenVINOKerasTensor(
+            ov_opset.matmul(q_ov, b_ov, True, False).output(0)
+        )
+        x_ov = get_ov_output(solve_triangular(r, rhs, lower=False))
+    else:
+        # Under-determined: take QR of A^T to get the minimum-norm
+        # solution. A^T = Q R, then A = R^T Q^T, so `A x = b` gives
+        # `R^T z = b` with `x = Q z`.
+        a_t_ov = ov_opset.transpose(
+            a_ov, ov_opset.constant([1, 0], Type.i32)
+        ).output(0)
+        q, r = qr(OpenVINOKerasTensor(a_t_ov), mode="reduced")
+        r_t = OpenVINOKerasTensor(
+            ov_opset.transpose(
+                get_ov_output(r), ov_opset.constant([1, 0], Type.i32)
+            ).output(0)
+        )
+        z_ov = get_ov_output(
+            solve_triangular(r_t, OpenVINOKerasTensor(b_ov), lower=True)
+        )
+        x_ov = ov_opset.matmul(get_ov_output(q), z_ov, False, False).output(0)
+
+    if orig_type == Type.f64:
+        x_ov = ov_opset.convert(x_ov, Type.f64).output(0)
+    if squeeze_out:
+        x_ov = ov_opset.squeeze(x_ov, ov_opset.constant([-1], Type.i32)).output(
+            0
+        )
+    return OpenVINOKerasTensor(x_ov)
 
 
 def matrix_rank(x, tol=None):


### PR DESCRIPTION
## Description
`lstsq` was added to `keras.ops.linalg` but raised `NotImplementedError` on the OpenVINO backend. This PR implements it via QR (since OpenVINO has no SVD op): thin QR + upper-triangular solve for over-determined / square systems, and QR of `A^T` + lower-triangular solve + back-multiply for the minimum-norm solution to under-determined systems. For full-rank `a` this matches `numpy.linalg.lstsq`.

Chaining `Transpose + Inverse + MatMul` on constants triggers a CPU constant-folding bug that returns zeros, so the implementation also takes a fast numpy path when both inputs are `Constant` nodes — same pattern as the existing fallback in `numpy.py`. The symbolic QR graph is exercised whenever either input is a runtime `Parameter`, where the bug does not reproduce.

`rcond` is accepted for API parity but ignored on the symbolic path — it only affects the SVD-based rank truncation that this implementation cannot do. The constant-fast path honors `rcond` because it delegates to numpy.

`LinalgOpsCorrectnessTest::test_lstsq` is removed from `excluded_concrete_tests.txt` and the 3 parameterized cases now pass on OpenVINO.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
