### PR TITLE
Reject HDF5 ExternalLink/SoftLink traversal via intermediate path components

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1163,6 +1163,43 @@ class DiskIOStore:
             file_utils.rmtree(self.tmp_dir)
 
 
+def _reject_h5_link_traversal(parent, name):
+    """Reject a name whose path traverses an `ExternalLink`/`SoftLink`.
+
+    `parent.get(name, getlink=True)` reports only the link type of the *final*
+    path component, so a multi-component name such as ``"ext/kernel"`` whose
+    *intermediate* component (``"ext"``) is an `ExternalLink` is silently
+    followed into the external file while the guard inspects only the final
+    component (an ordinary dataset in that file). Check the link type of every
+    component -- without dereferencing it -- so an intermediate link cannot
+    smuggle a traversal past `safe_get_h5_group` / `safe_get_h5_dataset` and
+    disclose an arbitrary HDF5 file at load time.
+    """
+    # Only h5py groups/files have links to traverse (an in-memory dict store
+    # used for some code paths does not); leave existence handling to the
+    # caller's `name not in parent` check.
+    if not isinstance(parent, (h5py.Group, h5py.File)):
+        return
+    # An absolute name resolves from the file root, mirroring `parent[name]`.
+    current = parent.file if name.startswith("/") else parent
+    for component in name.split("/"):
+        if not component:  # skip empty components (leading/duplicate slashes)
+            continue
+        if not isinstance(current, (h5py.Group, h5py.File)):
+            # The path descends past a dataset; let the caller's lookup fail.
+            return
+        link_type = current.get(
+            component, default=None, getclass=True, getlink=True
+        )
+        if link_type is None:
+            # Missing component; the caller's existence check raises KeyError.
+            return
+        if link_type in (h5py.ExternalLink, h5py.SoftLink):
+            raise ValueError(f"Not allowed: H5 file with {link_type.__name__}")
+        # Safe to descend: `component` is a hard link within the same file.
+        current = current[component]
+
+
 def safe_get_h5_group(parent, name):
     """Retrieve a Group within a given File or Group.
 
@@ -1173,13 +1210,10 @@ def safe_get_h5_group(parent, name):
     Returns:
         The child h5py.Group.
     """
+    _reject_h5_link_traversal(parent, name)
     # Also handles the case when the group is an empty dict initially.
     if name not in parent:
         raise KeyError(name)
-
-    group_type = parent.get(name, default=None, getclass=True, getlink=True)
-    if group_type in (h5py.ExternalLink, h5py.SoftLink):
-        raise ValueError(f"Not allowed: H5 file with {group_type.__name__}")
 
     group = parent[name]
     if not isinstance(group, h5py.Group):
@@ -1210,13 +1244,10 @@ def safe_get_h5_dataset(group, name):
     Returns:
         The child h5py.Dataset.
     """
+    _reject_h5_link_traversal(group, name)
     # Also handles the case when the group is an empty dict initially.
     if name not in group:
         raise KeyError(name)
-
-    dataset_type = group.get(name, default=None, getclass=True, getlink=True)
-    if dataset_type in (h5py.ExternalLink, h5py.SoftLink):
-        raise ValueError(f"Not allowed: H5 file with {dataset_type.__name__}")
 
     dataset = group[name]
     if not isinstance(dataset, h5py.Dataset):

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1176,9 +1176,10 @@ def _reject_h5_link_traversal(parent, name):
     disclose an arbitrary HDF5 file at load time.
     """
     # Only h5py groups/files have links to traverse (an in-memory dict store
-    # used for some code paths does not); leave existence handling to the
-    # caller's `name not in parent` check.
-    if not isinstance(parent, (h5py.Group, h5py.File)):
+    # used for some code paths does not), and `h5py` is an optional dependency,
+    # so guard `h5py.available` before referencing its attributes; leave
+    # existence handling to the caller's `name not in parent` check.
+    if not h5py.available or not isinstance(parent, (h5py.Group, h5py.File)):
         return
     # An absolute name resolves from the file root, mirroring `parent[name]`.
     current = parent.file if name.startswith("/") else parent

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1800,6 +1800,76 @@ class SafeGetH5DatasetTest(testing.TestCase):
         with self.assertRaises(ValueError):
             reloaded.load_weights(good_path)
 
