### PR TITLE
Bound build-time weight allocation when loading against stored weights

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -618,6 +618,17 @@ class Layer(BackendLayer, Operation):
             else:
                 initializer = "zeros"
         initializer = initializers.get(initializer)
+        # When rebuilding a model from a loaded file, bound the cumulative
+        # build-time allocation against the weights stored in the file so an
+        # untrusted config cannot declare oversized layers and exhaust memory
+        # before any weight data is read. The budget is only installed by the
+        # loader (see `saving_lib._BuildAllocationBudget`); direct model
+        # construction in user code is unaffected.
+        _build_budget = global_state.get_global_attribute(
+            "keras_build_allocation_budget"
+        )
+        if _build_budget is not None:
+            _build_budget.consume(shape, dtype)
         with backend.name_scope(self.name, caller=self):
             variable = backend.Variable(
                 initializer=initializer,

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -508,6 +508,13 @@ class _BuildAllocationBudget:
 
     def consume(self, shape, dtype):
         try:
+            # Reject negative dimensions: `math.prod` of a shape with a
+            # negative entry can be negative, which would *decrease* the
+            # running total and let a later oversized allocation slip past the
+            # budget. `int(dim)` also normalizes NumPy integers and raises on a
+            # `None`/non-integer entry, which the `except` below ignores.
+            if any(int(dim) < 0 for dim in shape):
+                return
             num_bytes = math.prod(shape) * np.dtype(dtype).itemsize
         except (TypeError, ValueError):
             # Non-numeric dtype or a shape with non-integer entries: nothing to

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -471,13 +471,95 @@ def _safe_zip_read(archive, name):
         return f.read()
 
 
+# A model loaded from a `.keras` allocates each layer's weights at build time,
+# from the (untrusted) config, *before* any weight data is read. A config that
+# declares oversized layers (a huge Dense `units`, Conv `filters`, Embedding
+# dimension, ...) would otherwise drive a multi-gigabyte allocation from a
+# few-KB file (CWE-789 / CWE-400). Bound the cumulative build-time allocation
+# against the size of the weights actually stored in the file: a genuine model
+# declares roughly as much as it stores (ratio ~1), while a bomb declares far
+# more than the file could ever fill. The floor allows small models (whose
+# stored weights are tiny) to build freely; the expansion ratio leaves ample
+# headroom for any honest model.
+_BUILD_ALLOCATION_FLOOR_BYTES = 1 << 30  # 1 GiB
+_BUILD_ALLOCATION_MAX_EXPANSION = 1000
+# `Layer.add_weight` reads the ambient budget under this global-state key. Keep
+# in sync with `keras/src/layers/layer.py`.
+_BUILD_ALLOCATION_BUDGET_KEY = "keras_build_allocation_budget"
+
+
+class _BuildAllocationBudget:
+    """Ambient cap on cumulative build-time weight allocation while loading.
+
+    Set around `_model_from_config` so it applies only to a model rebuilt from
+    a loaded file (building a model directly in user code is unaffected, since
+    no budget is installed). `Layer.add_weight` consumes from it before each
+    allocation and raises once the total exceeds the limit derived from the
+    bytes of weight data stored in the file.
+    """
+
+    def __init__(self, stored_bytes):
+        self.stored_bytes = stored_bytes
+        self.limit = max(
+            _BUILD_ALLOCATION_FLOOR_BYTES,
+            _BUILD_ALLOCATION_MAX_EXPANSION * stored_bytes,
+        )
+        self.allocated = 0
+
+    def consume(self, shape, dtype):
+        try:
+            num_bytes = math.prod(shape) * np.dtype(dtype).itemsize
+        except (TypeError, ValueError):
+            # Non-numeric dtype or a shape with non-integer entries: nothing to
+            # bound here, leave it to the backend.
+            return
+        self.allocated += num_bytes
+        if self.allocated > self.limit:
+            raise ValueError(
+                "Refusing to build a model that allocates at least "
+                f"{readable_memory_size(self.allocated)} of weights at build "
+                "time, far more than the "
+                f"{readable_memory_size(self.stored_bytes)} of weight data "
+                "stored in the file; the configuration may declare oversized "
+                "layers (potential memory-exhaustion bomb)."
+            )
+
+    def __enter__(self):
+        self._previous = global_state.get_global_attribute(
+            _BUILD_ALLOCATION_BUDGET_KEY
+        )
+        global_state.set_global_attribute(_BUILD_ALLOCATION_BUDGET_KEY, self)
+        return self
+
+    def __exit__(self, *args):
+        global_state.set_global_attribute(
+            _BUILD_ALLOCATION_BUDGET_KEY, self._previous
+        )
+
+
+def _stored_weights_size(archive):
+    """Uncompressed size of the weights member in a `.keras` archive.
+
+    Used to bound build-time weight allocation against the weights actually
+    present in the file. Returns 0 when there is no weights member, so a config
+    shipped without weights is still held to the floor.
+    """
+    for name in (_VARS_FNAME_H5, _VARS_FNAME_NPZ):
+        try:
+            return archive.getinfo(name).file_size
+        except KeyError:
+            continue
+    return 0
+
+
 def _load_model_from_fileobj(fileobj, custom_objects, compile, safe_mode):
     with zipfile.ZipFile(fileobj, "r") as zf:
         config_json = _safe_zip_read(zf, _CONFIG_FILENAME)
 
-        model = _model_from_config(
-            config_json, custom_objects, compile, safe_mode
-        )
+        with _BuildAllocationBudget(_stored_weights_size(zf)):
+            model = _model_from_config(
+                config_json, custom_objects, compile, safe_mode
+            )
 
         all_filenames = zf.namelist()
         extract_dir = None

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1873,6 +1873,17 @@ class BuildAllocationBudgetTest(testing.TestCase):
         layer.build((None, 256))
         self.assertEqual(tuple(layer.kernel.shape), (256, 512))
 
+    def test_negative_dimension_does_not_underflow_budget(self):
+        # A negative dimension makes `math.prod(shape)` negative, which must
+        # not decrease the running total and let a later oversized allocation
+        # slip past the budget.
+        budget = saving_lib._BuildAllocationBudget(stored_bytes=0)
+        budget.consume((128, -1_000_000_000), "float32")
+        self.assertEqual(budget.allocated, 0)
+        # A subsequent genuinely-oversized allocation is still rejected.
+        with self.assertRaisesRegex(ValueError, "memory-exhaustion bomb"):
+            budget.consume((1_000_000_000, 1_000), "float32")
+
 
 class SavingDiskIOStoreTest(testing.TestCase):
     def test_disk_io_store_rejects_path_traversal(self):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1801,6 +1801,79 @@ class SafeGetH5DatasetTest(testing.TestCase):
             reloaded.load_weights(good_path)
 
 
+class BuildAllocationBudgetTest(testing.TestCase):
+    def _tampered_keras(self, model, class_name, key, value):
+        """Save `model`, then rewrite `class_name`'s `key` to `value` in its
+        config.json — an oversized layer in an otherwise tiny file."""
+        src = os.path.join(self.get_temp_dir(), "src.keras")
+        model.save(src)
+        with zipfile.ZipFile(src) as zin:
+            names = zin.namelist()
+            blobs = {n: zin.read(n) for n in names}
+        cfg = json.loads(blobs["config.json"])
+
+        def bump(obj):
+            if isinstance(obj, dict):
+                if obj.get("class_name") == class_name:
+                    obj["config"][key] = value
+                for v in obj.values():
+                    bump(v)
+            elif isinstance(obj, list):
+                for v in obj:
+                    bump(v)
+
+        bump(cfg)
+        blobs["config.json"] = json.dumps(cfg).encode()
+        evil = os.path.join(self.get_temp_dir(), "evil.keras")
+        with zipfile.ZipFile(evil, "w", zipfile.ZIP_DEFLATED) as zo:
+            for name in names:
+                zo.writestr(name, blobs[name])
+        return evil
+
+    def test_rejects_oversized_dense_units(self):
+        # A tampered config declaring a huge `units` is rejected before the
+        # (128 x 1e9) kernel is allocated.
+        model = keras.Sequential([keras.Input((128,)), keras.layers.Dense(4)])
+        evil = self._tampered_keras(model, "Dense", "units", 1_000_000_000)
+        self.assertLess(os.path.getsize(evil), 1 << 16)  # tiny file on disk
+        with self.assertRaisesRegex(ValueError, "memory-exhaustion bomb"):
+            saving_lib.load_model(evil)
+
+    def test_rejects_oversized_conv_filters(self):
+        model = keras.Sequential(
+            [keras.Input((32, 32, 3)), keras.layers.Conv2D(4, 3)]
+        )
+        evil = self._tampered_keras(model, "Conv2D", "filters", 500_000_000)
+        with self.assertRaisesRegex(ValueError, "memory-exhaustion bomb"):
+            saving_lib.load_model(evil)
+
+    def test_allows_genuine_model(self):
+        # A genuine model (declared weights ~= stored weights) loads normally.
+        model = keras.Sequential(
+            [
+                keras.Input((128,)),
+                keras.layers.Dense(256),
+                keras.layers.Dense(10),
+            ]
+        )
+        path = os.path.join(self.get_temp_dir(), "ok.keras")
+        model.save(path)
+        reloaded = saving_lib.load_model(path)
+        self.assertEqual(reloaded.count_params(), model.count_params())
+
+    def test_budget_only_applies_during_load(self):
+        # The cap is loader-scoped: no budget is installed during direct model
+        # construction in user code, so large in-code layers are unrestricted.
+        from keras.src.backend.common import global_state
+
+        self.assertIsNone(
+            global_state.get_global_attribute("keras_build_allocation_budget")
+        )
+        layer = keras.layers.Dense(512)
+        layer.build((None, 256))
+        self.assertEqual(tuple(layer.kernel.shape), (256, 512))
+
+
 class SavingDiskIOStoreTest(testing.TestCase):
     def test_disk_io_store_rejects_path_traversal(self):
         store = saving_lib.DiskIOStore("assets", archive=None, mode="w")


### PR DESCRIPTION
## Description

Loading a `.keras` rebuilds the model from its (untrusted) config and allocates
each layer's weights at build time — a Dense `units`, Conv `filters`, or
Embedding dimension comes straight from the config — **before any weight data is
read**. A config that declares oversized layers therefore drives a
multi-gigabyte allocation from a few-kilobyte file under the default
`safe_mode=True`, OOM-killing the loading process (CWE-789 / CWE-400). A tampered
`config.json` that bumps a `Dense` `units` to `1e9` makes `load_model` try to
allocate a `(128 x 1e9)` kernel (~512 GiB) from a tiny file.

Unlike a fixed size cap or a check against available RAM, this PR bounds the
cumulative build-time allocation against the **size of the weights actually
stored in the file**, reusing the "declared vs stored" principle already applied
to the HDF5 / npz / ZIP guards: a genuine model declares roughly what it stores
(ratio ~1), while a bomb declares far more than the file could ever fill.
`saving_lib` installs an ambient `_BuildAllocationBudget` (limit =
`max(1 GiB, 1000 × stored-weights-size)`) around `_model_from_config`, and
`Layer.add_weight` consumes from it before each allocation, raising once the
running total exceeds the limit — *before* the oversized variable is created.

Key properties that keep this safe and false-positive-free:

- **Loader-scoped.** The budget is installed only while a loaded config is
  rebuilt. Building a model directly in user code installs no budget, so large
  in-code models are never restricted. `add_weight` does one cheap global-state
  lookup (a no-op) outside loading.
- **Anchored to stored bytes, not a fixed cap or RAM.** It is therefore
  device-independent (weights may live on GPU/TPU, not CPU RAM) and never fires
  on an honest model, which stores roughly what it declares. The 1 GiB floor
  lets small models build freely; the 1000× ratio leaves ample headroom.
- **No bypass via omitting weights.** A config shipped without a weights member
  is held to the floor rather than left unbounded.

Adds tests: oversized `Dense` `units` and `Conv2D` `filters` configs are
rejected before allocation, a genuine model still loads, and direct in-code
construction stays unbounded.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
