### PR TITLE
Reuse loader validation for cumulative HDF5 checks in KerasFileEditor

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -45,7 +45,7 @@ _H5_SHAPE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
 _H5_SHAPE_BOMB_MAX_EXPANSION = 1000
 
 
-def _reject_h5_shape_bomb(h5_file):
+def _reject_h5_shape_bomb(h5_file, file_size=None):
     """Reject a cumulative shape/decompression-bomb HDF5 weights file.
 
     `KerasFileEditor` walks the weights in `_extract_weights_from_store` rather
@@ -57,27 +57,46 @@ def _reject_h5_shape_bomb(h5_file):
     the file against the bytes actually stored on disk, mirroring the loader's
     HDF5 shape-bomb guard, so opening an untrusted file cannot drive the editor
     into memory exhaustion (CWE-789 / CWE-409 / CWE-400).
+
+    `file_size` is the bytes stored on disk; the caller passes the archive's
+    recorded size (or the OS file size) so the check does not depend on
+    `h5py.File.id.get_filesize()`, which can be unreliable for stream-backed
+    files. It falls back to that when no size is provided.
     """
-    try:
-        file_size = h5_file.id.get_filesize()
-    except Exception:
-        # If the on-disk size cannot be determined, skip the check rather than
-        # break opening the file.
-        return
+    if file_size is None:
+        try:
+            file_size = h5_file.id.get_filesize()
+        except Exception:
+            # If the on-disk size cannot be determined, skip the check rather
+            # than break opening the file.
+            return
     if file_size <= 0:
         return
     total_declared = 0
 
-    def _accumulate(_name, obj):
+    def _accumulate(group):
         nonlocal total_declared
-        # A null-dataspace dataset has `shape is None`; skip it (`math.prod`
-        # would raise on `None`).
-        if isinstance(obj, h5py.Dataset) and obj.shape is not None:
-            total_declared += math.prod(obj.shape) * obj.dtype.itemsize
+        for key in group.keys():
+            # Check the link type before accessing the child so an
+            # `ExternalLink`/`SoftLink` is rejected rather than resolved: the
+            # external file is never opened, and a soft-link cycle cannot
+            # recurse (mirrors `_extract_weights_from_store`).
+            child_class = group.get(
+                key, default=None, getclass=True, getlink=True
+            )
+            if child_class in (h5py.ExternalLink, h5py.SoftLink):
+                raise ValueError(
+                    f"Not allowed: H5 file with {child_class.__name__}"
+                )
+            obj = group[key]
+            if isinstance(obj, h5py.Group):
+                _accumulate(obj)
+            elif isinstance(obj, h5py.Dataset) and obj.shape is not None:
+                # A null-dataspace dataset has `shape is None`; skip it
+                # (`math.prod` would raise on `None`).
+                total_declared += math.prod(obj.shape) * obj.dtype.itemsize
 
-    # `visititems` only walks hard-linked datasets; external/soft links are
-    # rejected separately by `_extract_weights_from_store` when accessed.
-    h5_file.visititems(_accumulate)
+    _accumulate(h5_file)
     if (
         total_declared > _H5_SHAPE_BOMB_FLOOR_BYTES
         and total_declared > _H5_SHAPE_BOMB_MAX_EXPANSION * file_size
@@ -154,7 +173,21 @@ class KerasFileEditor:
                 f"Received: filepath={filepath}"
             )
 
-        _reject_h5_shape_bomb(weights_store.h5_file)
+        # Pass the archive's recorded weights size (or OS file size) so the
+        # shape-bomb ratio check does not rely on `get_filesize()`, which can
+        # be unreliable for the stream-backed `.keras` weights member.
+        file_size = None
+        if filepath.endswith(".keras"):
+            try:
+                file_size = zf.getinfo(f"{saving_lib._VARS_FNAME}.h5").file_size
+            except KeyError:
+                pass
+        elif filepath.endswith(".weights.h5"):
+            try:
+                file_size = os.path.getsize(filepath)
+            except OSError:
+                pass
+        _reject_h5_shape_bomb(weights_store.h5_file, file_size=file_size)
         weights_dict, object_metadata = self._extract_weights_from_store(
             weights_store.h5_file
         )

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -35,6 +35,62 @@ def is_ipython_notebook():
         return False
 
 
