### PR TITLE
Added loss test suite

### DIFF
--- a/keras/api/_tf_keras/keras/losses/__init__.py
+++ b/keras/api/_tf_keras/keras/losses/__init__.py
@@ -10,6 +10,8 @@ from keras.src.losses import get as get
 from keras.src.losses import serialize as serialize
 from keras.src.losses.loss import Loss as Loss
 from keras.src.losses.losses import CTC as CTC
+from keras.src.losses.losses import MSSSIM as MSSSIM
+from keras.src.losses.losses import PSNR as PSNR
 from keras.src.losses.losses import BinaryCrossentropy as BinaryCrossentropy
 from keras.src.losses.losses import (
     BinaryFocalCrossentropy as BinaryFocalCrossentropy,
@@ -24,9 +26,11 @@ from keras.src.losses.losses import (
     CategoricalGeneralizedCrossEntropy as CategoricalGeneralizedCrossEntropy,
 )
 from keras.src.losses.losses import CategoricalHinge as CategoricalHinge
+from keras.src.losses.losses import Charbonnier as Charbonnier
 from keras.src.losses.losses import Circle as Circle
 from keras.src.losses.losses import CosineSimilarity as CosineSimilarity
 from keras.src.losses.losses import Dice as Dice
+from keras.src.losses.losses import EdgeAwareSmoothness as EdgeAwareSmoothness
 from keras.src.losses.losses import Hinge as Hinge
 from keras.src.losses.losses import Huber as Huber
 from keras.src.losses.losses import KLDivergence as KLDivergence
@@ -39,11 +43,13 @@ from keras.src.losses.losses import MeanSquaredError as MeanSquaredError
 from keras.src.losses.losses import (
     MeanSquaredLogarithmicError as MeanSquaredLogarithmicError,
 )
+from keras.src.losses.losses import PerceptualLoss as PerceptualLoss
 from keras.src.losses.losses import Poisson as Poisson
 from keras.src.losses.losses import (
     SparseCategoricalCrossentropy as SparseCategoricalCrossentropy,
 )
 from keras.src.losses.losses import SquaredHinge as SquaredHinge
+from keras.src.losses.losses import TotalVariation as TotalVariation
 from keras.src.losses.losses import Tversky as Tversky
 from keras.src.losses.losses import binary_crossentropy as binary_crossentropy
 from keras.src.losses.losses import (
@@ -59,10 +65,14 @@ from keras.src.losses.losses import (
     categorical_generalized_cross_entropy as categorical_generalized_cross_entropy,
 )
 from keras.src.losses.losses import categorical_hinge as categorical_hinge
+from keras.src.losses.losses import charbonnier as charbonnier
 from keras.src.losses.losses import circle as circle
 from keras.src.losses.losses import cosine_similarity as cosine_similarity
 from keras.src.losses.losses import ctc as ctc
 from keras.src.losses.losses import dice as dice
+from keras.src.losses.losses import (
+    edge_aware_smoothness as edge_aware_smoothness,
+)
 from keras.src.losses.losses import hinge as hinge
 from keras.src.losses.losses import huber as huber
 from keras.src.losses.losses import kl_divergence as KLD
@@ -77,9 +87,12 @@ from keras.src.losses.losses import mean_squared_error as MSE
 from keras.src.losses.losses import mean_squared_error as mse
 from keras.src.losses.losses import mean_squared_logarithmic_error as MSLE
 from keras.src.losses.losses import mean_squared_logarithmic_error as msle
+from keras.src.losses.losses import msssim as msssim
 from keras.src.losses.losses import poisson as poisson
+from keras.src.losses.losses import psnr as psnr
 from keras.src.losses.losses import (
     sparse_categorical_crossentropy as sparse_categorical_crossentropy,
 )
 from keras.src.losses.losses import squared_hinge as squared_hinge
+from keras.src.losses.losses import total_variation as total_variation
 from keras.src.losses.losses import tversky as tversky

--- a/keras/api/losses/__init__.py
+++ b/keras/api/losses/__init__.py
@@ -9,6 +9,8 @@ from keras.src.losses import get as get
 from keras.src.losses import serialize as serialize
 from keras.src.losses.loss import Loss as Loss
 from keras.src.losses.losses import CTC as CTC
+from keras.src.losses.losses import MSSSIM as MSSSIM
+from keras.src.losses.losses import PSNR as PSNR
 from keras.src.losses.losses import BinaryCrossentropy as BinaryCrossentropy
 from keras.src.losses.losses import (
     BinaryFocalCrossentropy as BinaryFocalCrossentropy,
@@ -23,9 +25,11 @@ from keras.src.losses.losses import (
     CategoricalGeneralizedCrossEntropy as CategoricalGeneralizedCrossEntropy,
 )
 from keras.src.losses.losses import CategoricalHinge as CategoricalHinge
+from keras.src.losses.losses import Charbonnier as Charbonnier
 from keras.src.losses.losses import Circle as Circle
 from keras.src.losses.losses import CosineSimilarity as CosineSimilarity
 from keras.src.losses.losses import Dice as Dice
+from keras.src.losses.losses import EdgeAwareSmoothness as EdgeAwareSmoothness
 from keras.src.losses.losses import Hinge as Hinge
 from keras.src.losses.losses import Huber as Huber
 from keras.src.losses.losses import KLDivergence as KLDivergence
@@ -38,11 +42,13 @@ from keras.src.losses.losses import MeanSquaredError as MeanSquaredError
 from keras.src.losses.losses import (
     MeanSquaredLogarithmicError as MeanSquaredLogarithmicError,
 )
+from keras.src.losses.losses import PerceptualLoss as PerceptualLoss
 from keras.src.losses.losses import Poisson as Poisson
 from keras.src.losses.losses import (
     SparseCategoricalCrossentropy as SparseCategoricalCrossentropy,
 )
 from keras.src.losses.losses import SquaredHinge as SquaredHinge
+from keras.src.losses.losses import TotalVariation as TotalVariation
 from keras.src.losses.losses import Tversky as Tversky
 from keras.src.losses.losses import binary_crossentropy as binary_crossentropy
 from keras.src.losses.losses import (
@@ -58,10 +64,14 @@ from keras.src.losses.losses import (
     categorical_generalized_cross_entropy as categorical_generalized_cross_entropy,
 )
 from keras.src.losses.losses import categorical_hinge as categorical_hinge
+from keras.src.losses.losses import charbonnier as charbonnier
 from keras.src.losses.losses import circle as circle
 from keras.src.losses.losses import cosine_similarity as cosine_similarity
 from keras.src.losses.losses import ctc as ctc
 from keras.src.losses.losses import dice as dice
+from keras.src.losses.losses import (
+    edge_aware_smoothness as edge_aware_smoothness,
+)
 from keras.src.losses.losses import hinge as hinge
 from keras.src.losses.losses import huber as huber
 from keras.src.losses.losses import kl_divergence as kl_divergence
@@ -74,9 +84,12 @@ from keras.src.losses.losses import mean_squared_error as mean_squared_error
 from keras.src.losses.losses import (
     mean_squared_logarithmic_error as mean_squared_logarithmic_error,
 )
+from keras.src.losses.losses import msssim as msssim
 from keras.src.losses.losses import poisson as poisson
+from keras.src.losses.losses import psnr as psnr
 from keras.src.losses.losses import (
     sparse_categorical_crossentropy as sparse_categorical_crossentropy,
 )
 from keras.src.losses.losses import squared_hinge as squared_hinge
+from keras.src.losses.losses import total_variation as total_variation
 from keras.src.losses.losses import tversky as tversky

--- a/keras/src/losses/__init__.py
+++ b/keras/src/losses/__init__.py
@@ -3,14 +3,18 @@ import inspect
 from keras.src.api_export import keras_export
 from keras.src.losses.loss import Loss
 from keras.src.losses.losses import CTC
+from keras.src.losses.losses import MSSSIM
+from keras.src.losses.losses import PSNR
 from keras.src.losses.losses import BinaryCrossentropy
 from keras.src.losses.losses import BinaryFocalCrossentropy
 from keras.src.losses.losses import CategoricalCrossentropy
 from keras.src.losses.losses import CategoricalFocalCrossentropy
 from keras.src.losses.losses import CategoricalHinge
+from keras.src.losses.losses import Charbonnier
 from keras.src.losses.losses import Circle
 from keras.src.losses.losses import CosineSimilarity
 from keras.src.losses.losses import Dice
+from keras.src.losses.losses import EdgeAwareSmoothness
 from keras.src.losses.losses import Hinge
 from keras.src.losses.losses import Huber
 from keras.src.losses.losses import KLDivergence
@@ -20,19 +24,23 @@ from keras.src.losses.losses import MeanAbsoluteError
 from keras.src.losses.losses import MeanAbsolutePercentageError
 from keras.src.losses.losses import MeanSquaredError
 from keras.src.losses.losses import MeanSquaredLogarithmicError
+from keras.src.losses.losses import PerceptualLoss
 from keras.src.losses.losses import Poisson
 from keras.src.losses.losses import SparseCategoricalCrossentropy
 from keras.src.losses.losses import SquaredHinge
+from keras.src.losses.losses import TotalVariation
 from keras.src.losses.losses import Tversky
 from keras.src.losses.losses import binary_crossentropy
 from keras.src.losses.losses import binary_focal_crossentropy
 from keras.src.losses.losses import categorical_crossentropy
 from keras.src.losses.losses import categorical_focal_crossentropy
 from keras.src.losses.losses import categorical_hinge
+from keras.src.losses.losses import charbonnier
 from keras.src.losses.losses import circle
 from keras.src.losses.losses import cosine_similarity
 from keras.src.losses.losses import ctc
 from keras.src.losses.losses import dice
+from keras.src.losses.losses import edge_aware_smoothness
 from keras.src.losses.losses import hinge
 from keras.src.losses.losses import huber
 from keras.src.losses.losses import kl_divergence
@@ -41,9 +49,12 @@ from keras.src.losses.losses import mean_absolute_error
 from keras.src.losses.losses import mean_absolute_percentage_error
 from keras.src.losses.losses import mean_squared_error
 from keras.src.losses.losses import mean_squared_logarithmic_error
+from keras.src.losses.losses import msssim
 from keras.src.losses.losses import poisson
+from keras.src.losses.losses import psnr
 from keras.src.losses.losses import sparse_categorical_crossentropy
 from keras.src.losses.losses import squared_hinge
+from keras.src.losses.losses import total_variation
 from keras.src.losses.losses import tversky
 from keras.src.saving import serialization_lib
 
@@ -74,6 +85,13 @@ ALL_OBJECTS = {
     # Image segmentation
     Dice,
     Tversky,
+    # Image restoration
+    Charbonnier,
+    PSNR,
+    TotalVariation,
+    EdgeAwareSmoothness,
+    MSSSIM,
+    PerceptualLoss,
     # Similarity
     Circle,
     # Sequence
@@ -101,6 +119,12 @@ ALL_OBJECTS = {
     # Image segmentation
     dice,
     tversky,
+    # Image restoration
+    charbonnier,
+    psnr,
+    total_variation,
+    edge_aware_smoothness,
+    msssim,
     # Similarity
     circle,
     # Sequence

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -3191,7 +3191,7 @@ def edge_aware_smoothness(y_true, y_pred, axis=None, data_format=None):
             f"(batched images). Received input rank {rank}."
         )
 
-    spatial_axes = _canonicalize_spatial_axes(None, data_format, rank)
+    all_spatial_axes = _canonicalize_spatial_axes(None, data_format, rank)
     axis = _canonicalize_spatial_axes(axis, data_format, rank)
 
     loss = 0.0
@@ -3204,9 +3204,10 @@ def edge_aware_smoothness(y_true, y_pred, axis=None, data_format=None):
         pred_grad = y_pred[tuple(slice1)] - y_pred[tuple(slice2)]
         true_grad = y_true[tuple(slice1)] - y_true[tuple(slice2)]
         weighted = ops.abs(pred_grad) * ops.exp(-ops.abs(true_grad))
-        loss = loss + ops.sum(weighted, axis=spatial_axes)
+        loss = loss + ops.sum(weighted, axis=all_spatial_axes)
     if ops.ndim(loss) > 0:
         loss = ops.sum(loss, axis=-1)
+    return loss
     return loss
 
 

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -11,6 +11,9 @@ from keras.src.saving import serialization_lib
 from keras.src.utils.numerical_utils import build_pos_neg_masks
 from keras.src.utils.numerical_utils import normalize
 
+# Standard MS-SSIM power factors from the multi-scale SSIM paper.
+_MS_SSIM_WEIGHTS = (0.0448, 0.2856, 0.3001, 0.2363, 0.1333)
+
 
 class LossFunctionWrapper(Loss):
     def __init__(
@@ -2791,3 +2794,1111 @@ def categorical_generalized_cross_entropy(y_true, y_pred, q):
     gce_loss = (1 - ops.power(p, q)) / q
 
     return gce_loss
+
+
+def _canonicalize_spatial_axes(axis, data_format, y_rank):
+    """Return and validate the spatial axes tuple for an image tensor.
+
+    For `channels_last` the default spatial axes are `(-3, -2)` and the
+    channel axis is `-1`. For `channels_first` the default spatial axes are
+    `(-2, -1)` and the channel axis is `-3`.
+    """
+    data_format = backend.standardize_data_format(data_format)
+    if data_format == "channels_last":
+        default_spatial = (-3, -2)
+        channel_axis = -1
+    else:
+        default_spatial = (-2, -1)
+        channel_axis = -3
+
+    if axis is None:
+        axis = default_spatial
+    if isinstance(axis, int):
+        axis = (axis,)
+    axis = tuple(canonicalize_axis(a, y_rank) for a in axis)
+    channel_axis = canonicalize_axis(channel_axis, y_rank)
+
+    if y_rank == 4 and 0 in axis:
+        raise ValueError(
+            f"`axis` must not include the batch axis 0. Received axis={axis}."
+        )
+    if channel_axis in axis:
+        raise ValueError(
+            "`axis` must not include the channel axis. "
+            f"Received axis={axis} for data_format={data_format}."
+        )
+    return axis
+
+
+def _ensure_4d_images(y_true, y_pred, data_format):
+    """Convert 3D/4D image tensors to 4D channels_last tensors.
+
+    Returns:
+        Tuple of `(y_true_4d, y_pred_4d, was_unbatched, original_data_format)`.
+    """
+    data_format = backend.standardize_data_format(data_format)
+    y_pred = ops.convert_to_tensor(y_pred)
+    y_true = ops.cast(y_true, y_pred.dtype)
+
+    rank = ops.ndim(y_pred)
+    if rank not in (3, 4):
+        raise ValueError(
+            "Image restoration losses expect rank 3 (single image) or rank 4 "
+            f"(batched images). Received input rank {rank}."
+        )
+
+    unbatched = rank == 3
+    if unbatched:
+        y_pred = ops.expand_dims(y_pred, axis=0)
+        y_true = ops.expand_dims(y_true, axis=0)
+
+    if data_format == "channels_first":
+        y_pred = ops.moveaxis(y_pred, 1, -1)
+        y_true = ops.moveaxis(y_true, 1, -1)
+
+    return y_true, y_pred, unbatched, data_format
+
+
+def _restore_batch_dim(result, unbatched):
+    """Remove the batch dimension that was added for unbatched inputs."""
+    if unbatched and ops.ndim(result) > 0:
+        result = ops.squeeze(result, axis=0)
+    return result
+
+
+def _create_gaussian_kernel2d(filter_size, filter_sigma, dtype):
+    """Create a 2D Gaussian kernel for SSIM filtering."""
+    x = ops.arange(filter_size, dtype=dtype)
+    x = x - (filter_size - 1) / 2.0
+    gauss_1d = ops.exp(-(x**2) / (2.0 * filter_sigma**2))
+    gauss_1d = gauss_1d / ops.sum(gauss_1d)
+    return ops.expand_dims(gauss_1d, axis=-1) * ops.expand_dims(
+        gauss_1d, axis=0
+    )
+
+
+def _ssim_components_per_channel(
+    img1, img2, max_val, filter_size, filter_sigma, k1, k2
+):
+    """Compute luminance and contrast-structure components per channel.
+
+    Args:
+        img1: 4D tensor `(B, H, W, C)` in channels-last format.
+        img2: 4D tensor `(B, H, W, C)` in channels-last format.
+
+    Returns:
+        Tuple of `(luminance, contrast_structure)`, each of shape
+        `(B, H', W', C)` where `H' = H - filter_size + 1`.
+    """
+    dtype = img1.dtype
+    c1 = ops.cast((k1 * max_val) ** 2, dtype)
+    c2 = ops.cast((k2 * max_val) ** 2, dtype)
+
+    kernel = _create_gaussian_kernel2d(filter_size, filter_sigma, dtype)
+    kernel = ops.reshape(kernel, (filter_size, filter_size, 1, 1))
+
+    shape = backend.shape(img1)
+    height = shape[1]
+    width = shape[2]
+    channels = shape[3]
+
+    def _depthwise_conv4d(x):
+        x = ops.transpose(x, (0, 3, 1, 2))
+        x = ops.reshape(x, [-1, height, width, 1])
+        y = ops.conv(
+            x, kernel, strides=1, padding="valid", data_format="channels_last"
+        )
+        shape_y = backend.shape(y)
+        y = ops.reshape(y, [-1, channels, shape_y[1], shape_y[2]])
+        return ops.transpose(y, (0, 2, 3, 1))
+
+    mu1 = _depthwise_conv4d(img1)
+    mu2 = _depthwise_conv4d(img2)
+
+    mu1_sq = mu1 * mu1
+    mu2_sq = mu2 * mu2
+    mu1_mu2 = mu1 * mu2
+
+    sigma1_sq = _depthwise_conv4d(img1 * img1) - mu1_sq
+    sigma2_sq = _depthwise_conv4d(img2 * img2) - mu2_sq
+    sigma12 = _depthwise_conv4d(img1 * img2) - mu1_mu2
+
+    luminance = (2.0 * mu1_mu2 + c1) / (mu1_sq + mu2_sq + c1)
+    contrast_structure = (2.0 * sigma12 + c2) / (sigma1_sq + sigma2_sq + c2)
+    return luminance, contrast_structure
+
+
+def _multiscale_ssim(
+    img1,
+    img2,
+    max_val,
+    power_factors,
+    filter_size,
+    filter_sigma,
+    k1,
+    k2,
+):
+    """Compute Multi-Scale SSIM between two 4D channels-last image tensors.
+
+    SSIM is computed over the spatial axes `(-3, -2)` and averaged over the
+    channel axis `(-1)`. Returns a per-image tensor of shape `(B,)`.
+    """
+    num_scales = len(power_factors)
+    weighted_components = []
+
+    for i in range(num_scales - 1):
+        _, cs = _ssim_components_per_channel(
+            img1, img2, max_val, filter_size, filter_sigma, k1, k2
+        )
+        cs = ops.mean(cs, axis=(1, 2))
+        cs = ops.maximum(cs, 0.0)
+        weighted_components.append(ops.power(cs, power_factors[i]))
+        img1 = ops.nn.average_pool(
+            img1,
+            pool_size=2,
+            strides=2,
+            padding="same",
+            data_format="channels_last",
+        )
+        img2 = ops.nn.average_pool(
+            img2,
+            pool_size=2,
+            strides=2,
+            padding="same",
+            data_format="channels_last",
+        )
+
+    luminance, cs = _ssim_components_per_channel(
+        img1, img2, max_val, filter_size, filter_sigma, k1, k2
+    )
+    ssim = luminance * cs
+    ssim = ops.mean(ssim, axis=(1, 2))
+    ssim = ops.maximum(ssim, 0.0)
+    weighted_components.append(ops.power(ssim, power_factors[-1]))
+
+    ms_ssim_per_channel = ops.prod(
+        ops.stack(weighted_components, axis=1), axis=1
+    )
+    return ops.mean(ms_ssim_per_channel, axis=-1)
+
+
+@keras_export("keras.losses.charbonnier")
+def charbonnier(y_true, y_pred, epsilon=1e-3):
+    """Computes the Charbonnier loss between `y_true` and `y_pred`.
+
+    The Charbonnier loss is a smooth variant of L1 loss commonly used in
+    image restoration tasks. It is less sensitive to outliers than MSE while
+    remaining differentiable at zero.
+
+    Formula:
+
+    ```python
+    loss = mean(sqrt((y_true - y_pred) ** 2 + epsilon ** 2))
+    ```
+
+    The mean is taken over all axes except the batch axis.
+
+    Args:
+        y_true: Ground truth values.
+        y_pred: Predicted values.
+        epsilon: Small constant added for numerical stability and to control
+            smoothness around zero. Defaults to `1e-3`.
+
+    Returns:
+        Charbonnier loss values with shape `[batch_size]`.
+
+    Example:
+
+    >>> y_true = np.random.random((2, 64, 64, 3))
+    >>> y_pred = np.random.random((2, 64, 64, 3))
+    >>> loss = keras.losses.charbonnier(y_true, y_pred)
+    """
+    y_pred = ops.convert_to_tensor(y_pred)
+    y_true = ops.cast(y_true, y_pred.dtype)
+    epsilon = ops.cast(epsilon, y_pred.dtype)
+    diff = y_true - y_pred
+    loss = ops.sqrt(ops.square(diff) + ops.square(epsilon))
+    axes = list(range(1, ops.ndim(loss)))
+    if axes:
+        loss = ops.mean(loss, axis=axes)
+    return loss
+
+
+@keras_export("keras.losses.psnr")
+def psnr(y_true, y_pred, max_val=1.0, axis=None):
+    """Computes the negative PSNR between `y_true` and `y_pred`.
+
+    Peak Signal-to-Noise Ratio (PSNR) is commonly used as an image quality
+    metric. Returned as a loss, it equals `-PSNR`, so minimizing this loss
+    maximizes PSNR.
+
+    Formula:
+
+    ```python
+    mse = mean((y_true - y_pred) ** 2, axis=axis)
+    psnr = 20 * log10(max_val) - 10 * log10(mse)
+    loss = -psnr
+    ```
+
+    Args:
+        y_true: Ground truth image tensor. Expected rank 3 or 4.
+        y_pred: Predicted image tensor. Expected rank 3 or 4.
+        max_val: The maximum possible pixel value. Defaults to `1.0`.
+        axis: Tuple of axes over which the MSE is computed. Defaults to all
+            axes except the batch axis.
+
+    Returns:
+        Negative PSNR values with shape `[batch_size]`.
+
+    Example:
+
+    >>> y_true = np.random.random((2, 64, 64, 3))
+    >>> y_pred = y_true + 0.1
+    >>> loss = keras.losses.psnr(y_true, y_pred)
+    """
+    y_pred = ops.convert_to_tensor(y_pred)
+    y_true = ops.cast(y_true, y_pred.dtype)
+    max_val = ops.cast(max_val, y_pred.dtype)
+
+    rank = ops.ndim(y_pred)
+    if rank not in (3, 4):
+        raise ValueError(
+            "`psnr` expects rank 3 (single image) or rank 4 (batched images). "
+            f"Received input rank {rank}."
+        )
+
+    if axis is None:
+        axis = tuple(range(1, rank))
+    elif isinstance(axis, int):
+        axis = (axis,)
+
+    mse = ops.mean(ops.square(y_true - y_pred), axis=axis)
+    mse = ops.maximum(mse, backend.epsilon())
+    psnr_value = 20.0 * ops.log10(max_val) - 10.0 * ops.log10(mse)
+    return -psnr_value
+
+
+@keras_export("keras.losses.total_variation")
+def total_variation(y_true, y_pred, axis=None, data_format=None):
+    """Computes the total variation of `y_pred`.
+
+    Total variation measures the sum of absolute differences between
+    neighboring pixels. It is typically used as a regularizer in image
+    restoration to encourage spatial smoothness. `y_true` is ignored and is
+    present only for API consistency with other Keras losses.
+
+    Formula:
+
+    ```python
+    loss = sum(abs(y_pred[..., 1:, ...] - y_pred[..., :-1, ...]))
+    ```
+
+    The loss is computed over the spatial axes specified by `axis` and then
+    summed over the channel dimension, yielding one scalar value per image.
+
+    Args:
+        y_true: Ground truth values
+        y_pred: Predicted image tensor. Expected rank 3 or 4.
+        axis: Tuple of spatial axes over which to compute total variation.
+            If `None`, defaults to `(-3, -2)` for channels-last data or
+            `(-2, -1)` for channels-first data.
+        data_format: A string specifying the data format, either
+            `"channels_last"` or `"channels_first"`. If `None`, defaults to
+            `keras.config.image_data_format()`.
+
+    Returns:
+        Total variation values with shape `[batch_size]` (or a scalar for
+        unbatched rank-3 inputs).
+
+    Example:
+
+    >>> y_true = np.zeros((2, 64, 64, 3))
+    >>> y_pred = np.random.random((2, 64, 64, 3))
+    >>> loss = keras.losses.total_variation(y_true, y_pred)
+    """
+    y_pred = ops.convert_to_tensor(y_pred)
+    data_format = backend.standardize_data_format(data_format)
+
+    rank = ops.ndim(y_pred)
+    if rank not in (3, 4):
+        raise ValueError(
+            "`total_variation` expects rank 3 (single image) or rank 4 "
+            f"(batched images). Received input rank {rank}."
+        )
+
+    axis = _canonicalize_spatial_axes(axis, data_format, rank)
+
+    loss = 0.0
+    ndim = rank
+    for ax in axis:
+        slice1 = [slice(None)] * ndim
+        slice1[ax] = slice(1, None)
+        slice2 = [slice(None)] * ndim
+        slice2[ax] = slice(None, -1)
+        diff = y_pred[tuple(slice1)] - y_pred[tuple(slice2)]
+        loss = loss + ops.sum(ops.abs(diff), axis=axis)
+    if ops.ndim(loss) > 0:
+        loss = ops.sum(loss, axis=-1)
+    return loss
+
+
+@keras_export("keras.losses.edge_aware_smoothness")
+def edge_aware_smoothness(y_true, y_pred, axis=None, data_format=None):
+    """Computes edge-aware smoothness loss between `y_true` and `y_pred`.
+
+    This loss encourages `y_pred` to be smooth while preserving edges present
+    in `y_true`. The predicted gradient at each pixel is down-weighted by an
+    exponential of the corresponding ground-truth gradient magnitude.
+
+    Formula:
+
+    ```python
+    loss = sum(abs(dy_pred) * exp(-abs(dy_true)))
+    ```
+
+    Args:
+        y_true: Ground truth image tensor used to detect edges. Expected rank
+            3 or 4.
+        y_pred: Predicted image tensor that is penalized for being non-smooth.
+            Expected rank 3 or 4.
+        axis: Tuple of spatial axes over which to compute the loss. If `None`,
+            defaults to `(-3, -2)` for channels-last data or `(-2, -1)` for
+            channels-first data.
+        data_format: A string specifying the data format, either
+            `"channels_last"` or `"channels_first"`. If `None`, defaults to
+            `keras.config.image_data_format()`.
+
+    Returns:
+        Edge-aware smoothness values with shape `[batch_size]` (or a scalar
+        for unbatched rank-3 inputs).
+
+    Example:
+
+    >>> y_true = np.random.random((2, 64, 64, 3))
+    >>> y_pred = np.random.random((2, 64, 64, 3))
+    >>> loss = keras.losses.edge_aware_smoothness(y_true, y_pred)
+    """
+    y_pred = ops.convert_to_tensor(y_pred)
+    y_true = ops.cast(y_true, y_pred.dtype)
+    data_format = backend.standardize_data_format(data_format)
+
+    rank = ops.ndim(y_pred)
+    if rank not in (3, 4):
+        raise ValueError(
+            "`edge_aware_smoothness` expects rank 3 (single image) or rank 4 "
+            f"(batched images). Received input rank {rank}."
+        )
+
+    axis = _canonicalize_spatial_axes(axis, data_format, rank)
+
+    loss = 0.0
+    ndim = rank
+    for ax in axis:
+        slice1 = [slice(None)] * ndim
+        slice1[ax] = slice(1, None)
+        slice2 = [slice(None)] * ndim
+        slice2[ax] = slice(None, -1)
+        pred_grad = y_pred[tuple(slice1)] - y_pred[tuple(slice2)]
+        true_grad = y_true[tuple(slice1)] - y_true[tuple(slice2)]
+        weighted = ops.abs(pred_grad) * ops.exp(-ops.abs(true_grad))
+        loss = loss + ops.sum(weighted, axis=axis)
+    if ops.ndim(loss) > 0:
+        loss = ops.sum(loss, axis=-1)
+    return loss
+
+
+@keras_export("keras.losses.msssim")
+def msssim(
+    y_true,
+    y_pred,
+    max_val=1.0,
+    alpha=0.84,
+    l1_weight=0.0,
+    axis=None,
+    data_format=None,
+    filter_size=11,
+    filter_sigma=1.5,
+    k1=0.01,
+    k2=0.03,
+    power_factors=_MS_SSIM_WEIGHTS,
+):
+    """Computes the Multi-Scale Structural Similarity (MS-SSIM) loss.
+
+    The returned value is `alpha * (1 - MS-SSIM) + (1 - alpha) * l1_weight * L1`
+    so that minimizing it maximizes MS-SSIM. When `l1_weight` is `0`, only the
+    MS-SSIM term is returned (scaled by `alpha`).
+
+    SSIM is computed over the spatial axes and averaged over channels. The
+    `axis` argument is validated to be the spatial axes for the given
+    `data_format` and is used only for the optional L1 term.
+
+    Args:
+        y_true: Ground truth image tensor. Expected rank 3 or 4.
+        y_pred: Predicted image tensor. Expected rank 3 or 4.
+        max_val: The maximum possible pixel value. Defaults to `1.0`.
+        alpha: Weight of the MS-SSIM term in the MS-SSIM + L1 combination.
+            Defaults to `0.84`.
+        l1_weight: Weight of the L1 term. When `0`, the L1 term is omitted.
+            Defaults to `0.0`.
+        axis: Tuple of spatial axes. If `None`, defaults to `(-3, -2)` for
+            channels-last data or `(-2, -1)` for channels-first data.
+        data_format: A string specifying the data format, either
+            `"channels_last"` or `"channels_first"`. If `None`, defaults to
+            `keras.config.image_data_format()`.
+        filter_size: Size of the Gaussian filter used for SSIM. Defaults to
+            `11`.
+        filter_sigma: Standard deviation of the Gaussian filter. Defaults to
+            `1.5`.
+        k1: First SSIM stabilization constant. Defaults to `0.01`.
+        k2: Second SSIM stabilization constant. Defaults to `0.03`.
+        power_factors: Tuple of weights for each scale. Defaults to the
+            standard MS-SSIM weights. The number of scales equals
+            `len(power_factors)`.
+
+    Returns:
+        MS-SSIM loss values with shape `[batch_size]`.
+
+    Example:
+
+    >>> y_true = np.random.random((2, 32, 32, 3))
+    >>> y_pred = y_true + 0.05
+    >>> loss = keras.losses.msssim(
+    ...     y_true, y_pred, filter_size=5, power_factors=(0.5, 0.5)
+    ... )
+
+    """
+    y_true, y_pred, unbatched, data_format = _ensure_4d_images(
+        y_true, y_pred, data_format
+    )
+
+    _canonicalize_spatial_axes(axis, data_format, ops.ndim(y_pred))
+
+    shape = backend.shape(y_pred)
+    height = shape[1]
+    width = shape[2]
+    num_scales = len(power_factors)
+    min_size = filter_size * (2 ** (num_scales - 1))
+    if height < min_size or width < min_size:
+        raise ValueError(
+            "MS-SSIM requires input spatial size to be at least "
+            f"{min_size}x{min_size} for {num_scales} scales and "
+            f"filter_size={filter_size}. Received shape "
+            f"({shape[0]}, {height}, {width}, {shape[3]}). Use fewer "
+            "scales, a smaller filter_size, or larger input images."
+        )
+
+    ms_ssim = _multiscale_ssim(
+        y_pred,
+        y_true,
+        max_val,
+        power_factors,
+        filter_size,
+        filter_sigma,
+        k1,
+        k2,
+    )
+
+    ms_ssim = ops.cast(ms_ssim, y_pred.dtype)
+    loss = alpha * (1.0 - ms_ssim)
+
+    if not (isinstance(l1_weight, (int, float)) and l1_weight == 0.0):
+        l1_weight = ops.cast(l1_weight, y_pred.dtype)
+        # Use the channels-last spatial axes for the L1 term.
+        l1 = ops.mean(ops.abs(y_true - y_pred), axis=(1, 2))
+        l1 = ops.mean(l1, axis=-1)  # average over channels
+        loss = loss + (1.0 - alpha) * l1_weight * l1
+
+    return _restore_batch_dim(loss, unbatched)
+
+
+@keras_export("keras.losses.Charbonnier")
+class Charbonnier(LossFunctionWrapper):
+    """Computes the Charbonnier loss between labels and predictions.
+
+    Args:
+        epsilon: Small constant added for numerical stability. Defaults to
+            `1e-3`.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`.
+
+    Example:
+
+    >>> y_true = np.random.random((2, 64, 64, 3))
+    >>> y_pred = np.random.random((2, 64, 64, 3))
+    >>> loss = keras.losses.Charbonnier()(y_true, y_pred)
+    """
+
+    def __init__(
+        self,
+        epsilon=1e-3,
+        reduction="sum_over_batch_size",
+        name="charbonnier",
+        dtype=None,
+    ):
+        super().__init__(
+            charbonnier,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            epsilon=epsilon,
+        )
+        self.epsilon = epsilon
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update({"epsilon": self.epsilon})
+        return config
+
+
+@keras_export("keras.losses.PSNR")
+class PSNR(LossFunctionWrapper):
+    """Computes the negative PSNR loss between labels and predictions.
+
+    Args:
+        max_val: The maximum possible pixel value. Defaults to `1.0`.
+        axis: Tuple of axes over which the MSE is computed. Defaults to all
+            axes except the batch axis.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`.
+
+    Example:
+
+    >>> y_true = np.random.random((2, 64, 64, 3))
+    >>> y_pred = y_true + 0.1
+    >>> loss = keras.losses.PSNR()(y_true, y_pred)
+    """
+
+    def __init__(
+        self,
+        max_val=1.0,
+        axis=None,
+        reduction="sum_over_batch_size",
+        name="psnr",
+        dtype=None,
+    ):
+        super().__init__(
+            psnr,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            max_val=max_val,
+            axis=axis,
+        )
+        self.max_val = max_val
+        self.axis = axis
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update({"max_val": self.max_val, "axis": self.axis})
+        return config
+
+
+@keras_export("keras.losses.TotalVariation")
+class TotalVariation(LossFunctionWrapper):
+    """Computes the total variation of predictions.
+
+    Args:
+        axis: Tuple of spatial axes over which to compute total variation.
+            If `None`, defaults to `(-3, -2)` for channels-last data or
+            `(-2, -1)` for channels-first data.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`.
+        data_format: A string specifying the data format, either
+            `"channels_last"` or `"channels_first"`. If `None`, defaults to
+            `keras.config.image_data_format()`.
+
+    Example:
+
+    >>> y_true = np.zeros((2, 64, 64, 3))
+    >>> y_pred = np.random.random((2, 64, 64, 3))
+    >>> loss = keras.losses.TotalVariation()(y_true, y_pred)
+    """
+
+    def __init__(
+        self,
+        axis=None,
+        reduction="sum_over_batch_size",
+        name="total_variation",
+        dtype=None,
+        data_format=None,
+    ):
+        super().__init__(
+            total_variation,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            axis=axis,
+            data_format=data_format,
+        )
+        self.axis = axis
+        self.data_format = data_format
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update({"axis": self.axis, "data_format": self.data_format})
+        return config
+
+
+@keras_export("keras.losses.EdgeAwareSmoothness")
+class EdgeAwareSmoothness(LossFunctionWrapper):
+    """Computes edge-aware smoothness loss between labels and predictions.
+
+    Args:
+        axis: Tuple of spatial axes over which to compute the loss. If `None`,
+            defaults to `(-3, -2)` for channels-last data or `(-2, -1)` for
+            channels-first data.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`.
+        data_format: A string specifying the data format, either
+            `"channels_last"` or `"channels_first"`. If `None`, defaults to
+            `keras.config.image_data_format()`.
+
+    Example:
+
+    >>> y_true = np.random.random((2, 64, 64, 3))
+    >>> y_pred = np.random.random((2, 64, 64, 3))
+    >>> loss = keras.losses.EdgeAwareSmoothness()(y_true, y_pred)
+    """
+
+    def __init__(
+        self,
+        axis=None,
+        reduction="sum_over_batch_size",
+        name="edge_aware_smoothness",
+        dtype=None,
+        data_format=None,
+    ):
+        super().__init__(
+            edge_aware_smoothness,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            axis=axis,
+            data_format=data_format,
+        )
+        self.axis = axis
+        self.data_format = data_format
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update({"axis": self.axis, "data_format": self.data_format})
+        return config
+
+
+@keras_export("keras.losses.MSSSIM")
+class MSSSIM(LossFunctionWrapper):
+    """Computes the Multi-Scale Structural Similarity (MS-SSIM) loss.
+
+    Args:
+        max_val: The maximum possible pixel value. Defaults to `1.0`.
+        alpha: Weight of the MS-SSIM term in the MS-SSIM + L1 combination.
+            Defaults to `0.84`.
+        l1_weight: Weight of the optional L1 term. When `0`, the L1 term is
+            omitted. Defaults to `0.0`.
+        axis: Tuple of spatial axes. If `None`, defaults to `(-3, -2)` for
+            channels-last data or `(-2, -1)` for channels-first data.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`.
+        data_format: A string specifying the data format, either
+            `"channels_last"` or `"channels_first"`. If `None`, defaults to
+            `keras.config.image_data_format()`.
+        filter_size: Size of the Gaussian filter used for SSIM. Defaults to
+            `11`.
+        filter_sigma: Standard deviation of the Gaussian filter. Defaults to
+            `1.5`.
+        k1: First SSIM stabilization constant. Defaults to `0.01`.
+        k2: Second SSIM stabilization constant. Defaults to `0.03`.
+        power_factors: Tuple of weights for each scale. Defaults to the
+            standard MS-SSIM weights.
+
+    Example:
+
+    >>> y_true = np.random.random((2, 32, 32, 3))
+    >>> y_pred = y_true + 0.05
+    >>> loss = keras.losses.MSSSIM(
+    ...     filter_size=5, power_factors=(0.5, 0.5)
+    ... )(y_true, y_pred)
+    """
+
+    def __init__(
+        self,
+        max_val=1.0,
+        alpha=0.84,
+        l1_weight=0.0,
+        axis=None,
+        reduction="sum_over_batch_size",
+        name="msssim",
+        dtype=None,
+        data_format=None,
+        filter_size=11,
+        filter_sigma=1.5,
+        k1=0.01,
+        k2=0.03,
+        power_factors=_MS_SSIM_WEIGHTS,
+    ):
+        super().__init__(
+            msssim,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            max_val=max_val,
+            alpha=alpha,
+            l1_weight=l1_weight,
+            axis=axis,
+            data_format=data_format,
+            filter_size=filter_size,
+            filter_sigma=filter_sigma,
+            k1=k1,
+            k2=k2,
+            power_factors=power_factors,
+        )
+        self.max_val = max_val
+        self.alpha = alpha
+        self.l1_weight = l1_weight
+        self.axis = axis
+        self.data_format = data_format
+        self.filter_size = filter_size
+        self.filter_sigma = filter_sigma
+        self.k1 = k1
+        self.k2 = k2
+        self.power_factors = power_factors
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update(
+            {
+                "max_val": self.max_val,
+                "alpha": self.alpha,
+                "l1_weight": self.l1_weight,
+                "axis": self.axis,
+                "data_format": self.data_format,
+                "filter_size": self.filter_size,
+                "filter_sigma": self.filter_sigma,
+                "k1": self.k1,
+                "k2": self.k2,
+                "power_factors": self.power_factors,
+            }
+        )
+        return config
+
+
+@keras_export("keras.losses.PerceptualLoss")
+class PerceptualLoss(Loss):
+    """Computes perceptual distance using feature extractor outputs.
+
+    Perceptual loss compares `y_true` and `y_pred` after passing them through a
+    user-provided feature extractor. The extractor may return a single tensor,
+    a list/tuple of tensors, or a dictionary of tensors. When multiple feature
+    tensors are returned, the per-feature losses are added together.
+
+    Args:
+        feature_extractor: A callable, layer, or model used to produce features
+            from `y_true` and `y_pred`. It is called with `training=False` when
+            supported.
+        layers: Optional feature outputs to use. For dictionary outputs, pass
+            keys. For list/tuple outputs, pass integer indices. If `None`, all
+            extractor outputs are used.
+        weights: Optional feature weights. Pass a scalar to weight every
+            selected feature equally, a list/tuple matching `layers`, or a
+            dictionary mapping selected output keys/indices to weights.
+        feature_loss: Per-feature distance, either `"l1"` or `"l2"`. Defaults
+            to `"l2"`.
+        normalize: Whether to L2-normalize feature tensors before computing the
+            distance. Defaults to `False`.
+        normalize_axis: Axis along which features are normalized when
+            `normalize=True`. Defaults to `-1`.
+        axis: Axes over which each feature distance is averaged. If `None`,
+            averages over all axes except the first axis.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`.
+
+    Example:
+
+    >>> inputs = keras.Input((64, 64, 3))
+    >>> x = keras.layers.Conv2D(8, 3, activation="relu")(inputs)
+    >>> features = keras.layers.GlobalAveragePooling2D()(x)
+    >>> extractor = keras.Model(inputs, features)
+    >>> loss = keras.losses.PerceptualLoss(extractor)
+    >>> y_true = np.random.random((2, 64, 64, 3))
+    >>> y_pred = np.random.random((2, 64, 64, 3))
+    >>> loss(y_true, y_pred)
+    """
+
+    def __init__(
+        self,
+        feature_extractor=None,
+        layers=None,
+        weights=None,
+        feature_loss="l2",
+        normalize=False,
+        normalize_axis=-1,
+        axis=None,
+        reduction="sum_over_batch_size",
+        name="perceptual_loss",
+        dtype=None,
+    ):
+        super().__init__(name=name, reduction=reduction, dtype=dtype)
+        if feature_loss not in ("l1", "l2"):
+            raise ValueError(
+                "Invalid value for argument `feature_loss`. "
+                "Expected one of {'l1', 'l2'}. "
+                f"Received: feature_loss={feature_loss}"
+            )
+        self.feature_extractor = feature_extractor
+        self.layers = layers
+        self.weights = weights
+        self.feature_loss = feature_loss
+        self.normalize = normalize
+        self.normalize_axis = normalize_axis
+        self.axis = axis
+
+    def call(self, y_true, y_pred):
+        if self.feature_extractor is None:
+            raise ValueError(
+                "`feature_extractor` must be provided before calling "
+                "`PerceptualLoss`."
+            )
+
+        y_true_features = self._select_features(
+            self._call_feature_extractor(y_true)
+        )
+        y_pred_features = self._select_features(
+            self._call_feature_extractor(y_pred)
+        )
+        if len(y_true_features) != len(y_pred_features):
+            raise ValueError(
+                "`feature_extractor` must return the same number of feature "
+                "outputs for `y_true` and `y_pred`."
+            )
+        if not y_true_features:
+            raise ValueError(
+                "`feature_extractor` must return at least one feature output."
+            )
+
+        feature_weights = self._resolve_weights(
+            [key for key, _ in y_true_features]
+        )
+        loss = None
+        for (y_true_key, y_true_feature), (
+            y_pred_key,
+            y_pred_feature,
+        ), feature_weight in zip(
+            y_true_features, y_pred_features, feature_weights
+        ):
+            if y_true_key != y_pred_key:
+                raise ValueError(
+                    "`feature_extractor` returned mismatched feature outputs "
+                    f"for `y_true` and `y_pred`: {y_true_key} vs. "
+                    f"{y_pred_key}."
+                )
+            y_true_feature = ops.convert_to_tensor(
+                y_true_feature, dtype=self.dtype
+            )
+            y_pred_feature = ops.convert_to_tensor(
+                y_pred_feature, dtype=self.dtype
+            )
+            y_true_feature, y_pred_feature = squeeze_or_expand_to_same_rank(
+                y_true_feature, y_pred_feature
+            )
+            if self.normalize:
+                normalize_axis = canonicalize_axis(
+                    self.normalize_axis, ops.ndim(y_pred_feature)
+                )
+                y_true_feature = normalize(y_true_feature, axis=normalize_axis)
+                y_pred_feature = normalize(y_pred_feature, axis=normalize_axis)
+
+            difference = y_pred_feature - y_true_feature
+            if self.feature_loss == "l1":
+                feature_loss = ops.abs(difference)
+            else:
+                feature_loss = ops.square(difference)
+
+            reduction_axis = self._feature_reduction_axis(feature_loss)
+            if reduction_axis is not None:
+                feature_loss = ops.mean(feature_loss, axis=reduction_axis)
+
+            feature_loss = feature_loss * ops.cast(
+                feature_weight, feature_loss.dtype
+            )
+            loss = feature_loss if loss is None else loss + feature_loss
+
+        return loss
+
+    def _call_feature_extractor(self, inputs):
+        try:
+            return self.feature_extractor(inputs, training=False)
+        except TypeError:
+            return self.feature_extractor(inputs)
+
+    def _select_features(self, features):
+        selectors = self._feature_selectors()
+        if isinstance(features, dict):
+            if selectors is None:
+                return list(features.items())
+            selected_features = []
+            for selector in selectors:
+                if selector not in features:
+                    raise ValueError(
+                        "`layers` contains a key that is not present in the "
+                        "`feature_extractor` output dictionary. "
+                        f"Received: {selector}"
+                    )
+                selected_features.append((selector, features[selector]))
+            return selected_features
+
+        if isinstance(features, (list, tuple)):
+            if selectors is None:
+                return list(enumerate(features))
+            selected_features = []
+            for selector in selectors:
+                if not isinstance(selector, int):
+                    raise ValueError(
+                        "`layers` entries must be integer indices when "
+                        "`feature_extractor` returns a list or tuple. "
+                        f"Received: {selector}"
+                    )
+                index = selector
+                if index < 0:
+                    index += len(features)
+                if index < 0 or index >= len(features):
+                    raise ValueError(
+                        "`layers` contains an index that is out of range for "
+                        "`feature_extractor` outputs. "
+                        f"Received: {selector}"
+                    )
+                selected_features.append((selector, features[selector]))
+            return selected_features
+
+        if selectors is not None:
+            raise ValueError(
+                "`layers` can only be used when `feature_extractor` returns "
+                "a dictionary, list, or tuple of features."
+            )
+        return [(0, features)]
+
+    def _feature_selectors(self):
+        if self.layers is None:
+            return None
+        if isinstance(self.layers, (list, tuple)):
+            return list(self.layers)
+        return [self.layers]
+
+    def _resolve_weights(self, feature_keys):
+        if self.weights is None:
+            return [1.0] * len(feature_keys)
+        if isinstance(self.weights, dict):
+            missing = [key for key in feature_keys if key not in self.weights]
+            if missing:
+                raise ValueError(
+                    "`weights` is missing entries for selected feature "
+                    f"outputs: {missing}"
+                )
+            return [self.weights[key] for key in feature_keys]
+        if isinstance(self.weights, (list, tuple)):
+            if len(self.weights) != len(feature_keys):
+                raise ValueError(
+                    "`weights` must have the same length as the selected "
+                    "feature outputs. "
+                    f"Received {len(self.weights)} weights for "
+                    f"{len(feature_keys)} feature outputs."
+                )
+            return list(self.weights)
+        return [self.weights] * len(feature_keys)
+
+    def _feature_reduction_axis(self, feature_loss):
+        rank = ops.ndim(feature_loss)
+        if self.axis is None:
+            if rank == 0:
+                return None
+            if rank == 1:
+                return (0,)
+            return tuple(range(1, rank))
+        axis = self.axis
+        if isinstance(axis, int):
+            axis = (axis,)
+        else:
+            axis = tuple(axis)
+        if not axis:
+            return None
+        return tuple(canonicalize_axis(a, rank) for a in axis)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update(
+            {
+                "feature_extractor": serialization_lib.serialize_keras_object(
+                    self.feature_extractor
+                ),
+                "layers": self.layers,
+                "weights": self.weights,
+                "feature_loss": self.feature_loss,
+                "normalize": self.normalize,
+                "normalize_axis": self.normalize_axis,
+                "axis": self.axis,
+            }
+        )
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        config = config.copy()
+        feature_extractor = config.get("feature_extractor")
+        if feature_extractor is not None:
+            config["feature_extractor"] = (
+                serialization_lib.deserialize_keras_object(feature_extractor)
+            )
+        return cls(**config)

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -3273,7 +3273,7 @@ def msssim(
 
     _canonicalize_spatial_axes(axis, data_format, ops.ndim(y_pred))
 
-    shape = backend.shape(y_pred)
+    shape = y_pred.shape
     height = shape[1]
     width = shape[2]
     num_scales = len(power_factors)

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -3190,6 +3190,7 @@ def edge_aware_smoothness(y_true, y_pred, axis=None, data_format=None):
             f"(batched images). Received input rank {rank}."
         )
 
+    spatial_axes = _canonicalize_spatial_axes(None, data_format, rank)
     axis = _canonicalize_spatial_axes(axis, data_format, rank)
 
     loss = 0.0
@@ -3202,7 +3203,7 @@ def edge_aware_smoothness(y_true, y_pred, axis=None, data_format=None):
         pred_grad = y_pred[tuple(slice1)] - y_pred[tuple(slice2)]
         true_grad = y_true[tuple(slice1)] - y_true[tuple(slice2)]
         weighted = ops.abs(pred_grad) * ops.exp(-ops.abs(true_grad))
-        loss = loss + ops.sum(weighted, axis=axis)
+        loss = loss + ops.sum(weighted, axis=spatial_axes)
     if ops.ndim(loss) > 0:
         loss = ops.sum(loss, axis=-1)
     return loss

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -3273,19 +3273,20 @@ def msssim(
 
     _canonicalize_spatial_axes(axis, data_format, ops.ndim(y_pred))
 
-    shape = backend.shape(y_pred)
+    shape = y_pred.shape
     height = shape[1]
     width = shape[2]
     num_scales = len(power_factors)
     min_size = filter_size * (2 ** (num_scales - 1))
-    if height < min_size or width < min_size:
-        raise ValueError(
-            "MS-SSIM requires input spatial size to be at least "
-            f"{min_size}x{min_size} for {num_scales} scales and "
-            f"filter_size={filter_size}. Received shape "
-            f"({shape[0]}, {height}, {width}, {shape[3]}). Use fewer "
-            "scales, a smaller filter_size, or larger input images."
-        )
+    if isinstance(height, int) and isinstance(width, int):
+        if height < min_size or width < min_size:
+            raise ValueError(
+                "MS-SSIM requires input spatial size to be at least "
+                f"{min_size}x{min_size} for {num_scales} scales and "
+                f"filter_size={filter_size}. Received shape "
+                f"({shape[0]}, {height}, {width}, {shape[3]}). Use fewer "
+                "scales, a smaller filter_size, or larger input images."
+            )
 
     ms_ssim = _multiscale_ssim(
         y_pred,

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -3126,7 +3126,7 @@ def total_variation(y_true, y_pred, axis=None, data_format=None):
             f"(batched images). Received input rank {rank}."
         )
 
-    spatial_axes = _canonicalize_spatial_axes(None, data_format, rank)
+    all_spatial_axes = _canonicalize_spatial_axes(None, data_format, rank)
     axis = _canonicalize_spatial_axes(axis, data_format, rank)
 
     loss = 0.0
@@ -3137,9 +3137,10 @@ def total_variation(y_true, y_pred, axis=None, data_format=None):
         slice2 = [slice(None)] * ndim
         slice2[ax] = slice(None, -1)
         diff = y_pred[tuple(slice1)] - y_pred[tuple(slice2)]
-        loss = loss + ops.sum(ops.abs(diff), axis=spatial_axes)
+        loss = loss + ops.sum(ops.abs(diff), axis=all_spatial_axes)
     if ops.ndim(loss) > 0:
         loss = ops.sum(loss, axis=-1)
+    return loss
     return loss
 
 

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -3126,6 +3126,7 @@ def total_variation(y_true, y_pred, axis=None, data_format=None):
             f"(batched images). Received input rank {rank}."
         )
 
+    spatial_axes = _canonicalize_spatial_axes(None, data_format, rank)
     axis = _canonicalize_spatial_axes(axis, data_format, rank)
 
     loss = 0.0
@@ -3136,7 +3137,7 @@ def total_variation(y_true, y_pred, axis=None, data_format=None):
         slice2 = [slice(None)] * ndim
         slice2[ax] = slice(None, -1)
         diff = y_pred[tuple(slice1)] - y_pred[tuple(slice2)]
-        loss = loss + ops.sum(ops.abs(diff), axis=axis)
+        loss = loss + ops.sum(ops.abs(diff), axis=spatial_axes)
     if ops.ndim(loss) > 0:
         loss = ops.sum(loss, axis=-1)
     return loss

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -3278,14 +3278,15 @@ def msssim(
     width = shape[2]
     num_scales = len(power_factors)
     min_size = filter_size * (2 ** (num_scales - 1))
-    if height < min_size or width < min_size:
-        raise ValueError(
-            "MS-SSIM requires input spatial size to be at least "
-            f"{min_size}x{min_size} for {num_scales} scales and "
-            f"filter_size={filter_size}. Received shape "
-            f"({shape[0]}, {height}, {width}, {shape[3]}). Use fewer "
-            "scales, a smaller filter_size, or larger input images."
-        )
+    if isinstance(height, int) and isinstance(width, int):
+        if height < min_size or width < min_size:
+            raise ValueError(
+                "MS-SSIM requires input spatial size to be at least "
+                f"{min_size}x{min_size} for {num_scales} scales and "
+                f"filter_size={filter_size}. Received shape "
+                f"({shape[0]}, {height}, {width}, {shape[3]}). Use fewer "
+                "scales, a smaller filter_size, or larger input images."
+            )
 
     ms_ssim = _multiscale_ssim(
         y_pred,
@@ -3862,10 +3863,8 @@ class PerceptualLoss(Loss):
     def _feature_reduction_axis(self, feature_loss):
         rank = ops.ndim(feature_loss)
         if self.axis is None:
-            if rank == 0:
+            if rank <= 1:
                 return None
-            if rank == 1:
-                return (0,)
             return tuple(range(1, rank))
         axis = self.axis
         if isinstance(axis, int):

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -2481,6 +2481,12 @@ class TotalVariationTest(testing.TestCase):
             y_true, y_pred
         )
         self.assertAllClose(loss, 0.0)
+    
+    def test_custom_axis(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        loss = losses.TotalVariation(axis=1)(y_true, y_pred)
+        self.assertAllClose(loss, 9.0)
 
     def test_dtype_arg(self):
         y_true = np.zeros((1, 2, 2, 1), dtype="float32")
@@ -2596,6 +2602,12 @@ class EdgeAwareSmoothnessTest(testing.TestCase):
             axis=None, data_format="channels_first"
         )(y_true, y_pred)
         self.assertAllClose(loss, 0.0)
+    
+    def test_custom_axis(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        loss = losses.EdgeAwareSmoothness(axis=1)(y_true, y_pred)
+        self.assertAllClose(loss, 9.0)
 
     def test_dtype_arg(self):
         y_true = np.zeros((1, 2, 2, 1), dtype="float32")
@@ -2801,6 +2813,11 @@ class _ListFeatureExtractor:
         return [inputs, inputs * 3.0]
 
 
+class _ScalarFeatureExtractor:
+    def __call__(self, inputs, training=False):
+        return ops.mean(inputs, axis=-1)
+
+
 class _TrainingAwareFeatureExtractor:
     def __init__(self):
         self.training_values = []
@@ -2886,6 +2903,23 @@ class PerceptualLossTest(testing.TestCase):
             _IdentityFeatureExtractor(), reduction="sum"
         )(y_true, y_pred)
         self.assertAllClose(loss, 2.0)
+
+    def test_one_dimensional_features_keep_batch_axis(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.array(
+            [[1.0, 1.0, 1.0, 1.0], [2.0, 2.0, 2.0, 2.0]],
+            dtype="float32",
+        )
+        per_sample = losses.PerceptualLoss(
+            _ScalarFeatureExtractor(), reduction=None
+        )(y_true, y_pred)
+        self.assertEqual(backend.shape(per_sample), (2,))
+        self.assertAllClose(per_sample, np.array([1.0, 4.0]))
+
+        summed = losses.PerceptualLoss(
+            _ScalarFeatureExtractor(), reduction="sum"
+        )(y_true, y_pred)
+        self.assertAllClose(summed, 5.0)
 
     def test_sample_weight(self):
         y_true = np.zeros((2, 4), dtype="float32")

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -4,6 +4,9 @@ import numpy as np
 import pytest
 
 from keras.src import backend
+from keras.src import layers
+from keras.src import losses as losses_module
+from keras.src import ops
 from keras.src import testing
 from keras.src.losses import losses
 
@@ -2275,3 +2278,663 @@ class CategoricalGeneralizedCrossEntropyTest(testing.TestCase):
             y_true, y_pred
         )
         self.assertDType(output, "bfloat16")
+
+
+class CharbonnierTest(testing.TestCase):
+    def test_config(self):
+        self.run_class_serialization_test(
+            losses.Charbonnier(name="mycharbonnier", epsilon=0.5)
+        )
+
+    def test_correctness(self):
+        y_true = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
+        y_pred = y_true + 1.0
+        epsilon = 1e-3
+        expected = np.mean(np.sqrt(1.0 + epsilon**2))
+
+        loss = losses.charbonnier(y_true, y_pred)
+        self.assertAllClose(loss, [expected, expected])
+
+        loss = losses.Charbonnier()(y_true, y_pred)
+        self.assertAllClose(loss, expected)
+
+    def test_all_correct_unweighted(self):
+        y_true = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
+        loss = losses.Charbonnier(epsilon=0.0)(y_true, y_true)
+        self.assertAllClose(loss, 0.0)
+
+    def test_no_reduction(self):
+        y_true = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
+        y_pred = y_true + 1.0
+        loss = losses.Charbonnier(reduction=None)(y_true, y_pred)
+        self.assertEqual(backend.shape(loss), (2,))
+
+    def test_sum_reduction(self):
+        y_true = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
+        y_pred = y_true + 1.0
+        loss = losses.Charbonnier(reduction="sum")(y_true, y_pred)
+        expected = losses.charbonnier(y_true, y_pred)
+        self.assertAllClose(loss, ops.sum(expected))
+
+    def test_dtype_arg(self):
+        y_true = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
+        y_pred = y_true + 1.0
+        loss = losses.Charbonnier(dtype="bfloat16")(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
+    def test_sample_weight(self):
+        y_true = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32")
+        y_pred = y_true + 1.0
+        sample_weight = np.array([0.5, 2.0], dtype="float32")
+        loss = losses.Charbonnier()(y_true, y_pred, sample_weight=sample_weight)
+        per_sample = losses.charbonnier(y_true, y_pred)
+        sample_weight_t = ops.convert_to_tensor(sample_weight, per_sample.dtype)
+        expected = ops.sum(per_sample * sample_weight_t) / len(sample_weight)
+        self.assertAllClose(loss, expected)
+
+    def test_epsilon_parameter(self):
+        y_true = np.array([[0.0, 0.0], [0.0, 0.0]], dtype="float32")
+        y_pred = y_true + 0.0
+        self.assertAllClose(
+            losses.Charbonnier(epsilon=0.0)(y_true, y_pred), 0.0
+        )
+        self.assertAllClose(
+            losses.Charbonnier(epsilon=1.0)(y_true, y_pred), 1.0
+        )
+
+
+class PSNRTest(testing.TestCase):
+    def test_config(self):
+        self.run_class_serialization_test(
+            losses.PSNR(name="mypsnr", max_val=255.0)
+        )
+
+    def test_correctness(self):
+        y_true = np.array([[[[0.0, 1.0], [1.0, 0.0]]]], dtype="float32")
+        y_pred = y_true + 0.1
+
+        loss = losses.psnr(y_true, y_pred)
+        self.assertAllClose(loss, [-20.0])
+
+        loss = losses.PSNR()(y_true, y_pred)
+        self.assertAllClose(loss, -20.0)
+
+    def test_all_correct_unweighted(self):
+        y_true = np.array([[[[0.0, 1.0], [1.0, 0.0]]]], dtype="float32")
+        loss = losses.PSNR()(y_true, y_true)
+        # MSE is clamped to backend epsilon to avoid -inf.
+        expected = 10.0 * ops.log10(backend.epsilon())
+        self.assertAllClose(loss, expected, atol=1e-4)
+
+    def test_no_reduction(self):
+        y_true = np.array(
+            [[[[0.0, 1.0], [1.0, 0.0]]], [[[0.5, 0.5], [0.5, 0.5]]]],
+            dtype="float32",
+        )
+        y_pred = y_true + 0.1
+        loss = losses.PSNR(reduction=None)(y_true, y_pred)
+        self.assertEqual(backend.shape(loss), (2,))
+
+    def test_sum_reduction(self):
+        y_true = np.array(
+            [[[[0.0, 1.0], [1.0, 0.0]]], [[[0.5, 0.5], [0.5, 0.5]]]],
+            dtype="float32",
+        )
+        y_pred = y_true + 0.1
+        loss = losses.PSNR(reduction="sum")(y_true, y_pred)
+        expected = losses.psnr(y_true, y_pred)
+        self.assertAllClose(loss, ops.sum(expected))
+
+    def test_dtype_arg(self):
+        y_true = np.array([[[[0.0, 1.0], [1.0, 0.0]]]], dtype="float32")
+        y_pred = y_true + 0.1
+        loss = losses.PSNR(dtype="bfloat16")(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
+    def test_sample_weight(self):
+        y_true = np.array(
+            [[[[0.0, 1.0], [1.0, 0.0]]], [[[0.5, 0.5], [0.5, 0.5]]]],
+            dtype="float32",
+        )
+        y_pred = y_true + 0.1
+        sample_weight = np.array([0.5, 2.0], dtype="float32")
+        loss = losses.PSNR()(y_true, y_pred, sample_weight=sample_weight)
+        per_sample = losses.psnr(y_true, y_pred)
+        sample_weight_t = ops.convert_to_tensor(sample_weight, per_sample.dtype)
+        expected = ops.sum(per_sample * sample_weight_t) / len(sample_weight)
+        self.assertAllClose(loss, expected)
+
+    def test_unbatched(self):
+        y_true = np.array([[[0.0, 1.0], [1.0, 0.0]]], dtype="float32")
+        y_pred = y_true + 0.1
+        loss = losses.PSNR()(y_true, y_pred)
+        self.assertAllClose(loss, -20.0)
+
+    def test_max_val(self):
+        y_true = np.array([[[[0.0, 255.0], [255.0, 0.0]]]], dtype="float32")
+        y_pred = y_true + 2.55
+        loss = losses.PSNR(max_val=255.0)(y_true, y_pred)
+        self.assertAllClose(loss, -40.0)
+
+    def test_invalid_rank(self):
+        y_true = np.array([[0.0, 1.0], [1.0, 0.0]], dtype="float32")
+        y_pred = y_true + 0.1
+        with self.assertRaisesRegex(ValueError, "rank"):
+            losses.PSNR()(y_true, y_pred)
+
+
+class TotalVariationTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.data_format = backend.image_data_format()
+        backend.set_image_data_format("channels_last")
+
+    def tearDown(self):
+        super().tearDown()
+        backend.set_image_data_format(self.data_format)
+
+    def test_config(self):
+        self.run_class_serialization_test(
+            losses.TotalVariation(name="mytv", data_format="channels_last")
+        )
+
+    def test_correctness(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        expected = np.array([14.0], dtype="float32")
+
+        loss = losses.total_variation(y_true, y_pred)
+        self.assertAllClose(loss, expected)
+
+        loss = losses.TotalVariation()(y_true, y_pred)
+        self.assertAllClose(loss, 14.0)
+
+    def test_all_correct_unweighted(self):
+        y_pred = np.ones((2, 4, 4, 3), dtype="float32")
+        y_true = np.zeros_like(y_pred)
+        loss = losses.TotalVariation()(y_true, y_pred)
+        self.assertAllClose(loss, 0.0)
+
+    def test_no_reduction(self):
+        y_true = np.zeros((2, 2, 2, 1), dtype="float32")
+        y_pred = np.array(
+            [
+                [[[1.0], [2.0]], [[4.0], [8.0]]],
+                [[[1.0], [2.0]], [[4.0], [8.0]]],
+            ],
+            dtype="float32",
+        )
+        loss = losses.TotalVariation(reduction=None)(y_true, y_pred)
+        self.assertEqual(backend.shape(loss), (2,))
+        self.assertAllClose(loss, np.array([14.0, 14.0]))
+
+    def test_sum_reduction(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        loss = losses.TotalVariation(reduction="sum")(y_true, y_pred)
+        self.assertAllClose(loss, 14.0)
+
+    def test_channels_first(self):
+        y_true = np.zeros((2, 3, 4, 4), dtype="float32")
+        y_pred = np.ones((2, 3, 4, 4), dtype="float32")
+        loss = losses.TotalVariation(axis=None, data_format="channels_first")(
+            y_true, y_pred
+        )
+        self.assertAllClose(loss, 0.0)
+
+    def test_dtype_arg(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        loss = losses.TotalVariation(dtype="bfloat16")(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
+    def test_sample_weight(self):
+        y_true = np.zeros((2, 4, 4, 3), dtype="float32")
+        y_pred = np.zeros((2, 4, 4, 3), dtype="float32")
+        y_pred[0, :, :, :] = np.arange(4)[None, :, None] * 1.0
+        y_pred[1, :, :, :] = np.arange(4)[None, :, None] * 2.0
+        sample_weight = np.array([0.5, 2.0], dtype="float32")
+        loss = losses.TotalVariation()(
+            y_true, y_pred, sample_weight=sample_weight
+        )
+        per_sample = losses.total_variation(y_true, y_pred)
+        sample_weight_t = ops.convert_to_tensor(sample_weight, per_sample.dtype)
+        expected = ops.sum(per_sample * sample_weight_t) / len(sample_weight)
+        self.assertAllClose(loss, expected)
+
+    def test_unbatched(self):
+        y_true = np.zeros((2, 2, 1), dtype="float32")
+        y_pred = np.array([[[1.0], [2.0]], [[4.0], [8.0]]], dtype="float32")
+        loss = losses.TotalVariation()(y_true, y_pred)
+        self.assertAllClose(loss, 14.0)
+
+    def test_non_square(self):
+        y_true = np.zeros((1, 2, 3, 1), dtype="float32")
+        y_pred = np.arange(6, dtype="float32").reshape((1, 2, 3, 1))
+        loss = losses.TotalVariation()(y_true, y_pred)
+        # Vertical: |3-0|+|4-1|+|5-2| = 9
+        # Horizontal: |1-0|+|2-1|+|4-3|+|5-4| = 4
+        self.assertAllClose(loss, 13.0)
+
+    def test_invalid_rank(self):
+        y_true = np.zeros((2, 2), dtype="float32")
+        y_pred = np.zeros_like(y_true)
+        with self.assertRaisesRegex(ValueError, "rank"):
+            losses.TotalVariation()(y_true, y_pred)
+
+    def test_invalid_axis(self):
+        y_true = np.zeros((2, 4, 4, 3), dtype="float32")
+        y_pred = np.zeros_like(y_true)
+        with self.assertRaisesRegex(ValueError, "axis"):
+            losses.TotalVariation(axis=0)(y_true, y_pred)
+        with self.assertRaisesRegex(ValueError, "axis"):
+            losses.TotalVariation(axis=-1)(y_true, y_pred)
+
+
+class EdgeAwareSmoothnessTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.data_format = backend.image_data_format()
+        backend.set_image_data_format("channels_last")
+
+    def tearDown(self):
+        super().tearDown()
+        backend.set_image_data_format(self.data_format)
+
+    def test_config(self):
+        self.run_class_serialization_test(
+            losses.EdgeAwareSmoothness(
+                name="myedge", data_format="channels_last"
+            )
+        )
+
+    def test_correctness(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        expected = losses.total_variation(y_true, y_pred)
+
+        loss = losses.edge_aware_smoothness(y_true, y_pred)
+        self.assertAllClose(loss, expected)
+
+        loss = losses.EdgeAwareSmoothness()(y_true, y_pred)
+        self.assertAllClose(loss, ops.mean(expected))
+
+    def test_edge_preservation(self):
+        y_true = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        y_pred = y_true
+        loss_with_edge = losses.edge_aware_smoothness(y_true, y_pred)
+
+        y_true_flat = np.zeros_like(y_true)
+        loss_without_edge = losses.edge_aware_smoothness(y_true_flat, y_pred)
+
+        self.assertTrue(ops.all(loss_with_edge < loss_without_edge))
+
+    def test_all_correct_unweighted(self):
+        y_pred = np.ones((2, 4, 4, 3), dtype="float32")
+        y_true = np.random.random((2, 4, 4, 3)).astype("float32")
+        loss = losses.EdgeAwareSmoothness()(y_true, y_pred)
+        self.assertAllClose(loss, 0.0)
+
+    def test_no_reduction(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        loss = losses.EdgeAwareSmoothness(reduction=None)(y_true, y_pred)
+        expected = losses.total_variation(y_true, y_pred)
+        self.assertAllClose(loss, expected)
+
+    def test_sum_reduction(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        loss = losses.EdgeAwareSmoothness(reduction="sum")(y_true, y_pred)
+        expected = losses.total_variation(y_true, y_pred)
+        self.assertAllClose(loss, ops.sum(expected))
+
+    def test_channels_first(self):
+        y_true = np.zeros((2, 3, 4, 4), dtype="float32")
+        y_pred = np.ones((2, 3, 4, 4), dtype="float32")
+        loss = losses.EdgeAwareSmoothness(
+            axis=None, data_format="channels_first"
+        )(y_true, y_pred)
+        self.assertAllClose(loss, 0.0)
+
+    def test_dtype_arg(self):
+        y_true = np.zeros((1, 2, 2, 1), dtype="float32")
+        y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
+        loss = losses.EdgeAwareSmoothness(dtype="bfloat16")(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
+    def test_sample_weight(self):
+        y_true = np.zeros((2, 4, 4, 3), dtype="float32")
+        y_pred = np.zeros((2, 4, 4, 3), dtype="float32")
+        y_pred[0, :, :, :] = np.arange(4)[None, :, None] * 1.0
+        y_pred[1, :, :, :] = np.arange(4)[None, :, None] * 2.0
+        sample_weight = np.array([0.5, 2.0], dtype="float32")
+        loss = losses.EdgeAwareSmoothness()(
+            y_true, y_pred, sample_weight=sample_weight
+        )
+        per_sample = losses.edge_aware_smoothness(y_true, y_pred)
+        sample_weight_t = ops.convert_to_tensor(sample_weight, per_sample.dtype)
+        expected = ops.sum(per_sample * sample_weight_t) / len(sample_weight)
+        self.assertAllClose(loss, expected)
+
+    def test_non_square(self):
+        y_true = np.zeros((1, 2, 3, 1), dtype="float32")
+        y_pred = np.arange(6, dtype="float32").reshape((1, 2, 3, 1))
+        loss = losses.EdgeAwareSmoothness()(y_true, y_pred)
+        self.assertTrue(ops.isfinite(loss))
+
+    def test_invalid_rank(self):
+        y_true = np.zeros((2, 2), dtype="float32")
+        y_pred = np.zeros_like(y_true)
+        with self.assertRaisesRegex(ValueError, "rank"):
+            losses.EdgeAwareSmoothness()(y_true, y_pred)
+
+    def test_invalid_axis(self):
+        y_true = np.zeros((2, 4, 4, 3), dtype="float32")
+        y_pred = np.zeros_like(y_true)
+        with self.assertRaisesRegex(ValueError, "axis"):
+            losses.EdgeAwareSmoothness(axis=0)(y_true, y_pred)
+        with self.assertRaisesRegex(ValueError, "axis"):
+            losses.EdgeAwareSmoothness(axis=-1)(y_true, y_pred)
+
+
+class MSSSIMTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.data_format = backend.image_data_format()
+        backend.set_image_data_format("channels_last")
+
+    def tearDown(self):
+        super().tearDown()
+        backend.set_image_data_format(self.data_format)
+
+    def test_config(self):
+        self.run_class_serialization_test(
+            losses.MSSSIM(
+                name="mymsssim",
+                filter_size=5,
+                power_factors=(0.5, 0.5),
+            )
+        )
+
+    def _make_images(self, seed=0):
+        np.random.seed(seed)
+        return np.random.random((2, 32, 32, 3)).astype("float32")
+
+    def test_correctness(self):
+        y_true = self._make_images()
+        y_pred = y_true + 0.05
+
+        loss = losses.msssim(
+            y_true,
+            y_pred,
+            filter_size=5,
+            power_factors=(0.5, 0.5),
+        )
+        self.assertEqual(backend.shape(loss), (2,))
+        self.assertTrue(ops.all(loss > 0))
+
+        loss = losses.MSSSIM(filter_size=5, power_factors=(0.5, 0.5))(
+            y_true, y_pred
+        )
+        self.assertAllClose(
+            loss,
+            ops.mean(
+                losses.msssim(
+                    y_true, y_pred, filter_size=5, power_factors=(0.5, 0.5)
+                )
+            ),
+        )
+
+    def test_all_correct_unweighted(self):
+        y_true = self._make_images()
+        loss = losses.MSSSIM(filter_size=5, power_factors=(0.5, 0.5))(
+            y_true, y_true
+        )
+        self.assertAllClose(loss, 0.0, atol=1e-5)
+
+        loss_l1 = losses.MSSSIM(
+            filter_size=5,
+            power_factors=(0.5, 0.5),
+            l1_weight=1.0,
+        )(y_true, y_true)
+        self.assertAllClose(loss_l1, 0.0, atol=1e-5)
+
+    def test_l1_combination(self):
+        y_true = np.zeros((2, 32, 32, 3), dtype="float32")
+        y_pred = np.ones((2, 32, 32, 3), dtype="float32")
+        loss = losses.MSSSIM(
+            filter_size=5,
+            power_factors=(0.5, 0.5),
+            l1_weight=1.0,
+        )(y_true, y_pred)
+        self.assertTrue(loss > 0.0)
+
+    def test_no_reduction(self):
+        y_true = self._make_images()
+        y_pred = y_true + 0.05
+        loss = losses.MSSSIM(
+            filter_size=5, power_factors=(0.5, 0.5), reduction=None
+        )(y_true, y_pred)
+        self.assertEqual(backend.shape(loss), (2,))
+
+    def test_sum_reduction(self):
+        y_true = self._make_images()
+        y_pred = y_true + 0.05
+        loss = losses.MSSSIM(
+            filter_size=5, power_factors=(0.5, 0.5), reduction="sum"
+        )(y_true, y_pred)
+        expected = losses.msssim(
+            y_true, y_pred, filter_size=5, power_factors=(0.5, 0.5)
+        )
+        self.assertAllClose(loss, ops.sum(expected))
+
+    def test_dtype_arg(self):
+        y_true = self._make_images()
+        y_pred = y_true + 0.05
+        loss = losses.MSSSIM(
+            filter_size=5, power_factors=(0.5, 0.5), dtype="float16"
+        )(y_true, y_pred)
+        self.assertDType(loss, "float16")
+
+    def test_sample_weight(self):
+        y_true = self._make_images()
+        y_pred = y_true + 0.05
+        sample_weight = np.array([0.5, 2.0], dtype="float32")
+        loss = losses.MSSSIM(filter_size=5, power_factors=(0.5, 0.5))(
+            y_true, y_pred, sample_weight=sample_weight
+        )
+        per_sample = losses.msssim(
+            y_true, y_pred, filter_size=5, power_factors=(0.5, 0.5)
+        )
+        sample_weight_t = ops.convert_to_tensor(sample_weight, per_sample.dtype)
+        expected = ops.sum(per_sample * sample_weight_t) / len(sample_weight)
+        self.assertAllClose(loss, expected)
+
+    def test_channels_first(self):
+        y_true = np.random.random((2, 3, 32, 32)).astype("float32")
+        y_pred = y_true + 0.05
+        loss = losses.MSSSIM(
+            filter_size=5,
+            power_factors=(0.5, 0.5),
+            data_format="channels_first",
+        )(y_true, y_pred)
+        self.assertTrue(ops.isfinite(loss))
+
+    def test_invalid_rank(self):
+        y_true = np.zeros((32, 32), dtype="float32")
+        y_pred = y_true + 0.05
+        with self.assertRaisesRegex(ValueError, "rank"):
+            losses.MSSSIM(filter_size=5, power_factors=(0.5, 0.5))(
+                y_true, y_pred
+            )
+
+    def test_too_small_image(self):
+        y_true = np.zeros((2, 4, 4, 3), dtype="float32")
+        y_pred = y_true + 0.05
+        with self.assertRaisesRegex(ValueError, "spatial"):
+            losses.MSSSIM(filter_size=5, power_factors=(0.5, 0.5))(
+                y_true, y_pred
+            )
+
+    def test_invalid_axis(self):
+        y_true = self._make_images()
+        y_pred = y_true + 0.05
+        with self.assertRaisesRegex(ValueError, "axis"):
+            losses.MSSSIM(filter_size=5, power_factors=(0.5, 0.5), axis=0)(
+                y_true, y_pred
+            )
+
+
+class _IdentityFeatureExtractor:
+    def __call__(self, inputs, training=False):
+        return inputs
+
+
+class _DictFeatureExtractor:
+    def __call__(self, inputs, training=False):
+        return {"low": inputs, "high": inputs * 2.0}
+
+
+class _ListFeatureExtractor:
+    def __call__(self, inputs, training=False):
+        return [inputs, inputs * 3.0]
+
+
+class _TrainingAwareFeatureExtractor:
+    def __init__(self):
+        self.training_values = []
+
+    def __call__(self, inputs, training=None):
+        self.training_values.append(training)
+        return inputs
+
+
+class PerceptualLossTest(testing.TestCase):
+    def test_config(self):
+        self.run_class_serialization_test(
+            losses.PerceptualLoss(
+                feature_extractor=layers.Identity(name="identity_features"),
+                name="myperceptual",
+                feature_loss="l1",
+                normalize=True,
+                layers=None,
+            )
+        )
+
+    def test_get_registered_loss(self):
+        loss = losses_module.get("PerceptualLoss")
+        self.assertIsInstance(loss, losses.PerceptualLoss)
+
+    def test_l2_tensor_output(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        loss = losses.PerceptualLoss(_IdentityFeatureExtractor())(
+            y_true, y_pred
+        )
+        self.assertAllClose(loss, 1.0)
+
+    def test_l1_selected_dict_feature_with_weight(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        loss = losses.PerceptualLoss(
+            _DictFeatureExtractor(),
+            layers=["high"],
+            weights=[0.5],
+            feature_loss="l1",
+        )(y_true, y_pred)
+        self.assertAllClose(loss, 1.0)
+
+    def test_dict_weights_multiple_features(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        loss = losses.PerceptualLoss(
+            _DictFeatureExtractor(),
+            weights={"low": 1.0, "high": 0.25},
+        )(y_true, y_pred)
+        self.assertAllClose(loss, 2.0)
+
+    def test_list_feature_selection(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        loss = losses.PerceptualLoss(
+            _ListFeatureExtractor(), layers=[1], weights=[2.0]
+        )(y_true, y_pred)
+        self.assertAllClose(loss, 18.0)
+
+    def test_normalize(self):
+        y_true = np.array([[1.0, 0.0], [0.0, 2.0]], dtype="float32")
+        y_pred = np.array([[3.0, 0.0], [0.0, 4.0]], dtype="float32")
+        loss = losses.PerceptualLoss(
+            _IdentityFeatureExtractor(), normalize=True
+        )(y_true, y_pred)
+        self.assertAllClose(loss, 0.0)
+
+    def test_no_reduction(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        loss = losses.PerceptualLoss(
+            _IdentityFeatureExtractor(), reduction=None
+        )(y_true, y_pred)
+        self.assertEqual(backend.shape(loss), (2,))
+        self.assertAllClose(loss, np.array([1.0, 1.0]))
+
+    def test_sum_reduction(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        loss = losses.PerceptualLoss(
+            _IdentityFeatureExtractor(), reduction="sum"
+        )(y_true, y_pred)
+        self.assertAllClose(loss, 2.0)
+
+    def test_sample_weight(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        sample_weight = np.array([0.5, 2.0], dtype="float32")
+        loss = losses.PerceptualLoss(_IdentityFeatureExtractor())(
+            y_true, y_pred, sample_weight=sample_weight
+        )
+        self.assertAllClose(loss, 1.25)
+
+    def test_dtype_arg(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        loss = losses.PerceptualLoss(
+            _IdentityFeatureExtractor(), dtype="bfloat16"
+        )(y_true, y_pred)
+        self.assertDType(loss, "bfloat16")
+
+    def test_training_false_when_supported(self):
+        extractor = _TrainingAwareFeatureExtractor()
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        losses.PerceptualLoss(extractor)(y_true, y_pred)
+        self.assertEqual(extractor.training_values, [False, False])
+
+    def test_missing_extractor(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        with self.assertRaisesRegex(ValueError, "feature_extractor"):
+            losses.PerceptualLoss()(y_true, y_pred)
+
+    def test_invalid_feature_loss(self):
+        with self.assertRaisesRegex(ValueError, "feature_loss"):
+            losses.PerceptualLoss(
+                _IdentityFeatureExtractor(), feature_loss="cosine"
+            )
+
+    def test_invalid_layer_key(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        with self.assertRaisesRegex(ValueError, "layers"):
+            losses.PerceptualLoss(_DictFeatureExtractor(), layers=["missing"])(
+                y_true, y_pred
+            )
+
+    def test_invalid_weight_length(self):
+        y_true = np.zeros((2, 4), dtype="float32")
+        y_pred = np.ones((2, 4), dtype="float32")
+        with self.assertRaisesRegex(ValueError, "weights"):
+            losses.PerceptualLoss(_DictFeatureExtractor(), weights=[1.0])(
+                y_true, y_pred
+            )

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -2481,7 +2481,7 @@ class TotalVariationTest(testing.TestCase):
             y_true, y_pred
         )
         self.assertAllClose(loss, 0.0)
-    
+
     def test_custom_axis(self):
         y_true = np.zeros((1, 2, 2, 1), dtype="float32")
         y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")
@@ -2602,7 +2602,7 @@ class EdgeAwareSmoothnessTest(testing.TestCase):
             axis=None, data_format="channels_first"
         )(y_true, y_pred)
         self.assertAllClose(loss, 0.0)
-    
+
     def test_custom_axis(self):
         y_true = np.zeros((1, 2, 2, 1), dtype="float32")
         y_pred = np.array([[[[1.0], [2.0]], [[4.0], [8.0]]]], dtype="float32")


### PR DESCRIPTION
Docs for what I used and implemented. I will also add references for each if needed.
Adds: #23126 

## Charbonnier

- Public API: `keras.losses.charbonnier`, `keras.losses.Charbonnier`.
- Purpose: differentiable L1-style reconstruction loss,
  `sqrt((y_pred - y_true)^2 + epsilon^2)`.
- Supports: batched/unbatched tensors, dtype policy, Keras reductions,
  sample weights and configurable `epsilon`.

## PSNR

- Public API: `keras.losses.psnr`, `keras.losses.PSNR`.
- Purpose: optimize negtive peak signal-to-noise ratio so higher PSNR maps to
  a lower loss.
- Supports: configurable `max_val`, custom reduction axes, dtype policy, Keras
  reductions, sample weights and rank val for image-like tensors.

## TotalVariation

- Public API: `keras.losses.total_variation`, `keras.losses.TotalVariation`.
- Purpose: regularizes predictions, penalizes spatial variation.
- Supports: channels-last and channels-first image data, configurable spatial
  axes, batched and unbatched tensors, non-square images, dtype policy, Keras
  reductions, sample weights and axis validation.

## EdgeAwareSmoothness

- Public API: `keras.losses.edge_aware_smoothness`, `keras.losses.EdgeAwareSmoothness`.
- Purpose: encourages smooth predictions while preserving target-image edges by
  weighting prediction gradients with target gradients.
- Supports: channels-last and channels-first image data, configurable spatial
  axes, batched tensors, non-square images, dtype policy, Keras reductions,
  sample weights and axis validation.

## MSSSIM

- Public API: `keras.losses.msssim`, `keras.losses.MSSSIM`.
- Purpose: Multi-Scale Structural Similarity loss, with optional L1 blending for
  restoration tasks.
- Supports: configurable `max_val`, `alpha`, `l1_weight`, Gaussian filter size
  and sigma, SSIM stabilization constants, scale power factors, channels-last
  and channels-first image data, custom spatial axes, dtype policy, Keras
  reductions, sample weights, rank validation and small-image validation.

## PerceptualLoss (It was optional to add as it has really large overhead) 

- Public API: `keras.losses.PerceptualLoss`.
- Purpose: compares features extracted from `y_true` and `y_pred`, enabling VGG,
  encoder, task-model, or user-defined perceptual supervision without bundling a
  mandatory pretrained model.
- Feature extractor support: any callable/layer/model that returns a tensor,
  list/tuple of tensors, or dictionary of tensors. When supported, it is called
  with `training=False` for deterministic inference-mode features.
- Feature selection: `layers=None` uses every extractor output. Dictionary
  outputs can be selected by key; list/tuple outputs can be selected by integer
  index.
- Feature weighting: no weights, scalar weights, list/tuple weights matching the
  selected outputs, or dictionary weights keyed by selected output names/indices.
- Distance modes: `feature_loss="l2"` and `feature_loss="l1"`.
- Normalization: optional L2 feature normalization with configurable
  `normalize_axis`.
- Reduction: configurable feature reduction axes plus normal Keras loss
  reductions and sample weights.
- Overhead: It runs the provided feature extractor once
  for `y_true` and once for `y_pred`, and keeps intermediate feature tensors for
  the selected outputs. Runtime and memory therefore scale with the extractor
  architecture and selected feature layers. No new package dependency is added.



## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
