### PR TITLE
Reject decompression-bomb members in the shared archive extraction path

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -174,6 +174,10 @@ def _reject_extraction_bombs(members, stored_size):
         declared = getattr(finfo, "file_size", None)
         if declared is None:
             declared = getattr(finfo, "size", 0) or 0
+        # Clamp a negative size from a malformed archive: it would otherwise
+        # decrease the running total and let a later oversized member slip past
+        # the cumulative cap.
+        declared = max(0, declared)
         name = getattr(finfo, "filename", None) or getattr(finfo, "name", "?")
         # Per-member ratio: a zip member carries its own stored size, so a
         # single hugely-expanding member is a bomb regardless of the others.

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -123,19 +123,99 @@ def filter_safe_tarinfos(members, base_dir):
             )
 
 
+# An archive member whose declared (uncompressed) size exceeds this floor and
+# more than `_EXTRACT_BOMB_MAX_EXPANSION` times the bytes stored on disk is
+# treated as a decompression bomb (CWE-409), as is any archive whose members
+# cumulatively do (CWE-400). Genuine archives store their data at a ratio far
+# below this, so the guard is false-positive-free; the 256 MiB floor matches
+# the `.keras` asset-extraction guard.
+_EXTRACT_BOMB_FLOOR_BYTES = 1 << 28  # 256 MiB
+_EXTRACT_BOMB_MAX_EXPANSION = 100
+
+
+def _archive_stored_size(archive):
+    """Best-effort on-disk (compressed) size of an open archive.
+
+    Used as the denominator of the decompression-ratio check. Returns `None`
+    if it cannot be determined, which disables the cumulative ratio check (the
+    per-member zip check still applies).
+    """
+    name = getattr(archive, "name", None) or getattr(archive, "filename", None)
+    try:
+        if name is not None and os.path.exists(name):
+            return os.path.getsize(name)
+    except (OSError, TypeError, ValueError):
+        pass
+    if isinstance(archive, zipfile.ZipFile):
+        return sum(info.compress_size for info in archive.infolist())
+    return None
+
+
+def _reject_extraction_bombs(members, stored_size):
+    """Yield path-filtered members, refusing to extract a decompression bomb.
+
+    Bounds the declared (uncompressed) size of each member, and the running
+    total across members, against the archive's stored size on disk, so
+    neither a single oversized member nor many smaller ones can write
+    unbounded data to disk (CWE-409 / CWE-400). Members are consumed lazily,
+    so a tar member is rejected from its header before its data is extracted.
+    `stored_size` of `None` (unknown) disables the cumulative ratio check.
+    """
+    cap = None
+    if stored_size is not None:
+        cap = max(
+            _EXTRACT_BOMB_FLOOR_BYTES,
+            _EXTRACT_BOMB_MAX_EXPANSION * stored_size,
+        )
+    total = 0
+    for finfo in members:
+        # `ZipInfo.file_size` / `TarInfo.size`: the declared uncompressed size,
+        # available from the member header before any data is read.
+        declared = getattr(finfo, "file_size", None)
+        if declared is None:
+            declared = getattr(finfo, "size", 0) or 0
+        name = getattr(finfo, "filename", None) or getattr(finfo, "name", "?")
+        # Per-member ratio: a zip member carries its own stored size, so a
+        # single hugely-expanding member is a bomb regardless of the others.
+        compress_size = getattr(finfo, "compress_size", None)
+        if (
+            compress_size is not None
+            and declared > _EXTRACT_BOMB_FLOOR_BYTES
+            and declared > _EXTRACT_BOMB_MAX_EXPANSION * compress_size
+        ):
+            raise ValueError(
+                f"Not allowed: archive member '{name}' declares "
+                f"{declared / (1 << 20):.1f} MiB but only "
+                f"{compress_size / (1 << 20):.1f} MiB are stored on disk; "
+                "refusing to extract a decompression bomb."
+            )
+        total += declared
+        if cap is not None and total > cap:
+            raise ValueError(
+                f"Not allowed: extracting '{name}' would write "
+                f"{total / (1 << 20):.1f} MiB from a "
+                f"{stored_size / (1 << 20):.1f} MiB archive; refusing to "
+                "extract a potential decompression bomb."
+            )
+        yield finfo
+
+
 def extract_open_archive(archive, path="."):
     """Extracts an open tar or zip archive to the provided directory.
 
-    This function filters unsafe paths during extraction.
+    This function filters unsafe paths and rejects decompression bombs during
+    extraction.
 
     Args:
         archive: The archive object, either a `TarFile` or a `ZipFile`.
         path: Where to extract the archive file.
     """
