### PR TITLE
Implement column_stack function across multiple backends and add corresponding tests

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -168,6 +168,7 @@ from keras.src.ops.numpy import broadcast_to as broadcast_to
 from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
+from keras.src.ops.numpy import column_stack as column_stack
 from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -43,6 +43,7 @@ from keras.src.ops.numpy import broadcast_to as broadcast_to
 from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
+from keras.src.ops.numpy import column_stack as column_stack
 from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -168,6 +168,7 @@ from keras.src.ops.numpy import broadcast_to as broadcast_to
 from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
+from keras.src.ops.numpy import column_stack as column_stack
 from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -43,6 +43,7 @@ from keras.src.ops.numpy import broadcast_to as broadcast_to
 from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
+from keras.src.ops.numpy import column_stack as column_stack
 from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1698,3 +1698,7 @@ def unique(
 def dsplit(x, indices_or_sections):
     x = convert_to_tensor(x)
     return jnp.dsplit(x, indices_or_sections)
+
+
+def column_stack(xs):
+    return jnp.column_stack(xs)

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1701,4 +1701,5 @@ def dsplit(x, indices_or_sections):
 
 
 def column_stack(xs):
+    xs = [convert_to_tensor(x) for x in xs]
     return jnp.column_stack(xs)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1818,10 +1818,9 @@ def dsplit(x, indices_or_sections):
 
 
 def column_stack(xs):
-    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    xs = [convert_to_tensor(x) for x in xs]
+    dtype_set = set([x.dtype for x in xs])
     if len(dtype_set) > 1:
         dtype = dtypes.result_type(*dtype_set)
-        xs = tree.map_structure(
-            lambda x: convert_to_tensor(x).astype(dtype), xs
-        )
+        xs = [x.astype(dtype) for x in xs]
     return np.column_stack(xs)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1815,3 +1815,13 @@ def unique(
 def dsplit(x, indices_or_sections):
     x = convert_to_tensor(x)
     return np.dsplit(x, indices_or_sections)
+
+
+def column_stack(xs):
+    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    if len(dtype_set) > 1:
+        dtype = dtypes.result_type(*dtype_set)
+        xs = tree.map_structure(
+            lambda x: convert_to_tensor(x).astype(dtype), xs
+        )
+    return np.column_stack(xs)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -5947,8 +5947,7 @@ def column_stack(xs):
         xs = (xs,)
 
     elems = [convert_to_tensor(x) for x in xs]
-    element_type = elems[0].output.get_element_type()
-    elems = [get_ov_output(x, element_type) for x in elems]
+    elems = [get_ov_output(x) for x in elems]
 
     processed_elems = []
     for elem in elems:

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -5940,3 +5940,38 @@ def unique(
 
 def dsplit(x, indices_or_sections):
     return split(x, indices_or_sections, axis=2)
+
+
+def column_stack(xs):
+    if not isinstance(xs, (list, tuple)):
+        xs = (xs,)
+
+    elems = [convert_to_tensor(x) for x in xs]
+    element_type = elems[0].output.get_element_type()
+    elems = [get_ov_output(x, element_type) for x in elems]
+
+    processed_elems = []
+    for elem in elems:
+        rank = elem.get_partial_shape().rank.get_length()
+
+        if rank == 0:
+            elem = ov_opset.unsqueeze(
+                elem, ov_opset.constant(0, Type.i32)
+            ).output(0)
+            rank = 1
+
+        if rank == 1:
+            elem = ov_opset.unsqueeze(
+                elem, ov_opset.constant(1, Type.i32)
+            ).output(0)
+
+        processed_elems.append(elem)
+
+    base = processed_elems[0]
+    for i in range(1, len(processed_elems)):
+        base, processed_elems[i] = _align_operand_types(
+            base, processed_elems[i], "column_stack()"
+        )
+    processed_elems[0] = base
+
+    return OpenVINOKerasTensor(ov_opset.concat(processed_elems, 1).output(0))

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -4008,9 +4008,10 @@ def dsplit(x, indices_or_sections):
 
 
 def column_stack(xs):
-    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    xs = [convert_to_tensor(x) for x in xs]
+    dtype_set = set([x.dtype for x in xs])
     if len(dtype_set) > 1:
         dtype = dtypes.result_type(*dtype_set)
-        xs = tree.map_structure(lambda x: convert_to_tensor(x, dtype), xs)
+        xs = [tf.cast(x, dtype) for x in xs]
     xs = [tf.expand_dims(x, axis=-1) if len(x.shape) == 1 else x for x in xs]
     return tf.concat(xs, axis=1)

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -4005,3 +4005,12 @@ def unique(
 
 def dsplit(x, indices_or_sections):
     return split(x, indices_or_sections, axis=2)
+
+
+def column_stack(xs):
+    dtype_set = set([getattr(x, "dtype", type(x)) for x in xs])
+    if len(dtype_set) > 1:
+        dtype = dtypes.result_type(*dtype_set)
+        xs = tree.map_structure(lambda x: convert_to_tensor(x, dtype), xs)
+    xs = [tf.expand_dims(x, axis=-1) if len(x.shape) == 1 else x for x in xs]
+    return tf.concat(xs, axis=1)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2480,3 +2480,8 @@ def dsplit(x, indices_or_sections):
     if not isinstance(indices_or_sections, int):
         indices_or_sections = convert_to_tensor(indices_or_sections).tolist()
     return list(torch.dsplit(x, indices_or_sections))
+
+
+def column_stack(xs):
+    xs = [convert_to_tensor(x) for x in xs]
+    return torch.column_stack(xs)

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -19,7 +19,6 @@ And some more magic:
 import collections
 import functools
 import inspect
-import math
 import warnings
 from functools import wraps
 
@@ -342,7 +341,6 @@ class Layer(BackendLayer, Operation):
         self._build_shapes_dict = None
         # Parent path
         self._parent_path = None
-        self._remat_mode = get_current_remat_mode()
         self._initialize_tracker()
 
     @tracking.no_automatic_dependency_tracking
@@ -1769,36 +1767,9 @@ class Layer(BackendLayer, Operation):
         Returns:
             Rematerialized layer's `call` method.
         """
-
-        def compute_size(x):
-            return (
-                math.prod([d or 1 for d in x.shape])
-                if isinstance(x, KerasTensor)
-                else 0
-            )
-
-        # Full rematerialization
-        if self._remat_mode.mode == "full":
-            return remat.remat(layer_call)
-
-        # Apply rematerialization to specific layers
-        elif self._remat_mode.mode == "list_of_layers" and (
-            self.name in self._remat_mode.layer_names
-        ):
-            return remat.remat(layer_call)
-
-        # Apply rematerialization based on output size threshold
-        elif self._remat_mode.mode == "larger_than":
-            output_spec = self.compute_output_spec(*args, **kwargs)
-            output_size = sum(
-                tree.flatten(tree.map_structure(compute_size, output_spec))
-            )
-            if (
-                output_size
-                and output_size > self._remat_mode.output_size_threshold
-            ):
-                return remat.remat(layer_call)
-        elif self._remat_mode.mode == "activations":
+        if not self._remat_mode:
+            return layer_call
+        if self._remat_mode.mode == "activations":
             has_activation = (
                 hasattr(self, "activation") and self.activation is not None
             )
@@ -1814,7 +1785,11 @@ class Layer(BackendLayer, Operation):
                         self.activation = original_activation
 
                 return rematerialized_activation_call_wrapper
-        return layer_call
+        elif self._remat_mode.mode == "list_of_layers" and (
+            self.name in self._remat_mode.layer_names
+        ):
+            return remat.remat(layer_call)
+        return super().rematerialized_call(layer_call, *args, **kwargs)
 
     def _register_call_context_args(self, *names):
         """Registers call-context args for this layer.

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -213,6 +213,10 @@ class LayerTest(testing.TestCase):
         self.assertLen(mock_remat.rematted_functions, 1)
         next(iter(mock_remat.rematted_functions.values())).assert_called()
 
+    def test_rematerialized_call_none(self):
+        layer = layers.Dense(4)
+        layer.rematerialized_call(layer.call, ops.ones((2, 3)))
+
     def test_quantized_layer_with_remat(self):
         """Test rematerialization on a quantized layer."""
         mock_remat = MockRemat()

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -10031,3 +10031,92 @@ def dsplit(x, indices_or_sections):
     if any_symbolic_tensors((x,)):
         return Dsplit(indices_or_sections).symbolic_call(x)
     return backend.numpy.dsplit(x, indices_or_sections)
+
+
+class ColumnStack(Operation):
+    def call(self, xs):
+        return backend.numpy.column_stack(xs)
+
+    def compute_output_spec(self, xs):
+        if len(xs) == 0:
+            raise ValueError(
+                "`column_stack` requires at least one tensor, but received "
+                "an empty sequence."
+            )
+
+        first_shape = xs[0].shape
+        if len(first_shape) < 1:
+            raise ValueError(
+                "`column_stack` requires tensors of at least 1 dimension. "
+                f"Received tensor with shape {first_shape}."
+            )
+
+        # 1-D tensors are treated as columns, i.e. reshaped to (N, 1).
+        first_effective_shape = (
+            (first_shape[0], 1) if len(first_shape) == 1 else first_shape
+        )
+
+        total_size_on_axis = 0
+        dtypes_to_resolve = []
+        for x in xs:
+            x_shape = x.shape
+            if len(x_shape) < 1:
+                raise ValueError(
+                    "`column_stack` requires tensors of at least 1 "
+                    f"dimension. Received tensor with shape {x_shape}."
+                )
+            x_effective_shape = (
+                (x_shape[0], 1) if len(x_shape) == 1 else x_shape
+            )
+            if not shape_equal(
+                x_effective_shape,
+                first_effective_shape,
+                axis=[1],
+                allow_none=True,
+            ):
+                raise ValueError(
+                    "Every value in `xs` must have the same shape except on "
+                    "the `axis` dim (after 1-D tensors are reshaped to 2-D "
+                    "columns). But found element of shape "
+                    f"{x_shape}, which is different from the first "
+                    f"element's shape {first_shape}."
+                )
+            if total_size_on_axis is None or x_effective_shape[1] is None:
+                total_size_on_axis = None
+            else:
+                total_size_on_axis += x_effective_shape[1]
+            dtypes_to_resolve.append(getattr(x, "dtype", type(x)))
+
+        output_shape = list(first_effective_shape)
+        output_shape[1] = total_size_on_axis
+        dtype = dtypes.result_type(*dtypes_to_resolve)
+        return KerasTensor(output_shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.column_stack", "keras.ops.numpy.column_stack"])
+def column_stack(xs):
+    """Stack 1-D tensors as columns into a 2-D tensor.
+
+    Take a sequence of 1-D tensors and stack them as columns to make a
+    single 2-D tensor. 2-D tensors are stacked as-is, like with
+    `hstack`. Tensors with more than 2 dimensions are concatenated
+    along the second axis.
+
+    Args:
+        xs: Sequence of tensors.
+
+    Returns:
+        The tensor formed by stacking the given tensors.
+
+    Example:
+
+    >>> a = keras.ops.array([1, 2, 3])
+    >>> b = keras.ops.array([4, 5, 6])
+    >>> keras.ops.column_stack([a, b])
+    array([[1, 4],
+           [2, 5],
+           [3, 6]])
+    """
+    if any_symbolic_tensors((xs,)):
+        return ColumnStack().symbolic_call(xs)
+    return backend.numpy.column_stack(xs)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -10071,13 +10071,13 @@ class ColumnStack(Operation):
             if not shape_equal(
                 x_effective_shape,
                 first_effective_shape,
-                axis=[1],
+                axis=1,
                 allow_none=True,
             ):
                 raise ValueError(
-                    "Every value in `xs` must have the same shape except on "
-                    "the `axis` dim (after 1-D tensors are reshaped to 2-D "
-                    "columns). But found element of shape "
+                    "Every value in xs must have the same shape except on "
+                    "the column axis (axis 1) after 1-D tensors are reshaped "
+                    "to 2-D columns. But found element of shape "
                     f"{x_shape}, which is different from the first "
                     f"element's shape {first_shape}."
                 )

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1833,6 +1833,21 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         y = KerasTensor((None, None))
         self.assertEqual(knp.hstack([x, y]).shape, (None, None))
 
+    def test_column_stack(self):
+        # 1D tensors
+        x = KerasTensor((None,))
+        y = KerasTensor((None,))
+        self.assertEqual(knp.column_stack([x, y]).shape, (None, 2))
+
+        # 2D tensors
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, 3))
+        self.assertEqual(knp.column_stack([x, y]).shape, (None, 6))
+
+        x = KerasTensor((None, 3))
+        y = KerasTensor((None, None))
+        self.assertEqual(knp.column_stack([x, y]).shape, (None, None))
+
     def test_i0(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.i0(x).shape, (None, 3))
@@ -2808,6 +2823,17 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((2, 3))
         y = KerasTensor((2, 3))
         self.assertEqual(knp.hstack([x, y]).shape, (2, 6))
+
+    def test_column_stack(self):
+        # 1D tensors
+        x = KerasTensor((3,))
+        y = KerasTensor((3,))
+        self.assertEqual(knp.column_stack([x, y]).shape, (3, 2))
+
+        # 2D tensors
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.column_stack([x, y]).shape, (2, 6))
 
     def test_i0(self):
         x = KerasTensor((2, 3))
@@ -5964,6 +5990,19 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         y = np.ones([2, 5, 4])
         self.assertAllClose(knp.hstack([x, y]), np.hstack([x, y]))
         self.assertAllClose(knp.Hstack()([x, y]), np.hstack([x, y]))
+
+    def test_column_stack(self):
+        x = np.array([1, 2, 3])
+        y = np.array([4, 5, 6])
+        self.assertAllClose(knp.column_stack([x, y]), np.column_stack([x, y]))
+
+        x = np.array([[1, 2, 3], [4, 5, 6]])
+        y = np.array([[7, 8, 9], [10, 11, 12]])
+        self.assertAllClose(knp.column_stack([x, y]), np.column_stack([x, y]))
+
+        x = np.array([1, 2])
+        y = np.array([[3, 4], [5, 6]])
+        self.assertAllClose(knp.column_stack([x, y]), np.column_stack([x, y]))
 
     def test_i0(self):
         x = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
@@ -10179,6 +10218,31 @@ class NumpyDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Hstack().symbolic_call([x1, x2]).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
+    )
+    def test_column_stack(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((2,), dtype=dtype1)
+        x2 = knp.ones((2,), dtype=dtype2)
+        x1_jax = jnp.ones((2,), dtype=dtype1)
+        x2_jax = jnp.ones((2,), dtype=dtype2)
+
+        expected_dtype = standardize_dtype(
+            jnp.column_stack([x1_jax, x2_jax]).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.column_stack([x1, x2]).dtype), expected_dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.ColumnStack().symbolic_call([x1, x2]).dtype),
             expected_dtype,
         )
 

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -1,10 +1,13 @@
 import inspect
