### PR TITLE
Remove unsupported NPZ weight storage and consolidate ZIP validation

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -53,6 +53,11 @@ _MEMORY_UPPER_BOUND = 0.5  # 50%
 # Mirrors the `_ZIP_MEMBER_*` guard used by `_reject_zip_bomb`.
 _NPZ_MEMBER_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
 _NPZ_MEMBER_MAX_EXPANSION = 100
+# Floor for the *cumulative* (whole-archive) npz guard. A much lower floor than
+# the per-member one lets the cumulative guard also catch a single member that
+# declares just under the per-member floor, as well as several sub-floor
+# members that are read into memory together (see `_reject_npz_archive_bomb`).
+_NPZ_CUMULATIVE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
 
 
 _MODEL_CARD_TEMPLATE = """
@@ -447,6 +452,11 @@ def _model_from_config(config_json, custom_objects, compile, safe_mode):
 # The 4 GiB floor matches the HDF5 dataset guard for CVE-2026-0897.
 _ZIP_MEMBER_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
 _ZIP_MEMBER_MAX_EXPANSION = 100
+# Floor for the *cumulative* (whole-archive) guard below. A much lower floor
+# than the per-member one lets the cumulative guard also catch a single member
+# that declares just under the per-member floor, as well as the several
+# independent member reads on the load path that each stay under it.
+_ZIP_CUMULATIVE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
 
 
 def _reject_zip_bomb(archive, name):
@@ -464,6 +474,35 @@ def _reject_zip_bomb(archive, name):
         )
 
 
+def _reject_zip_archive_bomb(archive):
+    """Raise if a ZIP archive is cumulatively a decompression bomb (CWE-409).
+
+    `_reject_zip_bomb` bounds a *single* member, but its per-member floor can
+    be evaded by a member declaring just under the floor, or by the several
+    members that the load path reads into memory independently (`config.json`,
+    `model.weights.h5`, and the shard map), each staying under it. This bounds
+    the *cumulative* declared size of every member against the bytes actually
+    stored on disk, using the same expansion ratio. Genuine `.keras` archives
+    store their members uncompressed (declared size ~= stored size), so this
+    only fires on archives that declare far more than they store.
+    """
+    total_declared = 0
+    total_stored = 0
+    for info in archive.infolist():
+        total_declared += info.file_size
+        total_stored += info.compress_size
+    if (
+        total_declared > _ZIP_CUMULATIVE_BOMB_FLOOR_BYTES
+        and total_declared > _ZIP_MEMBER_MAX_EXPANSION * total_stored
+    ):
+        raise ValueError(
+            "Not allowed: the archive declares "
+            f"{readable_memory_size(total_declared)} across its members but "
+            f"only {readable_memory_size(total_stored)} are stored on disk; "
+            "refusing to load a potential decompression bomb."
+        )
+
+
 def _safe_zip_read(archive, name):
     """Read a ZIP member into memory, rejecting bombs (see CWE-409)."""
     _reject_zip_bomb(archive, name)
@@ -473,6 +512,7 @@ def _safe_zip_read(archive, name):
 
 def _load_model_from_fileobj(fileobj, custom_objects, compile, safe_mode):
     with zipfile.ZipFile(fileobj, "r") as zf:
+        _reject_zip_archive_bomb(zf)
         config_json = _safe_zip_read(zf, _CONFIG_FILENAME)
 
         model = _model_from_config(
@@ -641,6 +681,7 @@ def load_weights_only(
             weights_store = ShardedH5IOStore(filepath, mode="r")
         elif filepath_str.endswith(".keras"):
             archive = zipfile.ZipFile(filepath, "r")
+            _reject_zip_archive_bomb(archive)
             weights_store = H5IOStore(_VARS_FNAME_H5, archive=archive, mode="r")
 
         failed_saveables = set()
@@ -1769,6 +1810,29 @@ class ShardedH5IOStore(H5IOStore):
         return False
 
 
+def _npz_member_declared_bytes(zip_file, member_name):
+    """Return `(declared_bytes, stored_bytes)` for an npz `.npy` member.
+
+    Reads only the `.npy` header (which carries the declared shape and dtype),
+    so it never allocates the array itself. Returns `None` if the member is
+    absent from the archive.
+    """
+    try:
+        info = zip_file.getinfo(f"{member_name}.npy")
+    except KeyError:
+        return None
+    with zip_file.open(info) as member_file:
+        major, _ = npy_format.read_magic(member_file)
+        read_header = getattr(
+            npy_format,
+            f"read_array_header_{major}_0",
+            npy_format.read_array_header_2_0,
+        )
+        shape, _, dtype = read_header(member_file)
+    declared_bytes = math.prod(shape) * dtype.itemsize
+    return declared_bytes, info.compress_size
+
+
 class NpzIOStore:
     def __init__(self, root_path, archive=None, mode="r"):
         """Numerical variable store backed by NumPy.savez/load.