+# An HDF5 weights file whose datasets cumulatively declare more than this floor
+# of array data, and more than `_H5_SHAPE_BOMB_MAX_EXPANSION` times the bytes
+# actually stored on disk, is treated as a shape/decompression bomb
+# (CWE-789 / CWE-409). Mirrors the loader's HDF5 guard so the editor enjoys the
+# same protection (it walks the weights itself instead of going through the
+# loader's `safe_get_h5_dataset`).
+_H5_SHAPE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
+_H5_SHAPE_BOMB_MAX_EXPANSION = 1000
+
+
+def _reject_h5_shape_bomb(h5_file):
+    """Reject a cumulative shape/decompression-bomb HDF5 weights file.
+
+    `KerasFileEditor` walks the weights in `_extract_weights_from_store` rather
+    than through the loader's ratio-checked `safe_get_h5_dataset`, and its
+    per-dataset size guard has no decompression-ratio bound and no cumulative
+    budget: a dataset declaring just under the per-dataset limit while storing
+    almost nothing, or several such datasets, are read into memory in full from
+    a few-KB file. This bounds the cumulative declared size of every dataset in
+    the file against the bytes actually stored on disk, mirroring the loader's
+    HDF5 shape-bomb guard, so opening an untrusted file cannot drive the editor
+    into memory exhaustion (CWE-789 / CWE-409 / CWE-400).
+    """
+    try:
+        file_size = h5_file.id.get_filesize()
+    except Exception:
+        # If the on-disk size cannot be determined, skip the check rather than
+        # break opening the file.
+        return
+    if file_size <= 0:
+        return
+    total_declared = 0
+
+    def _accumulate(_name, obj):
+        nonlocal total_declared
+        # A null-dataspace dataset has `shape is None`; skip it (`math.prod`
+        # would raise on `None`).
+        if isinstance(obj, h5py.Dataset) and obj.shape is not None:
+            total_declared += math.prod(obj.shape) * obj.dtype.itemsize
+
+    # `visititems` only walks hard-linked datasets; external/soft links are
+    # rejected separately by `_extract_weights_from_store` when accessed.
+    h5_file.visititems(_accumulate)
+    if (
+        total_declared > _H5_SHAPE_BOMB_FLOOR_BYTES
+        and total_declared > _H5_SHAPE_BOMB_MAX_EXPANSION * file_size
+    ):
+        declared_str = summary_utils.readable_memory_size(total_declared)
+        stored_str = summary_utils.readable_memory_size(file_size)
+        raise ValueError(
+            "Refusing to open a potential decompression/shape bomb: the "
+            f"HDF5 weights declare {declared_str} of array data but only "
+            f"{stored_str} are stored on disk."
+        )
+
+
 @keras_export("keras.saving.KerasFileEditor")
 class KerasFileEditor:
     """Utility to inspect, edit, and resave Keras weights files.
@@ -98,6 +154,7 @@ class KerasFileEditor:
                 f"Received: filepath={filepath}"
             )
 
+        _reject_h5_shape_bomb(weights_store.h5_file)
         weights_dict, object_metadata = self._extract_weights_from_store(
             weights_store.h5_file
         )

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -209,3 +209,19 @@ class SavingTest(testing.TestCase):
         self.assertLess(os.path.getsize(bomb_fpath), 1 << 20)  # tiny on disk
         with self.assertRaisesRegex(ValueError, "shape bomb"):
             KerasFileEditor(bomb_fpath)
+
+    def test_shape_bomb_guard_rejects_external_link(self):
+        # The guard traverses the group manually and rejects an external/soft
+        # link itself (without resolving it), rather than relying only on
+        # `_extract_weights_from_store` to catch it.
+        from keras.src.saving.file_editor import _reject_h5_shape_bomb
+
+        secret_fpath = os.path.join(self.get_temp_dir(), "secret.h5")
+        with h5py.File(secret_fpath, "w") as f:
+            f.create_dataset("k", data=np.zeros((2, 2), "float32"))
+        mal_fpath = os.path.join(self.get_temp_dir(), "mal.weights.h5")
+        with h5py.File(mal_fpath, "w") as f:
+            f["ext"] = h5py.ExternalLink(secret_fpath, "/")
+        with h5py.File(mal_fpath, "r") as f:
+            with self.assertRaisesRegex(ValueError, "ExternalLink"):
+                _reject_h5_shape_bomb(f, file_size=os.path.getsize(mal_fpath))

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -161,3 +161,51 @@ class SavingTest(testing.TestCase):
 
         with self.assertRaisesRegex(ValueError, "virtual"):
             KerasFileEditor(virtual_fpath)
+
+    def test_rejects_shape_bomb(self):
+        # A few-KB file whose dataset declares far more than it stores on disk
+        # (chunked + gzip + fillvalue) must be rejected before the editor reads
+        # it into memory.
+        bomb_fpath = os.path.join(self.get_temp_dir(), "bomb.weights.h5")
+        with h5py.File(bomb_fpath, "w") as f:
+            vars_group = (
+                f.create_group("layers")
+                .create_group("dense")
+                .create_group("vars")
+            )
+            vars_group.create_dataset(
+                "0",
+                shape=(128 * (1 << 20),),  # 128 MiB declared, ~0 stored
+                dtype="uint8",
+                chunks=(1 << 20,),
+                compression="gzip",
+                fillvalue=0,
+            )
+        self.assertLess(os.path.getsize(bomb_fpath), 1 << 20)  # tiny on disk
+        with self.assertRaisesRegex(ValueError, "shape bomb"):
+            KerasFileEditor(bomb_fpath)
+
+    def test_rejects_cumulative_shape_bomb(self):
+        # Several datasets that each declare under the floor but jointly declare
+        # far more than is stored: the cumulative guard must reject them.
+        bomb_fpath = os.path.join(
+            self.get_temp_dir(), "cumulative_bomb.weights.h5"
+        )
+        with h5py.File(bomb_fpath, "w") as f:
+            vars_group = (
+                f.create_group("layers")
+                .create_group("dense")
+                .create_group("vars")
+            )
+            for i in range(3):  # 3 x 32 MiB declared = 96 MiB total
+                vars_group.create_dataset(
+                    str(i),
+                    shape=(32 * (1 << 20),),
+                    dtype="uint8",
+                    chunks=(1 << 20,),
+                    compression="gzip",
+                    fillvalue=0,
+                )
+        self.assertLess(os.path.getsize(bomb_fpath), 1 << 20)  # tiny on disk
+        with self.assertRaisesRegex(ValueError, "shape bomb"):
+            KerasFileEditor(bomb_fpath)


### PR DESCRIPTION
**Updated implementation: #23656.** This PR remains automatically closed for inactivity, and GitHub does not allow the author to reopen it. The original branch has been updated; the replacement draft contains the new commits. The implementation and validation notes below describe the replacement.

## Description


`KerasFileEditor` reads all datasets into memory, but a per-dataset size limit does not bound their combined expansion. Check the cumulative declared HDF5 dataset size before reading any arrays, for both standalone `.weights.h5` files and HDF5 weights embedded in `.keras` archives.

The preflight helper lives in `saving_lib` and reuses `safe_get_h5_group()` and `safe_get_h5_dataset()` from the loader. The editor also uses the shared dataset validator while extracting weights. This removes its duplicated external/virtual dataset checks and keeps validation consistent with the loader.

The preflight traverses metadata only. It rejects external/soft links before resolution, detects cyclic hard-linked groups, and handles scalar, empty, and null datasets plus named datatypes. The editor supplies the filesystem size or the ZIP member's uncompressed size for the cumulative check, and closes its HDF5 store and ZIP archive on both success and rejection.

**Depends on #23655 (the replacement for #23159).** This branch includes that PR's removal of unsupported NPZ weight storage and shared ZIP archive check. The editor reuses that ZIP check before opening archive members. After #23655 merges, this PR contains only the HDF5/editor follow-up.

## Validation

- TensorFlow backend: **159 passed, 7 skipped** across `file_editor_test.py`, `saving_lib_test.py`, and `saving_api_test.py`.
- PyTorch backend: **97 passed** across `file_editor_test.py` and `saving_lib_test.py`.
- Rejection tests cover single and cumulative oversized datasets in both `.weights.h5` and `.keras`; they make array reads fail to verify rejection happens before reading data.
- Tests cover metadata-only traversal, explicit file-size accounting, link rejection, cycle detection, resource closure, and normal editor operations.
- Repository-wide Ruff lint/format checks and `git diff --check` passed. API generation produced no API changes.
- Python 3.12.13, TensorFlow 2.21.0, PyTorch 2.14.0.

## AI assistance

OpenAI Codex assisted with the follow-up implementation, tests, validation, and this description.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