+import math
 import textwrap
 
 from keras.src import backend
 from keras.src import dtype_policies
 from keras.src import tree
 from keras.src.api_export import keras_export
+from keras.src.backend import KerasTensor
+from keras.src.backend.common import remat
 from keras.src.backend.common.keras_tensor import any_symbolic_tensors
 from keras.src.backend.config import is_nnx_enabled
 from keras.src.ops.node import Node
@@ -28,6 +31,7 @@ class Operation(KerasSaveable):
         self.name = name
         self._inbound_nodes = []
         self._outbound_nodes = []
+        self._remat_mode = remat.get_current_remat_mode()
 
     @traceback_utils.filter_traceback
     def __call__(self, *args, **kwargs):
@@ -36,7 +40,7 @@ class Operation(KerasSaveable):
             if any_symbolic_tensors(args, kwargs):
                 call_fn = self.symbolic_call
             else:
-                if getattr(self, "_remat_mode", None) is not None:
+                if self._remat_mode:
                     if getattr(self, "quantization_mode", None) is not None:
                         call_fn = self.rematerialized_call(
                             self.quantized_call,
@@ -61,7 +65,7 @@ class Operation(KerasSaveable):
         # Plain flow.
         if any_symbolic_tensors(args, kwargs):
             return self.symbolic_call(*args, **kwargs)
-        elif getattr(self, "_remat_mode", None) is not None:
+        elif self._remat_mode:
             if getattr(self, "quantization_mode", None) is not None:
                 return self.rematerialized_call(
                     self.quantized_call, *args, **kwargs
@@ -95,6 +99,42 @@ class Operation(KerasSaveable):
 
     def quantized_call(self, *args, **kwargs):
         raise NotImplementedError
+
+    def rematerialized_call(self, fn, *args, **kwargs):
+        """Enable rematerialization dynamically for an operation's call method.
+
+        Args:
+            fn: The original `call` or `quantized_call` method of an operation.
+
+        Returns:
+            Rematerialized method.
+        """
+        if not self._remat_mode:
+            return fn
+
+        def compute_size(x):
+            return (
+                math.prod([d or 1 for d in x.shape])
+                if isinstance(x, KerasTensor)
+                else 0
+            )
+
+        # Full rematerialization
+        if self._remat_mode.mode == "full":
+            return remat.remat(fn)
+
+        # Apply rematerialization based on output size threshold
+        elif self._remat_mode.mode == "larger_than":
+            output_spec = self.compute_output_spec(*args, **kwargs)
+            output_size = sum(
+                tree.flatten(tree.map_structure(compute_size, output_spec))
+            )
+            if (
+                output_size
+                and output_size > self._remat_mode.output_size_threshold
+            ):
+                return remat.remat(fn)
+        return fn
 
     def compute_output_spec(self, *args, **kwargs):
         try:

--- a/keras/src/ops/operation_test.py
+++ b/keras/src/ops/operation_test.py
@@ -6,6 +6,7 @@ from keras.src import testing
 from keras.src.backend.common import keras_tensor
 from keras.src.ops import numpy as knp
 from keras.src.ops import operation
+from keras.src.utils import traceback_utils
 
 
 class OpWithMultipleInputs(operation.Operation):
@@ -110,6 +111,17 @@ class OpWithKwargsInConstructorGetConfig(operation.Operation):
         return {**super().get_config(), "alpha": self.alpha}
 
 
+class OpWithQuantizedCall(operation.Operation):
+    def call(self, x):
+        return x
+
+    def quantized_call(self, x):
+        return x + 1
+
+    def compute_output_spec(self, x):
+        return keras_tensor.KerasTensor(x.shape, x.dtype)
+
+
 class OperationTest(testing.TestCase):
     def test_symbolic_call(self):
         x = keras_tensor.KerasTensor(shape=(2, 3), name="x")
@@ -194,6 +206,48 @@ class OperationTest(testing.TestCase):
         self.assertTrue(backend.is_tensor(out[1]))
         self.assertAllClose(out[0], np.ones((2, 3)))
         self.assertAllClose(out[1], np.ones((2, 3)) + 1)
+
+    def test_rematerialized_call(self):
+        from keras.src.backend.common.remat import RematScope
+
+        x = knp.ones((2, 3))
+
+        # Test standard rematerialized call using RematScope
+        with RematScope(mode="full"):
+            op = OpWithMultipleInputs(name="test_op")
+        out = op(x, x, x)
+        self.assertTrue(backend.is_tensor(out))
+        self.assertAllClose(out, 6 * np.ones((2, 3)))
+
+        # Test quantized rematerialized call
+        with RematScope(mode="full"):
+            op_q = OpWithQuantizedCall(name="test_op_q")
+        op_q.quantization_mode = object()
+        out = op_q(x)
+        self.assertTrue(backend.is_tensor(out))
+        self.assertAllClose(out, 2 * np.ones((2, 3)))
+
+        # Test traceback filtering branch
+        was_enabled = traceback_utils.is_traceback_filtering_enabled()
+        traceback_utils.enable_traceback_filtering()
+        try:
+            # Standard rematerialized
+            with RematScope(mode="full"):
+                op = OpWithMultipleInputs(name="test_op_traceback")
+            out = op(x, x, x)
+            self.assertTrue(backend.is_tensor(out))
+            self.assertAllClose(out, 6 * np.ones((2, 3)))
+
+            # Quantized rematerialized
+            with RematScope(mode="full"):
+                op_q = OpWithQuantizedCall(name="test_op_q_traceback")
+            op_q.quantization_mode = object()
+            out = op_q(x)
+            self.assertTrue(backend.is_tensor(out))
+            self.assertAllClose(out, 2 * np.ones((2, 3)))
+        finally:
+            if not was_enabled:
+                traceback_utils.disable_traceback_filtering()
 
     def test_serialization_with_default_init_and_get_config(self):
         # Explicit name passed in constructor is serialized and deserialized.


### PR DESCRIPTION
## Description
Implements a new column_stack operation in the Keras ops API, providing column-wise stacking of 1D and 2D tensors into a single tensor.  The operation is supported across all available backends (TensorFlow, JAX, NumPy, OpenVINO, and Torch).

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