+    stored_size = _archive_stored_size(archive)
     if isinstance(archive, zipfile.ZipFile):
         # Zip archive.
+        members = filter_safe_zipinfos(archive.infolist(), path)
         archive.extractall(
-            path, members=filter_safe_zipinfos(archive.infolist(), path)
+            path, members=_reject_extraction_bombs(members, stored_size)
         )
     else:
         # Tar archive.
@@ -150,9 +230,10 @@ def extract_open_archive(archive, path="."):
             and "filter" in inspect.signature(archive.extractall).parameters
         ):
             extractall_kwargs = {"filter": "data"}
+        members = filter_safe_tarinfos(archive, path)
         archive.extractall(
             path,
-            members=filter_safe_tarinfos(archive, path),
+            members=_reject_extraction_bombs(members, stored_size),
             **extractall_kwargs,
         )
 
@@ -199,7 +280,12 @@ def extract_archive(file_path, path=".", archive_format="auto"):
             with open_fn(file_path) as archive:
                 try:
                     extract_open_archive(archive, path)
-                except (tarfile.TarError, RuntimeError, KeyboardInterrupt):
+                except (
+                    tarfile.TarError,
+                    RuntimeError,
+                    KeyboardInterrupt,
+                    ValueError,
+                ):
                     if os.path.exists(path):
                         if os.path.isfile(path):
                             os.remove(path)

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -407,6 +407,26 @@ class ExtractArchiveTest(test_case.TestCase):
         with open(os.path.join(extract_path, "sample.txt")) as f:
             self.assertEqual(f.read(), self.file_content)
 
+    def test_extract_bomb_guard_ignores_negative_member_size(self):
+        # A malformed archive with a negative member size must not decrease the
+        # cumulative total and let a later oversized member slip past the cap.
+        class _FakeTarInfo:
+            def __init__(self, name, size):
+                self.name = name
+                self.size = size  # no compress_size -> cumulative check only
+
+        members = [
+            _FakeTarInfo("a", -10_000_000),  # negative -> clamped to 0
+            _FakeTarInfo(
+                "b", 8_000_000
+            ),  # would slip past if total underflowed
+        ]
+        with patch.object(file_utils, "_EXTRACT_BOMB_FLOOR_BYTES", 1 << 20):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                list(
+                    file_utils._reject_extraction_bombs(members, stored_size=8)
+                )
+
 
 class GetFileTest(test_case.TestCase):
     def setUp(self):

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import os
 import tarfile
 import urllib
@@ -11,6 +12,26 @@ from absl.testing import parameterized
 
 from keras.src.testing import test_case
 from keras.src.utils import file_utils
+
+
+class _ZeroStream(io.RawIOBase):
+    """A readable stream of `n` zero bytes, never materialized in memory.
+
+    Used to build a tiny archive whose member header declares a huge
+    (highly compressible) size without allocating that many bytes.
+    """
+
+    def __init__(self, n):
+        self.remaining = n
+
+    def readable(self):
+        return True
+
+    def readinto(self, b):
+        chunk = min(len(b), self.remaining, 1 << 20)
+        b[:chunk] = b"\x00" * chunk
+        self.remaining -= chunk
+        return chunk
 
 
 class PathToStringTest(test_case.TestCase):
@@ -329,6 +350,62 @@ class ExtractArchiveTest(test_case.TestCase):
             with self.assertRaises(KeyboardInterrupt):
                 file_utils.extract_archive(tar_path, extract_path, "tar")
         self.assertFalse(os.path.exists(extract_path))