@@ -1790,6 +1854,7 @@ class NpzIOStore:
             else:
                 self.f = open(root_path, mode="rb")
             self.contents = np.load(self.f, allow_pickle=False)
+            self._reject_npz_archive_bomb()
 
     def make(self, path, metadata=None):
         if not path:
@@ -1820,20 +1885,11 @@ class NpzIOStore:
         zip_file = getattr(self.contents, "zip", None)
         if zip_file is None:
             return
-        try:
-            info = zip_file.getinfo(f"{path}.npy")
-        except KeyError:
+        sizes = _npz_member_declared_bytes(zip_file, path)
+        if sizes is None:
             return
-        with zip_file.open(info) as member_file:
-            major, _ = npy_format.read_magic(member_file)
-            read_header = getattr(
-                npy_format,
-                f"read_array_header_{major}_0",
-                npy_format.read_array_header_2_0,
-            )
-            shape, _, dtype = read_header(member_file)
-        declared_bytes = math.prod(shape) * dtype.itemsize
-        stored_bytes = max(info.compress_size, 1)
+        declared_bytes, compress_size = sizes
+        stored_bytes = max(compress_size, 1)
         if (
             declared_bytes > _NPZ_MEMBER_BOMB_FLOOR_BYTES
             and declared_bytes > _NPZ_MEMBER_MAX_EXPANSION * stored_bytes
@@ -1841,7 +1897,40 @@ class NpzIOStore:
             raise ValueError(
                 f"Refusing to load npz weight '{path}': its header declares "
                 f"{readable_memory_size(declared_bytes)} but only "
-                f"{readable_memory_size(info.compress_size)} is stored on "
+                f"{readable_memory_size(compress_size)} is stored on "
+                "disk; refusing to load a potential decompression bomb."
+            )
+
+    def _reject_npz_archive_bomb(self):
+        """Guard against an npz that is cumulatively a shape/decompression bomb.
+
+        `_reject_npz_bomb` bounds a *single* member, but its per-member floor
+        can be evaded by a member declaring just under it, or by several
+        members that each stay under it and are read into memory together.
+        This bounds the *cumulative* declared size of every member against the
+        bytes actually stored on disk, using the same expansion ratio, so
+        sub-floor members cannot sum without bound (CWE-789 / CWE-409).
+        """
+        zip_file = getattr(self.contents, "zip", None)
+        if zip_file is None:
+            return
+        total_declared = 0
+        total_stored = 0
+        for member_name in self.contents.files:
+            sizes = _npz_member_declared_bytes(zip_file, member_name)
+            if sizes is None:
+                continue
+            declared_bytes, compress_size = sizes
+            total_declared += declared_bytes
+            total_stored += compress_size
+        if (
+            total_declared > _NPZ_CUMULATIVE_BOMB_FLOOR_BYTES
+            and total_declared > _NPZ_MEMBER_MAX_EXPANSION * total_stored
+        ):
+            raise ValueError(
+                "Refusing to load npz weights: the archive declares "
+                f"{readable_memory_size(total_declared)} across its members "
+                f"but only {readable_memory_size(total_stored)} is stored on "
                 "disk; refusing to load a potential decompression bomb."
             )
 

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1744,6 +1744,54 @@ class SafeZipReadTest(testing.TestCase):
             with self.assertRaisesRegex(ValueError, "decompression bomb"):
                 saving_lib.load_model(evil)
 
+    def test_rejects_cumulative_archive_bomb_under_floor(self):
+        # Several members that each stay under the (real, 4 GiB) per-member
+        # floor but jointly declare far more than is stored on disk: the
+        # per-member guard passes each one, the cumulative guard rejects them.
+        path = os.path.join(self.get_temp_dir(), "a.zip")
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for i in range(4):
+                zf.writestr(f"m{i}.json", b"A" * 100_000)
+        self.assertLess(os.path.getsize(path), 1 << 16)  # tiny file on disk
+        with mock.patch.object(
+            saving_lib, "_ZIP_CUMULATIVE_BOMB_FLOOR_BYTES", 64
+        ):
+            with zipfile.ZipFile(path, "r") as zf:
+                # The per-member guard (real 4 GiB floor) passes each member.
+                for i in range(4):
+                    saving_lib._reject_zip_bomb(zf, f"m{i}.json")
+                # The cumulative guard rejects the archive as a whole.
+                with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                    saving_lib._reject_zip_archive_bomb(zf)
+
+    def test_load_model_rejects_cumulative_bomb(self):
+        # End-to-end: a tiny `.keras` whose config.json declares well under the
+        # 4 GiB per-member floor (so `_reject_zip_bomb` passes) is still
+        # rejected by the cumulative guard before any member is read.
+        path = os.path.join(self.get_temp_dir(), "bomb.keras")
+        payload = b'{"x":"' + b" " * 400_000 + b'"}'
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("metadata.json", b'{"keras_version":"3"}')
+            zf.writestr("config.json", payload)
+        self.assertLess(os.path.getsize(path), 1 << 16)  # tiny file on disk
+        with mock.patch.object(
+            saving_lib, "_ZIP_CUMULATIVE_BOMB_FLOOR_BYTES", 64
+        ):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                saving_lib.load_model(path)
+
+    def test_does_not_reject_genuine_keras(self):
+        # A genuine `.keras` (members stored ~uncompressed, ratio ~1) must pass
+        # both the direct cumulative guard and an end-to-end load.
+        model = keras.Sequential(
+            [keras.Input((16,)), keras.layers.Dense(64), keras.layers.Dense(8)]
+        )
+        path = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(path)
+        with zipfile.ZipFile(path, "r") as zf:
+            saving_lib._reject_zip_archive_bomb(zf)  # must not raise
+        keras.saving.load_model(path)  # must not raise
+
 
 class SafeGetH5DatasetTest(testing.TestCase):
     def _shape_bomb_file(self):
@@ -1856,15 +1904,55 @@ class SavingNpzIOStoreTest(testing.TestCase):
         with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
             zf.writestr(f"{name}.npy", header.getvalue() + data)
 
+    def _write_npz_members(self, path, members, descr="<f8"):
+        """Write several members, each declaring `shape` but storing no data.
+
+        `members` is an iterable of `(name, shape)`; every member's `.npy`
+        header declares its array while almost nothing is stored on disk.
+        """
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for name, shape in members:
+                header = BytesIO()
+                np.lib.format.write_array_header_1_0(
+                    header,
+                    {"descr": descr, "fortran_order": False, "shape": shape},
+                )
+                zf.writestr(f"{name}.npy", header.getvalue())
+
     def test_npz_io_store_rejects_shape_bomb(self):
-        # Member declares an 8 PiB array but stores only its header.
+        # A single member declaring an 8 PiB array but storing only its header
+        # is rejected by the cumulative guard when the store is opened.
         temp_filepath = os.path.join(self.get_temp_dir(), "bomb.npz")
         self._write_npz_member(temp_filepath, "w", shape=(2**50,))
-        store = saving_lib.NpzIOStore(temp_filepath, mode="r")
-        with self.assertRaisesRegex(
-            ValueError, r"Refusing to load npz weight 'w'"
+        with self.assertRaisesRegex(ValueError, "decompression bomb"):
+            saving_lib.NpzIOStore(temp_filepath, mode="r")
+
+    def test_npz_io_store_rejects_cumulative_bomb(self):
+        # Several members each below the 4 GiB per-member floor that jointly
+        # declare far more than is stored: the per-member guard misses them,
+        # the cumulative guard rejects the store at open.
+        temp_filepath = os.path.join(self.get_temp_dir(), "cumulative.npz")
+        elems = (3 << 30) // 8  # 3 GiB of float64 each, below the 4 GiB floor
+        self._write_npz_members(
+            temp_filepath, [(f"w{i}", (elems,)) for i in range(3)]
+        )
+        self.assertLess(os.path.getsize(temp_filepath), 1 << 16)  # tiny file
+        with self.assertRaisesRegex(ValueError, "decompression bomb"):
+            saving_lib.NpzIOStore(temp_filepath, mode="r")
+
+    def test_npz_io_store_per_member_guard(self):
+        # With the cumulative floor raised, a single member over the 4 GiB
+        # per-member floor is still rejected by the per-member guard on `get`.
+        temp_filepath = os.path.join(self.get_temp_dir(), "bomb.npz")
+        self._write_npz_member(temp_filepath, "w", shape=(2**50,))
+        with mock.patch.object(
+            saving_lib, "_NPZ_CUMULATIVE_BOMB_FLOOR_BYTES", 1 << 62
         ):
-            store.get("w")
+            store = saving_lib.NpzIOStore(temp_filepath, mode="r")
+            with self.assertRaisesRegex(
+                ValueError, r"Refusing to load npz weight 'w'"
+            ):
+                store.get("w")
 
     def test_npz_io_store_loads_normal_array(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "store.npz")


### PR DESCRIPTION
**Updated implementation: #23655.** This PR remains automatically closed for inactivity, and GitHub does not allow the author to reopen it. The original branch has been updated; the replacement draft contains the new commits. The implementation and validation notes below describe the replacement.

## Description


Remove the unsupported NPZ model-weight format: `NpzIOStore`, NPZ constants and guards, save/load branches, the internal `weights_format` argument, and NPZ store tests. Update the pickling caller and require `model.weights.h5` when loading a model archive or directory. Dataset download formats are unaffected.

Consolidate archive validation in `_reject_zip_archive_bomb()`, shared by model loading, weight loading, `KerasFileEditor`, and asset extraction. It replaces the separate asset-extraction guard and limits the combined declared size of members exceeding the expansion ratio, using a 64 MiB floor. Ordinary stored weights cannot dilute the ratio of highly compressed assets. The existing per-member read guard remains for individual reads.

The archive check iterates the `ZipInfo` records already parsed by `ZipFile`: O(number of members) time and constant additional space. It does not open, read, or decompress member payloads. Asset extraction uses the same helper on the existing directory metadata; it does not add a second payload scan. Tests make `ZipFile.open()` fail if the check attempts a member read.

Regression coverage includes cumulative sub-threshold members, stored weights alongside compressed assets, rejection before member reads through all three public consumers, unsupported NPZ-only models, and normal HDF5 model round trips. Rejected weight loads close their archive, and rejected asset archives are checked before allocating a temporary extraction directory.

## Validation

- TensorFlow backend: 89 tests passed in `saving_lib_test.py` and `file_editor_test.py`.
- Additional saving API/model checks, including unzipped model loading and pickling: 135 passed, 7 skipped, 10 deselected.
- After the resource-cleanup adjustment, all 17 ZIP/asset-store tests passed.
- Repository-wide Ruff lint/format checks and `git diff --check` passed. API generation produced no API changes.
- Python 3.12.13, TensorFlow 2.21.0.

## AI assistance

OpenAI Codex assisted with the follow-up implementation, tests, validation, and this description.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
