### PR TITLE
Fix nextafter infinity boundary

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3513,8 +3513,13 @@ def nextafter(x1, x2):
     x2 = convert_to_tensor(x2)
 
     dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
-    x1 = tf.cast(x1, tf.float64)
-    x2 = tf.cast(x2, tf.float64)
+    compute_dtype = (
+        "float64"
+        if standardize_dtype(dtype) in ("bfloat16", "float16")
+        else dtype
+    )
+    x1 = tf.cast(x1, compute_dtype)
+    x2 = tf.cast(x2, compute_dtype)
     return tf.cast(tf.math.nextafter(x1, x2), dtype)
 
 

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2165,8 +2165,13 @@ def nextafter(x1, x2):
     x2 = convert_to_tensor(x2)
 
     dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
-    x1 = cast(x1, torch.float64)
-    x2 = cast(x2, torch.float64)
+    compute_dtype = (
+        "float64"
+        if standardize_dtype(dtype) in ("bfloat16", "float16")
+        else dtype
+    )
+    x1 = cast(x1, compute_dtype)
+    x2 = cast(x2, compute_dtype)
     return cast(torch.nextafter(x1, x2), dtype)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4532,6 +4532,20 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.nextafter(x, y), np.nextafter(x, y))
         self.assertAllClose(knp.Nextafter()(x, y), np.nextafter(x, y))
 
+    @pytest.mark.skipif(
+        backend.backend() == "openvino",
+        reason="OpenVINO nextafter uses a separate approximation path.",
+    )
+    def test_nextafter_inf_towards_negative_inf(self):
+        x = np.array([np.nan, np.inf, -0.0], dtype="float32")
+        y = np.array([1.0, -np.inf, 0.0], dtype="float32")
+
+        result = backend.convert_to_numpy(knp.nextafter(x, y)).astype("float32")
+        expected = np.nextafter(x, y).astype("float32")
+
+        self.assertTrue(np.isnan(result[0]))
+        self.assertAllClose(result[1:], expected[1:])
+
     def test_not_equal(self):
         x = np.array([[1, 2], [3, 4]])
         y = np.array([[5, 6], [7, 8]])


### PR DESCRIPTION
## Description

Fixes #23132.

The TensorFlow and Torch backends previously computed `nextafter` in `float64` and then cast back to the result dtype. For `float32` inputs, `nextafter(float64 inf, -inf)` produces the largest finite `float64` value, and casting that value to `float32` overflows back to `inf`.

This updates both backends to compute `nextafter` in Keras' resolved floating result dtype instead. For the reported `float32` case, this preserves NumPy-compatible behavior and returns the largest finite `float32` value. It also adds a regression test for `nextafter(inf, -inf)` on `float32` inputs.

*AI disclosure:* I used an AI coding assistant to help inspect the issue and prepare this patch. I reviewed the changes and take responsibility for the code.

## Tests

- `git diff --check`
- `python -m py_compile keras/src/backend/tensorflow/numpy.py keras/src/backend/torch/numpy.py keras/src/ops/numpy_test.py`
- `python -m ruff format --check keras/src/backend/tensorflow/numpy.py keras/src/backend/torch/numpy.py keras/src/ops/numpy_test.py`
- `python -m ruff check keras/src/backend/tensorflow/numpy.py keras/src/backend/torch/numpy.py keras/src/ops/numpy_test.py`
- Numerical sanity check with NumPy confirming the old `float64` upcast/downcast path overflows to `inf` while `float32` `nextafter` returns max finite `float32`.

Not run:

- `pytest keras/src/ops/numpy_test.py::NumpyTwoInputOpsCorrectnessTest::test_nextafter_inf_towards_negative_inf` because this workspace does not have the full Keras test dependencies or TensorFlow installed.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.