### PR TITLE
[OpenVINO] Remove stale exclusions for Equalization tests

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -1,9 +1,4 @@
 EqualizationTest::test_equalizes_to_all_bins
-EqualizationTest::test_input_dtypes_float32
-EqualizationTest::test_input_dtypes_int32
-EqualizationTest::test_input_dtypes_int64
-EqualizationTest::test_output_range_0_1
-EqualizationTest::test_output_range_0_255
 LinalgOpsCorrectnessTest::test_eig
 LinalgOpsCorrectnessTest::test_lstsq
 LinalgOpsCorrectnessTest::test_matrix_rank


### PR DESCRIPTION
## Description
The `Equalization` layer works correctly on the OpenVINO backend — verified by running each of the previously-excluded tests against the current implementation. Five exclusions are removed:

- `EqualizationTest::test_input_dtypes_float32`
- `EqualizationTest::test_input_dtypes_int32`
- `EqualizationTest::test_input_dtypes_int64`
- `EqualizationTest::test_output_range_0_1`
- `EqualizationTest::test_output_range_0_255`

Each passes in ~30 s when run individually against the OpenVINO backend (per-test wall time dominated by OpenVINO model compilation for the 512 × 512 input).

`EqualizationTest::test_equalizes_to_all_bins` is kept excluded for now. The test asserts every histogram bin 0–255 is present by calling `ops.convert_to_numpy(xs)` inside a 256-iteration `for` loop. On the OpenVINO backend each `convert_to_numpy` recompiles the underlying graph, so the loop pushes the test into the multi-minute range and would risk CI timeout. The layer itself is correct (the equivalent single-call check passes); this is a test-structure inefficiency rather than a real failure, and a follow-up that either caches `convert_to_numpy` results on `OpenVINOKerasTensor` or restructures the test would unblock the last entry.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
