### PR TITLE
Bump GPU tests timeout to 3 hours.

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     name: Run tests on GPU
     runs-on: linux-x86-g2-16-l4-1gpu
-    timeout-minutes: 120
+    timeout-minutes: 180
 
     container:
       image: python:3.11-slim


### PR DESCRIPTION
JAX GPU tests are currently always timing out at 2 hours.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