+    def _external_secret_file(self):
+        secret = os.path.join(self.get_temp_dir(), "secret.h5")
+        with h5py.File(secret, "w") as f:
+            f.create_dataset("kernel", data=np.full((3, 2), 99.0, "float32"))
+            f.create_dataset("bias", data=np.full((2,), 99.0, "float32"))
+        return secret
+
+    def test_rejects_intermediate_external_link(self):
+        # A multi-component name whose *intermediate* component is an
+        # ExternalLink must be rejected. `getlink` only inspects the final
+        # component, so the link would otherwise be followed into the external
+        # file and an arbitrary HDF5 file disclosed.
+        secret = self._external_secret_file()
+        path = os.path.join(self.get_temp_dir(), "mal.weights.h5")
+        with h5py.File(path, "w") as f:
+            f.create_group("layer")["ext"] = h5py.ExternalLink(secret, "/")
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "ExternalLink"):
+                saving_lib.safe_get_h5_dataset(f["layer"], "ext/kernel")
+            with self.assertRaisesRegex(ValueError, "ExternalLink"):
+                saving_lib.safe_get_h5_group(f, "layer/ext")
+
+    def test_rejects_intermediate_soft_link(self):
+        path = os.path.join(self.get_temp_dir(), "soft.weights.h5")
+        with h5py.File(path, "w") as f:
+            real = f.create_group("real")
+            real.create_dataset("kernel", data=np.zeros((2, 2), "float32"))
+            f["soft"] = h5py.SoftLink("/real")
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "SoftLink"):
+                saving_lib.safe_get_h5_dataset(f, "soft/kernel")
+
+    def test_allows_legitimate_nested_name(self):
+        # A multi-component name made only of real (hard-linked) groups and
+        # datasets must still resolve (no false positive).
+        path = os.path.join(self.get_temp_dir(), "ok.weights.h5")
+        with h5py.File(path, "w") as f:
+            f.create_group("layers").create_group("dense").create_dataset(
+                "kernel", data=np.zeros((2, 2), "float32")
+            )
+        with h5py.File(path, "r") as f:
+            self.assertIsInstance(
+                saving_lib.safe_get_h5_group(f, "layers/dense"), h5py.Group
+            )
+            self.assertEqual(
+                saving_lib.safe_get_h5_dataset(f, "layers/dense/kernel").shape,
+                (2, 2),
+            )
+
+    def test_load_subset_weights_rejects_intermediate_external_link(self):
+        # End-to-end via the legacy loader: a layer group whose `weight_names`
+        # traverse an intermediate ExternalLink is rejected before the external
+        # file is read.
+        from keras.src.legacy.saving.legacy_h5_format import (
+            load_subset_weights_from_hdf5_group,
+        )
+
+        secret = self._external_secret_file()
+        path = os.path.join(self.get_temp_dir(), "evil.weights.h5")
+        with h5py.File(path, "w") as f:
+            g = f.create_group("layer")
+            g["ext"] = h5py.ExternalLink(secret, "/")
+            g.attrs["weight_names"] = [
+                np.bytes_(b"ext/kernel"),
+                np.bytes_(b"ext/bias"),
+            ]
+        with h5py.File(path, "r") as f:
+            with self.assertRaisesRegex(ValueError, "ExternalLink"):
+                load_subset_weights_from_hdf5_group(f["layer"])
+
 
 class SavingDiskIOStoreTest(testing.TestCase):
     def test_disk_io_store_rejects_path_traversal(self):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1870,6 +1870,14 @@ class SafeGetH5DatasetTest(testing.TestCase):
             with self.assertRaisesRegex(ValueError, "ExternalLink"):
                 load_subset_weights_from_hdf5_group(f["layer"])
 
+    def test_link_traversal_skips_when_h5py_unavailable(self):
+        # `h5py` is an optional dependency; the guard must return gracefully
+        # (rather than crash referencing `h5py.Group`) when it is unavailable.
+        fake_h5py = mock.Mock()
+        fake_h5py.available = False
+        with mock.patch.object(saving_lib, "h5py", fake_h5py):
+            saving_lib._reject_h5_link_traversal({"layer": {}}, "layer/ext")
+
 
 class SavingDiskIOStoreTest(testing.TestCase):
     def test_disk_io_store_rejects_path_traversal(self):


### PR DESCRIPTION
## Description

`safe_get_h5_group` / `safe_get_h5_dataset` reject a member whose own link is an
`ExternalLink`/`SoftLink` by calling `parent.get(name, getlink=True)` — but
`getlink` reports only the link type of the **final** path component. When
`name` is a multi-component path such as `"ext/kernel"` and the **intermediate**
component (`"ext"`) is an `ExternalLink`, h5py silently follows it into an
external file and the guard inspects only the final component (`"kernel"`, an
ordinary dataset in that file). The guard therefore passes and the external file
is read:

```python
dataset_type = group.get(name, default=None, getclass=True, getlink=True)
if dataset_type in (h5py.ExternalLink, h5py.SoftLink):   # only the FINAL link
    raise ValueError(...)
dataset = group[name]                                    # reads the external file
```

The intermediate-link names are attacker-controlled: a layer group's
`weight_names` and the file's `layer_names` are HDF5 attributes taken verbatim
from the crafted file and passed straight into the guards by the loaders. A
malicious `.weights.h5` / `.keras` therefore reads an **arbitrary HDF5 file** on
the victim's host during `model.load_weights()` / `keras.saving.load_model()`,
under the default `safe_mode=True` — information disclosure of any HDF5 file the
process can read. This is the same security boundary as the original
`ExternalLink` advisories (GHSA-fx5g-469v-w8mc / GHSA-27f4-p4xq-cxg8), reached
by routing the link through an intermediate group so the existing guard never
inspects it.

This PR adds `_reject_h5_link_traversal`, which checks the link type of **every**
component of the name — without dereferencing it — and rejects an
`ExternalLink`/`SoftLink` at any level, descending only through hard links
within the same file. Both guards call it in place of the single-component
check, so every loader that routes through them (the legacy HDF5 loaders in
`legacy_h5_format.py` and the modern `H5IOStore`) is covered. Because the check
never dereferences a link, the external file is never even opened. Legitimate
multi-component names (e.g. `H5IOStore`'s `"layers/<name>"`) still resolve.

Adds tests: an intermediate `ExternalLink` and `SoftLink` are rejected at both
the group and dataset guards and via the legacy weight loader, while a genuine
nested name still resolves.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