+
+    def _create_tar_gz_bomb(self, declared_bytes):
+        """A tiny `.tar.gz` whose member header declares `declared_bytes` of
+        (highly compressible) zeros."""
+        archive_path = os.path.join(self.temp_dir, "bomb.tar.gz")
+        with tarfile.open(archive_path, "w:gz") as tf:
+            ti = tarfile.TarInfo("data.bin")
+            ti.size = declared_bytes
+            tf.addfile(ti, _ZeroStream(declared_bytes))
+        return archive_path
+
+    def _create_zip_bomb(self, declared_bytes):
+        """A tiny `.zip` whose member decompresses to `declared_bytes`."""
+        archive_path = os.path.join(self.temp_dir, "bomb.zip")
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            with zf.open("data.bin", "w") as f:
+                written = 0
+                chunk = b"\x00" * (1 << 20)
+                while written < declared_bytes:
+                    n = min(len(chunk), declared_bytes - written)
+                    f.write(chunk[:n])
+                    written += n
+        return archive_path
+
+    def test_extract_archive_rejects_tar_gz_bomb(self):
+        # A tiny .tar.gz declaring a far larger member is rejected before the
+        # member is written (the declared size is read from the header). The
+        # floor is lowered so the test stays small.
+        archive_path = self._create_tar_gz_bomb(8 << 20)  # 8 MiB declared
+        self.assertLess(os.path.getsize(archive_path), 1 << 20)  # tiny on disk
+        extract_path = os.path.join(self.temp_dir, "tar_bomb_out")
+        with patch.object(file_utils, "_EXTRACT_BOMB_FLOOR_BYTES", 1 << 20):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                file_utils.extract_archive(archive_path, extract_path, "tar")
+        self.assertFalse(os.path.exists(os.path.join(extract_path, "data.bin")))
+
+    def test_extract_archive_rejects_zip_bomb(self):
+        archive_path = self._create_zip_bomb(8 << 20)  # 8 MiB declared
+        self.assertLess(os.path.getsize(archive_path), 1 << 20)  # tiny on disk
+        extract_path = os.path.join(self.temp_dir, "zip_bomb_out")
+        with patch.object(file_utils, "_EXTRACT_BOMB_FLOOR_BYTES", 1 << 20):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                file_utils.extract_archive(archive_path, extract_path, "zip")
+        self.assertFalse(os.path.exists(os.path.join(extract_path, "data.bin")))
+
+    def test_extract_archive_allows_genuine_archive(self):
+        # A genuine low-ratio archive extracts fine even with the floor
+        # lowered (no false positive).
+        archive_path = self.create_tar()
+        extract_path = os.path.join(self.temp_dir, "genuine_out")
+        with patch.object(file_utils, "_EXTRACT_BOMB_FLOOR_BYTES", 1 << 20):
+            self.assertTrue(
+                file_utils.extract_archive(archive_path, extract_path, "tar")
+            )
+        with open(os.path.join(extract_path, "sample.txt")) as f:
+            self.assertEqual(f.read(), self.file_content)
 
 
 class GetFileTest(test_case.TestCase):


### PR DESCRIPTION
## Description

`extract_open_archive()` extracts every path-filtered tar/zip member with **no
decompression-ratio or size bound**. The path filters (`filter_safe_zipinfos` /
`filter_safe_tarinfos` + tar `filter="data"`) only validate each member's
*path*; nothing checks the declared uncompressed size against the bytes stored
on disk. So the public `keras.utils.extract_archive()` and
`keras.utils.get_file(..., extract=True)` (which routes through it) write an
untrusted archive's members to disk unbounded: a few-hundred-KB archive whose
member decompresses to gigabytes fills the victim's disk, and a large member is
also read on the fly into memory on the fallback path (CWE-409 / CWE-400).

This is the same public entry point as the tar directory-traversal
CVE-2025-12060 and the hard-link traversal fix #22973; here the impact is
resource exhaustion. The `.keras` load path was hardened against decompression
bombs (#23010 for the in-memory reads, #23101 for the `DiskIOStore` asset
extraction), but #23101's guard sits in `DiskIOStore.__init__` — the *call
site* — rather than in the shared `extract_open_archive()` that both
`DiskIOStore` and the public extraction/download APIs call, so the public path
stayed unguarded.

This PR moves the guard into the shared `extract_open_archive()` so it protects
every caller (`extract_archive`, `get_file(..., extract=True)`, and
`DiskIOStore`):

- `_reject_extraction_bombs` wraps the path-filtered member iterator and
  refuses to extract a member — or a running total across members — that
  declares more than a floor (256 MiB, matching the asset-extraction guard)
  **and** more than 100× the archive's stored size on disk. Members are
  consumed lazily, so a tar member is rejected from its header *before* its
  data is written; a zip member is additionally checked against its own stored
  size, so a single hugely-expanding member is caught regardless of the others.
- `_archive_stored_size` provides the on-disk (compressed) size used as the
  ratio denominator, falling back to the sum of zip member sizes.
- `extract_archive` now also cleans up the partially-extracted output when a
  bomb is detected (`ValueError` added to its existing cleanup-on-error path).

Genuine archives store their data at a ratio far below the threshold (and stay
under the floor), so the guard is false-positive-free. This covers both `.tar`
/`.tar.gz` and `.zip`, unlike the zip-only call-site guard.

Adds tests for tar.gz and zip bombs (rejected before any member is written) and
a genuine-archive no-false-positive case.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
