### PR TITLE
Reject ReDoS-prone Muon exclude_layers to avoid catastrophic backtracking

### DIFF
--- a/keras/src/optimizers/muon.py
+++ b/keras/src/optimizers/muon.py
@@ -170,7 +170,15 @@ class Muon(optimizer.Optimizer):
         self.ns_steps = ns_steps
         self.nesterov = nesterov
         self.exclude_embeddings = exclude_embeddings
-        self.exclude_layers = exclude_layers or []
+        # A bare string would iterate per-character (each a 1-char regex that
+        # matches almost any path); require a list and normalize to one so the
+        # config round-trips cleanly.
+        if isinstance(exclude_layers, str):
+            raise ValueError(
+                "Argument `exclude_layers` must be a list of strings. "
+                f"Received: exclude_layers='{exclude_layers}'"
+            )
+        self.exclude_layers = list(exclude_layers or [])
         for keyword in self.exclude_layers:
             _validate_exclude_layer(keyword)
         self.adam_weight_decay = adam_weight_decay

--- a/keras/src/optimizers/muon.py
+++ b/keras/src/optimizers/muon.py
@@ -4,6 +4,42 @@ from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.optimizers import optimizer
 
+# `exclude_layers` entries are matched against variable paths with `re.search`,
+# and the list is a constructor argument serialized into a model's config, so a
+# crafted entry can cause catastrophic regex backtracking (ReDoS, CWE-1333) that
+# hangs the first training step after an untrusted model is loaded. The entries
+# are documented as plain layer-name keywords (e.g. `["output_dense"]`), so we
+# restrict each one to a run of path characters, optionally ending in `.*` (or
+# `.*` itself). This admits every legitimate keyword while making any
+# backtracking-prone construct impossible; the validation regex is itself linear
+# (one quantifier over a character class), so it cannot be turned into a ReDoS.
+_MAX_EXCLUDE_LAYER_LENGTH = 256
+_SAFE_EXCLUDE_LAYER_RE = re.compile(r"^(?:[a-zA-Z0-9_./-]+(?:\.\*)?|\.\*)$")
+
+
+def _validate_exclude_layer(keyword):
+    if not isinstance(keyword, str):
+        raise ValueError(
+            "Each `exclude_layers` entry must be a string; received "
+            f"'{keyword}' of type {type(keyword)}."
+        )
+    if len(keyword) > _MAX_EXCLUDE_LAYER_LENGTH:
+        raise ValueError(
+            "An `exclude_layers` entry must be at most "
+            f"{_MAX_EXCLUDE_LAYER_LENGTH} characters; received an entry of "
+            f"length {len(keyword)}. Entries are matched as regular "
+            "expressions against variable paths, so an overly long entry can "
+            "cause catastrophic backtracking (ReDoS) during training."
+        )
+    if not _SAFE_EXCLUDE_LAYER_RE.match(keyword):
+        raise ValueError(
+            f"Unsafe or invalid `exclude_layers` entry '{keyword}'. Entries "
+            "must be layer-name keywords (alphanumeric characters, "
+            "underscores, slashes, hyphens, or dots), optionally ending in "
+            "`.*`, so that matching them cannot cause regular-expression "
+            "backtracking (ReDoS)."
+        )
+
 
 @keras_export(["keras.optimizers.Muon"])
 class Muon(optimizer.Optimizer):
@@ -135,6 +171,8 @@ class Muon(optimizer.Optimizer):
         self.nesterov = nesterov
         self.exclude_embeddings = exclude_embeddings
         self.exclude_layers = exclude_layers or []
+        for keyword in self.exclude_layers:
+            _validate_exclude_layer(keyword)
         self.adam_weight_decay = adam_weight_decay
         self.rms_rate = rms_rate
 

