### PR TITLE
Deduplicate shared variables in HDF5 saves

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -1562,6 +1562,7 @@ class ShardedH5IOStore(H5IOStore):
         self._h5_entry_group = {}
         self._h5_entry_metadata = None
         self._h5_entry_initialized = False
+        self._written_variable_datasets = {}
 
         # Init shard parameters.
         self.current_shard_index = 0
@@ -1771,29 +1772,43 @@ class ShardedH5IOStore(H5IOStore):
     def __setitem__(self, key, value):
         self._restore_h5_file()
 
-        # Accumulate `current_shard_size`.
-        value = backend.convert_to_numpy(value)
-        dtype = backend.standardize_dtype(value.dtype)
-        weight_counts = math.prod(value.shape)
-        per_param_size = dtype_utils.dtype_size(dtype)
-        value_size = weight_counts * per_param_size / 8  # In bytes.
-        self.total_shard_size += value_size
-        if value_size > self.max_shard_size:
-            value_size_str = readable_memory_size(value_size)
-            max_shard_size_str = readable_memory_size(self.max_shard_size)
-            raise ValueError(
-                f"The size of {key} is {value_size_str} which "
-                f"exceeds the maximum shard size {max_shard_size_str}. You "
-                "can increase the `max_shard_size` parameter to accommodate "
-                "the size."
+        variable_id = self._get_variable_id(value)
+        is_linked = False
+        if variable_id is not None:
+            linked_dataset_path = self._written_variable_datasets.get(
+                variable_id
             )
+            if linked_dataset_path is not None:
+                try:
+                    self.h5_file[linked_dataset_path]
+                    is_linked = True
+                except KeyError:
+                    pass
 
-        # Create a new shard if the current shard is full.
-        self.current_shard_size += value_size
-        if self.current_shard_size > self.max_shard_size:
-            self.close()
-            self.h5_file = self._create_new_shard_file()
-            self.current_shard_size = value_size
+        if not is_linked:
+            # Accumulate `current_shard_size`.
+            value_size_source = backend.convert_to_numpy(value)
+            dtype = backend.standardize_dtype(value_size_source.dtype)
+            weight_counts = math.prod(value_size_source.shape)
+            per_param_size = dtype_utils.dtype_size(dtype)
+            value_size = weight_counts * per_param_size / 8  # In bytes.
+            self.total_shard_size += value_size
+            if value_size > self.max_shard_size:
+                value_size_str = readable_memory_size(value_size)
+                max_shard_size_str = readable_memory_size(self.max_shard_size)
+                raise ValueError(
+                    f"The size of {key} is {value_size_str} which "
+                    f"exceeds the maximum shard size {max_shard_size_str}. "
+                    "You can increase the `max_shard_size` parameter to "
+                    "accommodate the size."
+                )
+
+            # Create a new shard if the current shard is full.
+            self.current_shard_size += value_size
+            if self.current_shard_size > self.max_shard_size:
+                self.close()
+                self.h5_file = self._create_new_shard_file()
+                self.current_shard_size = value_size
 
         super().__setitem__(key, value)
 

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -746,6 +746,7 @@ def _save_state(
     assets_store,
     inner_path,
     visited_saveables,
+    visited_variables=None,
 ):
     from keras.src.saving.keras_saveable import KerasSaveable
 
@@ -768,7 +769,13 @@ def _save_state(
     if id(saveable) in visited_saveables:
         return
 
+    if visited_variables is None:
+        visited_variables = {}
+
     if hasattr(saveable, "save_own_variables") and weights_store:
+        _warn_if_duplicate_own_variables(
+            saveable, inner_path, visited_variables
+        )
         if hasattr(saveable, "name") and isinstance(saveable.name, str):
             metadata = {"name": saveable.name}
         else:
@@ -792,6 +799,7 @@ def _save_state(
                     "\\", "/"
                 ),
                 visited_saveables=visited_saveables,
+                visited_variables=visited_variables,
             )
         elif isinstance(child_obj, (list, dict, tuple)):
             _save_container_state(
@@ -802,6 +810,7 @@ def _save_state(
                     "\\", "/"
                 ),
                 visited_saveables=visited_saveables,
+                visited_variables=visited_variables,
             )
 
 
@@ -916,6 +925,41 @@ def _get_unique_name(name, used_names):
     return name
 
 
+def _warn_if_duplicate_own_variables(saveable, inner_path, visited_variables):
+    if not hasattr(saveable, "_trainable_variables"):
+        return
+
+    all_vars = list(saveable._trainable_variables)
+    if hasattr(saveable, "_non_trainable_variables"):
+        all_vars += list(saveable._non_trainable_variables)
+
+    current_path = inner_path or "<root>"
+    for variable in all_vars:
+        variable_id = id(variable)
+        if variable_id not in visited_variables:
+            visited_variables[variable_id] = current_path
+            continue
+
+        previous_path = visited_variables[variable_id]
+        if previous_path == current_path:
+            continue
+
+        variable_name = getattr(variable, "path", None)
+        if variable_name is None:
+            variable_name = getattr(variable, "name", "variable")
+        warnings.warn(
+            f"Variable '{variable_name}' is referenced by multiple Keras "
+            f"saveables: '{previous_path}' and '{current_path}'. The variable "
+            "will be hard-linked in HDF5-based save files when possible to "
+            "avoid duplicating tensor data on disk. However, manually sharing "
+            "variable objects across different layer instances may not "
+            "preserve shared Python object identity when loading a full "
+            "model. Prefer using one shared layer instance instead of "
+            "assigning the same variable to multiple layers.",
+            stacklevel=6,
+        )
+
+
 def _container_path_present(weights_store, assets_store, path):
     """True if either store has anything under `path`.
 
@@ -934,6 +978,7 @@ def _save_container_state(
     assets_store,
     inner_path,
     visited_saveables,
+    visited_variables=None,
     visited_containers=None,
 ):
     from keras.src.saving.keras_saveable import KerasSaveable
@@ -963,6 +1008,7 @@ def _save_container_state(
                 assets_store,
                 inner_path=file_utils.join(inner_path, name).replace("\\", "/"),
                 visited_saveables=visited_saveables,
+                visited_variables=visited_variables,
             )
         elif isinstance(saveable, (list, dict, tuple)):
             name = _get_unique_name("container", used_names)
@@ -972,6 +1018,7 @@ def _save_container_state(
                 assets_store,
                 inner_path=file_utils.join(inner_path, name).replace("\\", "/"),
                 visited_saveables=visited_saveables,
+                visited_variables=visited_variables,
                 visited_containers=visited_containers,
             )
 
@@ -1289,6 +1336,7 @@ class H5IOStore:
         self._h5_entry_group = {}
         self._h5_entry_metadata = None
         self._h5_entry_initialized = False
+        self._written_variable_datasets = {}
 
     def __bool__(self):
         # Delegate `__bool__` to the underlying `h5_file`. Otherwise, Python
@@ -1419,11 +1467,32 @@ class H5IOStore:
             value = np.array(value)
         return value
 
+    def _get_variable_id(self, value):
+        if isinstance(value, backend.Variable):
+            return id(value)
+        return None
+
     def __setitem__(self, key, value):
         if self.mode not in ("w", "a"):
             raise ValueError("Setting a value is only allowed in write mode.")
         if not self._h5_entry_initialized:
             self._create_h5_group(self._h5_entry_path)
+
+        variable_id = self._get_variable_id(value)
+        if variable_id is not None:
+            linked_dataset_path = self._written_variable_datasets.get(
+                variable_id
+            )
+            if linked_dataset_path is not None:
+                try:
+                    self._h5_entry_group[key] = self.h5_file[
+                        linked_dataset_path
+                    ]
+                    return
+                except KeyError:
+                    # Sharded stores may have moved to another H5 file. In
+                    # that case, fall through and write the value normally.
+                    pass
 
         value = backend.convert_to_numpy(value)
         if backend.standardize_dtype(value.dtype) == "bfloat16":
@@ -1431,6 +1500,10 @@ class H5IOStore:
             ds.attrs["dtype"] = "bfloat16"
         else:
             self._h5_entry_group[key] = value
+            ds = self._h5_entry_group[key]
+
+        if variable_id is not None:
+            self._written_variable_datasets[variable_id] = ds.name
 
     def __delitem__(self, key):
         if self.mode not in ("w", "a"):

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -88,6 +88,34 @@ class LayerWithCustomSaving(MyDense):
 
 
 @keras.saving.register_keras_serializable(package="my_custom_package")
+class SharedVariableLayer(keras.layers.Layer):
+    def __init__(self, shared_kernel=None, **kwargs):
+        super().__init__(**kwargs)
+        self.shared_kernel = shared_kernel
+
+    def build(self, input_shape):
+        if self.shared_kernel is None:
+            self.kernel = self.add_weight(
+                shape=(input_shape[-1], 1),
+                name="kernel",
+                initializer="ones",
+            )
+        else:
+            self.kernel = self.shared_kernel
+        self.bias = self.add_weight(
+            shape=(1,),
+            name="bias",
+            initializer="zeros",
+        )
+
+    def call(self, inputs):
+        return ops.matmul(inputs, self.kernel) + self.bias
+
+    def get_config(self):
+        return super().get_config()
+
+
+@keras.saving.register_keras_serializable(package="my_custom_package")
 class CustomModelX(keras.Model):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -980,6 +1008,92 @@ class ComplexModel(keras.layers.Layer):
 
 
 class SavingBattleTest(testing.TestCase):
+    def _get_shared_variable_model(self):
+        inputs = keras.Input((2,))
+        layer_a = SharedVariableLayer(name="shared_a")
+        output_a = layer_a(inputs)
+        output_b = SharedVariableLayer(
+            shared_kernel=layer_a.kernel, name="shared_b"
+        )(inputs)
+        return keras.Model(inputs, output_a + output_b)
+
+    def _get_h5_dataset_paths(self, group, suffix):
+        paths = []
+
+        def collect(current_group, prefix=""):
+            for key in current_group.keys():
+                path = f"{prefix}/{key}" if prefix else key
+                value = current_group[key]
+                if isinstance(value, h5py.Dataset):
+                    if path.endswith(suffix):
+                        paths.append(path)
+                elif isinstance(value, h5py.Group):
+                    collect(value, path)
+
+        collect(group)
+        return sorted(paths)
+
+    def _assert_duplicate_h5_datasets_are_linked(self, h5_file):
+        kernel_paths = self._get_h5_dataset_paths(h5_file, "/vars/0")
+        shared_kernel_paths = [
+            path for path in kernel_paths if "shared_variable_layer" in path
+        ]
+        self.assertLen(shared_kernel_paths, 2)
+        dataset_addresses = [
+            h5py.h5o.get_info(h5_file[path].id).addr
+            for path in shared_kernel_paths
+        ]
+        self.assertEqual(dataset_addresses[0], dataset_addresses[1])
+
+    def test_model_save_hard_links_duplicate_variables(self):
+        model = self._get_shared_variable_model()
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "shared_variable_model.keras"
+        )
+        x = np.array([[1.0, 2.0]])
+        ref_output = model(x)
+
+        with pytest.warns(
+            UserWarning,
+            match="referenced by multiple Keras saveables",
+        ):
+            saving_lib.save_model(model, temp_filepath)
+
+        with zipfile.ZipFile(temp_filepath, "r") as zf:
+            with zf.open("model.weights.h5", "r") as weights_file:
+                with h5py.File(BytesIO(weights_file.read()), "r") as h5_file:
+                    self._assert_duplicate_h5_datasets_are_linked(h5_file)
+
+        loaded_model = saving_lib.load_model(temp_filepath)
+        self.assertAllClose(loaded_model(x), ref_output)
+
+    def test_save_weights_hard_links_duplicate_variables(self):
+        model = self._get_shared_variable_model()
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "shared_variable_model.weights.h5"
+        )
+        x = np.array([[1.0, 2.0]])
+        ref_output = model(x)
+
+        with pytest.warns(
+            UserWarning,
+            match="referenced by multiple Keras saveables",
+        ):
+            saving_lib.save_weights_only(model, temp_filepath)
+
+        with h5py.File(temp_filepath, "r") as h5_file:
+            self._assert_duplicate_h5_datasets_are_linked(h5_file)
+
+        loaded_model = self._get_shared_variable_model()
+        saving_lib.load_weights_only(loaded_model, temp_filepath)
+        self.assertAllClose(loaded_model(x), ref_output)
+        shared_layers = [
+            layer
+            for layer in loaded_model.layers
+            if isinstance(layer, SharedVariableLayer)
+        ]
+        self.assertIs(shared_layers[0].kernel, shared_layers[1].kernel)
+
     def test_custom_object_without_from_config(self):
         temp_filepath = os.path.join(
             self.get_temp_dir(), "custom_fn_model.keras"

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1094,6 +1094,48 @@ class SavingBattleTest(testing.TestCase):
         ]
         self.assertIs(shared_layers[0].kernel, shared_layers[1].kernel)
 
+    def test_sharded_save_weights_hard_links_duplicate_variables(self):
+        model = self._get_shared_variable_model()
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "shared_variable_model.weights.json"
+        )
+        x = np.array([[1.0, 2.0]])
+        ref_output = model(x)
+
+        with pytest.warns(
+            UserWarning,
+            match="referenced by multiple Keras saveables",
+        ):
+            saving_lib.save_weights_only(
+                model, temp_filepath, max_shard_size=0.000001
+            )
+
+        with open(temp_filepath) as f:
+            sharding_config = json.load(f)
+        shard_filenames = {
+            filename
+            for filenames in sharding_config["weight_map"].values()
+            for filename in (
+                filenames if isinstance(filenames, list) else [filenames]
+            )
+        }
+        self.assertLen(shard_filenames, 1)
+        shard_filepath = os.path.join(
+            os.path.dirname(temp_filepath), shard_filenames.pop()
+        )
+        with h5py.File(shard_filepath, "r") as h5_file:
+            self._assert_duplicate_h5_datasets_are_linked(h5_file)
+
+        loaded_model = self._get_shared_variable_model()
+        saving_lib.load_weights_only(loaded_model, temp_filepath)
+        self.assertAllClose(loaded_model(x), ref_output)
+        shared_layers = [
+            layer
+            for layer in loaded_model.layers
+            if isinstance(layer, SharedVariableLayer)
+        ]
+        self.assertIs(shared_layers[0].kernel, shared_layers[1].kernel)
+
     def test_custom_object_without_from_config(self):
         temp_filepath = os.path.join(
             self.get_temp_dir(), "custom_fn_model.keras"


### PR DESCRIPTION
## Description

Closes #18419.

This updates HDF5-backed saving so repeated references to the same `backend.Variable` are not written as duplicate tensor datasets. `H5IOStore` now tracks variables by object identity and writes later references as HDF5 hard links to the first dataset, preserving the existing per-saveable `path/vars/key` layout while avoiding duplicate storage.

The change also keeps a warning for unsupported manual variable sharing across different layer instances, because full-model loading may not preserve Python object identity for that pattern. A shared layer instance remains the preferred modeling pattern.

Regression coverage includes both `.keras` and `.weights.h5` saves. The tests assert that duplicate logical HDF5 paths point to the same object address, and that round-trip inference / weights loading remains correct.

AI disclosure: This PR was prepared with assistance from an AI coding agent. The submitted changes were locally verified, and the contributor takes responsibility for the code and review responses.

## Tests

- `python -m py_compile keras/src/saving/saving_lib.py keras/src/saving/saving_lib_test.py`
- `python -m ruff format --check keras/src/saving/saving_lib.py keras/src/saving/saving_lib_test.py`
- `python -m ruff check keras/src/saving/saving_lib.py keras/src/saving/saving_lib_test.py`
- `KERAS_BACKEND=numpy python -m pytest keras/src/saving/saving_lib_test.py::SavingBattleTest::test_model_save_hard_links_duplicate_variables keras/src/saving/saving_lib_test.py::SavingBattleTest::test_save_weights_hard_links_duplicate_variables -q`
- `KERAS_BACKEND=numpy python -m pytest keras/src/saving/saving_lib_test.py::SavingBattleTest -q -k "not remove_weights_only_saving_and_loading"`
- `git diff --check`

Not run locally: the full `SavingBattleTest` class without the exclusion above. `test_remove_weights_only_saving_and_loading` exercises mocked remote-path handling and requires TensorFlow/gfile in this local environment.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.