### PR TITLE
Verify all intermediary H5 groups when navigating H5 files.

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1173,20 +1173,32 @@ def safe_get_h5_group(parent, name):
     Returns:
         The child h5py.Group.
     """
-    # Also handles the case when the group is an empty dict initially.
-    if name not in parent:
-        raise KeyError(name)
+    current = parent
+    for name_part in name.split("/"):
+        if not name_part:
+            raise ValueError(f"Invalid path in H5 file: {name}")
 
-    group_type = parent.get(name, default=None, getclass=True, getlink=True)
-    if group_type in (h5py.ExternalLink, h5py.SoftLink):
-        raise ValueError(f"Not allowed: H5 file with {group_type.__name__}")
+        # Also handles the case when the group is an empty dict initially.
+        if name_part not in current:
+            raise KeyError(name)
 
-    group = parent[name]
-    if not isinstance(group, h5py.Group):
-        raise ValueError(
-            f"Invalid H5 file, expected Group but received {type(group)}"
-        )
-    return group
+        if isinstance(current, dict):
+            group_type = None
+        else:
+            group_type = current.get(
+                name_part, default=None, getclass=True, getlink=True
+            )
+
+        if group_type in (h5py.ExternalLink, h5py.SoftLink):
+            raise ValueError(f"Not allowed: H5 file with {group_type.__name__}")
+
+        current = current[name_part]
+        if not isinstance(current, h5py.Group):
+            raise ValueError(
+                f"Invalid H5 file, expected Group but received {type(current)}"
+            )
+
+    return current
 
 
 # Guard against HDF5 "shape bomb" datasets: a dataset can declare an enormous
@@ -1210,6 +1222,11 @@ def safe_get_h5_dataset(group, name):
     Returns:
         The child h5py.Dataset.
     """
+    if "/" in name:
+        # Separate the dataset name from it's parent group.
+        group_name, name = name.rsplit("/", 1)
+        group = safe_get_h5_group(group, group_name)
+
     # Also handles the case when the group is an empty dict initially.
     if name not in group:
         raise KeyError(name)


### PR DESCRIPTION
The H5 library is able to resolve nested group addressed using slashes in the name. Instead, resolve these manually to verify the group type each step of the way.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
