### PR TITLE
[Fix] keras.ops.hypot returns NaN instead of Inf for Inf and -Inf inputs

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -2230,7 +2230,16 @@ def hypot(x1, x2):
         max_val,
         ov_opset.sqrt(ov_opset.add(one, ov_opset.multiply(ratio, ratio))),
     )
-    return OpenVINOKerasTensor(result.output(0))
+    is_inf_mask = ov_opset.logical_or(
+        get_ov_output(isinf(x1_abs.output(0))),
+        get_ov_output(isinf(x2_abs.output(0))),
+    )
+    result = ov_opset.select(
+        is_inf_mask,
+        ov_opset.constant(np.inf, result.get_element_type()),
+        result,
+    ).output(0)
+    return OpenVINOKerasTensor(result)
 
 
 def identity(n, dtype=None):

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -2231,13 +2231,15 @@ def hypot(x1, x2):
         ov_opset.sqrt(ov_opset.add(one, ov_opset.multiply(ratio, ratio))),
     )
     is_inf_mask = ov_opset.logical_or(
-        get_ov_output(isinf(x1_abs)),
-        get_ov_output(isinf(x2_abs)),
+        get_ov_output(isinf(x1_abs.output(0))),
+        get_ov_output(isinf(x2_abs.output(0))),
     )
     result_output = result.output(0)
     result = ov_opset.select(
         is_inf_mask,
-        ov_opset.constant(np.inf, result_output.get_element_type()),
+        ov_opset.divide(
+            one, ov_opset.constant(0, result_output.get_element_type())
+        ),
         result_output,
     ).output(0)
     return OpenVINOKerasTensor(result)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -2231,13 +2231,14 @@ def hypot(x1, x2):
         ov_opset.sqrt(ov_opset.add(one, ov_opset.multiply(ratio, ratio))),
     )
     is_inf_mask = ov_opset.logical_or(
-        get_ov_output(isinf(x1_abs.output(0))),
-        get_ov_output(isinf(x2_abs.output(0))),
+        get_ov_output(isinf(x1_abs)),
+        get_ov_output(isinf(x2_abs)),
     )
+    result_output = result.output(0)
     result = ov_opset.select(
         is_inf_mask,
-        ov_opset.constant(np.inf, result.get_element_type()),
-        result,
+        ov_opset.constant(np.inf, result_output.get_element_type()),
+        result_output,
     ).output(0)
     return OpenVINOKerasTensor(result)
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1762,7 +1762,12 @@ def hypot(x1, x2):
     min_val = tf.minimum(x1_abs, x2_abs)
 
     ratio = tf.math.divide_no_nan(min_val, max_val)
-    return max_val * tf.sqrt(1.0 + tf.square(ratio))
+    result = max_val * tf.sqrt(1.0 + tf.square(ratio))
+    return tf.where(
+        tf.math.is_inf(x1_abs) | tf.math.is_inf(x2_abs),
+        tf.constant(float("inf"), dtype=result.dtype),
+        result,
+    )
 
 
 def identity(n, dtype=None):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3378,6 +3378,11 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.hypot(x, y), np.hypot(x, y))
         self.assertAllClose(knp.Hypot()(x, y), np.hypot(x, y))
 
+        x = np.array([np.nan, np.inf, np.nan, -0.0], dtype=np.float32)
+        y = np.array([1.0, -np.inf, np.inf, 0.0], dtype=np.float32)
+        self.assertAllClose(knp.hypot(x, y), np.hypot(x, y))
+        self.assertAllClose(knp.Hypot()(x, y), np.hypot(x, y))
+
     def test_subtract(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         y = np.array([[4, 5, 6], [3, 2, 1]])


### PR DESCRIPTION
## Description
Fixes: #23131 
Tf and OpenVINO backends used `max * sqrt(1 + (min/max)^2)`  but `inf / inf` gives `nan` 
Now both return positive inf when either input is inf

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