--- a/keras/src/optimizers/muon_test.py
+++ b/keras/src/optimizers/muon_test.py
@@ -41,6 +41,29 @@ class MuonTest(testing.TestCase):
         optimizer.update_step(grads, vars, 0.5)
         self.assertAllClose(vars, [0.5, 1.5, 2.5, 3.5], rtol=1e-4, atol=1e-4)
 
+    def test_rejects_redos_exclude_layers(self):
+        # `exclude_layers` entries are matched as regexes against variable
+        # paths during training, and the list is serialized into a model's
+        # config, so a backtracking-prone entry (or an overly long one) could
+        # cause catastrophic ReDoS when an untrusted model is loaded and
+        # trained. Anything outside the documented layer-name-keyword contract
+        # is rejected at construction (and therefore at deserialization).
+        for bad in (
+            "(a+)+$",  # nested quantifier (exponential)
+            ".*.*.*.*",  # multiple wildcards (polynomial)
+            "a*a*a*a*b",  # group-free polynomial backtracking
+            "encoder/(layer_0|layer_1)",  # alternation group
+        ):
+            with self.assertRaisesRegex(ValueError, "ReDoS"):
+                Muon(exclude_layers=[bad])
+        with self.assertRaisesRegex(ValueError, "at most"):
+            Muon(exclude_layers=["a" * 1000])
+        # Plain keywords and a simple trailing `.*` glob are still accepted.
+        optimizer = Muon(
+            exclude_layers=["output_dense", "block1/dense", "encoder/.*"]
+        )
+        self.assertLen(optimizer.exclude_layers, 3)
+
     def test_should_use_adamw(self):
         vars = backend.Variable([[1.0, 2.0], [3.0, 4.0]])
         optimizer = Muon(exclude_layers=["var"])

--- a/keras/src/optimizers/muon_test.py
+++ b/keras/src/optimizers/muon_test.py
@@ -58,6 +58,10 @@ class MuonTest(testing.TestCase):
                 Muon(exclude_layers=[bad])
         with self.assertRaisesRegex(ValueError, "at most"):
             Muon(exclude_layers=["a" * 1000])
+        # A bare string (instead of a list) is rejected rather than iterated
+        # per-character.
+        with self.assertRaisesRegex(ValueError, "must be a list of strings"):
+            Muon(exclude_layers="output_dense")
         # Plain keywords and a simple trailing `.*` glob are still accepted.
         optimizer = Muon(
             exclude_layers=["output_dense", "block1/dense", "encoder/.*"]


### PR DESCRIPTION
## Description

`Muon._should_use_adamw` decides, per variable, whether to fall back to the
AdamW update by matching the variable's path against each entry of
`exclude_layers` with `re.search`:

```python
for keyword in self.exclude_layers:
    if re.search(keyword, variable.path):
        return True
```

`exclude_layers` is an ordinary constructor argument that `get_config`
serializes, so a malicious model carries it. An entry crafted for catastrophic
backtracking (e.g. `(a+)+$`) pins a CPU core for an unbounded amount of time on
the first gradient step after the model is loaded with `compile=True` and
trained — a ReDoS (CWE-1333). No special flags are required; the regex runs on
the default training path.

The entries are documented as plain layer-name keywords ("keywords of layer
names to exclude", e.g. `exclude_layers=["output_dense"]`), so this PR validates
each entry at construction — and therefore at deserialization, before any
training step — against an allowlist: an entry must be a run of path characters,
optionally ending in `.*` (or be `.*` itself). This admits every legitimate
keyword while making any backtracking-prone construct (nested quantifiers,
alternation groups, multiple wildcards) impossible. The validation regex is
itself linear (one quantifier over a character class), so it cannot be turned
into a ReDoS.

This mirrors the `DTypePolicyMap` key guard in #23102, which addresses the same
config-controlled-regex ReDoS class on the model-loading path. A malicious model
now fails to load with a clear error instead of hanging the trainer.

Adds a regression test: backtracking-prone and over-long entries are rejected,
while plain keywords and a simple trailing `.*` glob are still accepted.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
