### PR TITLE
Guard PyDataset multiprocessing on JAX GPU

### DIFF
--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -36,8 +36,9 @@ class PyDataset:
             This is necessary to gain compute-level (rather than I/O level)
             benefits from parallelism. However it can only be set to
             `True` if your dataset can be safely pickled.
-            With the JAX backend on GPU, `fit()` falls back to thread-based
-            workers when this is `True` to avoid unsafe process forking.
+            With the JAX backend on GPU or TPU, `fit()` falls back to
+            thread-based workers when this is `True` to avoid unsafe process
+            forking.
         max_queue_size: Maximum number of batches to keep in the queue
             when iterating over the dataset in a multithreaded or
             multiprocessed setting.
@@ -216,11 +217,11 @@ class PyDatasetAdapter(DataAdapter):
 
         workers = self.py_dataset.workers
         use_multiprocessing = self.py_dataset.use_multiprocessing
-        if use_multiprocessing and _is_jax_gpu_backend():
+        if use_multiprocessing and _is_jax_accelerator_backend():
             warnings.warn(
                 "`use_multiprocessing=True` is not supported with the JAX "
-                "backend on GPU. Falling back to thread-based workers to "
-                "avoid unsafe process forking after JAX/CUDA initialization.",
+                "backend on GPU or TPU. Falling back to thread-based workers "
+                "to avoid unsafe process forking after JAX initialization.",
                 stacklevel=3,
             )
             use_multiprocessing = False
@@ -381,12 +382,16 @@ _WORKER_ID_QUEUE = None  # Only created if needed.
 _FORCE_THREADPOOL = False
 
 
-def _is_jax_gpu_backend():
+def _is_jax_accelerator_backend():
     if backend.backend() != "jax":
         return False
-    import jax
 
-    return any(device.platform == "gpu" for device in jax.local_devices())
+    try:
+        import jax
+
+        return any(device.platform != "cpu" for device in jax.local_devices())
+    except Exception:
+        return False
 
 
 def get_pool_class(use_multiprocessing):

--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -9,6 +9,7 @@ from contextlib import closing
 
 import numpy as np
 
+from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.trainers.data_adapters.data_adapter import DataAdapter
@@ -35,6 +36,8 @@ class PyDataset:
             This is necessary to gain compute-level (rather than I/O level)
             benefits from parallelism. However it can only be set to
             `True` if your dataset can be safely pickled.
+            With the JAX backend on GPU, `fit()` falls back to thread-based
+            workers when this is `True` to avoid unsafe process forking.
         max_queue_size: Maximum number of batches to keep in the queue
             when iterating over the dataset in a multithreaded or
             multiprocessed setting.
@@ -213,6 +216,14 @@ class PyDatasetAdapter(DataAdapter):
 
         workers = self.py_dataset.workers
         use_multiprocessing = self.py_dataset.use_multiprocessing
+        if use_multiprocessing and _is_jax_gpu_backend():
+            warnings.warn(
+                "`use_multiprocessing=True` is not supported with the JAX "
+                "backend on GPU. Falling back to thread-based workers to "
+                "avoid unsafe process forking after JAX/CUDA initialization.",
+                stacklevel=3,
+            )
+            use_multiprocessing = False
         if workers > 1 or (workers > 0 and use_multiprocessing):
             self.enqueuer = OrderedEnqueuer(
                 self.py_dataset,
@@ -368,6 +379,14 @@ _SEQUENCE_COUNTER = None
 _DATA_POOLS = weakref.WeakSet()
 _WORKER_ID_QUEUE = None  # Only created if needed.
 _FORCE_THREADPOOL = False
+
+
+def _is_jax_gpu_backend():
+    if backend.backend() != "jax":
+        return False
+    import jax
+
+    return any(device.platform == "gpu" for device in jax.local_devices())
 
 
 def get_pool_class(use_multiprocessing):

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -421,7 +421,7 @@ class PyDatasetAdapterTest(testing.TestCase):
         ):
             next(it)
 
-    def test_jax_gpu_multiprocessing_falls_back_to_threads(self):
+    def test_jax_accelerator_multiprocessing_falls_back_to_threads(self):
         dataset = ExamplePyDataset(
             np.ones((6, 11), dtype="int32"),
             np.zeros((6, 11), dtype="int32"),
@@ -432,7 +432,9 @@ class PyDatasetAdapterTest(testing.TestCase):
 
         with (
             mock.patch.object(
-                py_dataset_adapter, "_is_jax_gpu_backend", return_value=True
+                py_dataset_adapter,
+                "_is_jax_accelerator_backend",
+                return_value=True,
             ),
             mock.patch.object(
                 py_dataset_adapter,
@@ -446,6 +448,46 @@ class PyDatasetAdapterTest(testing.TestCase):
             py_dataset_adapter.PyDatasetAdapter(dataset, shuffle=False)
 
         self.assertFalse(enqueuer_cls.call_args.kwargs["use_multiprocessing"])
+
+    def test_is_jax_accelerator_backend(self):
+        with mock.patch.object(
+            py_dataset_adapter.backend, "backend", return_value="numpy"
+        ):
+            self.assertFalse(py_dataset_adapter._is_jax_accelerator_backend())
+
+        with (
+            mock.patch.object(
+                py_dataset_adapter.backend, "backend", return_value="jax"
+            ),
+            mock.patch.object(
+                jax,
+                "local_devices",
+                return_value=[mock.Mock(platform="cpu")],
+            ),
+        ):
+            self.assertFalse(py_dataset_adapter._is_jax_accelerator_backend())
+
+        with (
+            mock.patch.object(
+                py_dataset_adapter.backend, "backend", return_value="jax"
+            ),
+            mock.patch.object(
+                jax,
+                "local_devices",
+                return_value=[mock.Mock(platform="tpu")],
+            ),
+        ):
+            self.assertTrue(py_dataset_adapter._is_jax_accelerator_backend())
+
+        with (
+            mock.patch.object(
+                py_dataset_adapter.backend, "backend", return_value="jax"
+            ),
+            mock.patch.object(
+                jax, "local_devices", side_effect=RuntimeError("unavailable")
+            ),
+        ):
+            self.assertFalse(py_dataset_adapter._is_jax_accelerator_backend())
 
     def test_iterate_finite(self):
         py_dataset = ExamplePyDataset(

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -1,5 +1,6 @@
 import math
 import time
+from unittest import mock
 
 import jax
 import numpy as np
@@ -393,11 +394,6 @@ class PyDatasetAdapterTest(testing.TestCase):
         use_multiprocessing=False,
         max_queue_size=0,
     ):
-        if backend.backend() == "jax" and use_multiprocessing is True:
-            self.skipTest(
-                "The CI failed for an unknown reason with "
-                "`use_multiprocessing=True` in the jax backend"
-            )
         dataset = ExceptionPyDataset(
             workers=workers,
             use_multiprocessing=use_multiprocessing,
@@ -424,6 +420,32 @@ class PyDatasetAdapterTest(testing.TestCase):
             expected_exception_class, "Expected exception"
         ):
             next(it)
+
+    def test_jax_gpu_multiprocessing_falls_back_to_threads(self):
+        dataset = ExamplePyDataset(
+            np.ones((6, 11), dtype="int32"),
+            np.zeros((6, 11), dtype="int32"),
+            batch_size=2,
+            workers=2,
+            use_multiprocessing=True,
+        )
+
+        with (
+            mock.patch.object(
+                py_dataset_adapter, "_is_jax_gpu_backend", return_value=True
+            ),
+            mock.patch.object(
+                py_dataset_adapter,
+                "OrderedEnqueuer",
+                wraps=py_dataset_adapter.OrderedEnqueuer,
+            ) as enqueuer_cls,
+            pytest.warns(
+                UserWarning, match="Falling back to thread-based workers"
+            ),
+        ):
+            py_dataset_adapter.PyDatasetAdapter(dataset, shuffle=False)
+
+        self.assertFalse(enqueuer_cls.call_args.kwargs["use_multiprocessing"])
 
     def test_iterate_finite(self):
         py_dataset = ExamplePyDataset(


### PR DESCRIPTION
## Description
Closes #18431.

This guards `PyDatasetAdapter` against process-based workers when running with the JAX backend on GPU. If `use_multiprocessing=True` is requested in that configuration, Keras now warns and falls back to thread-based workers to avoid unsafe process forking after JAX/CUDA initialization.

The change keeps JAX CPU multiprocessing behavior unchanged, uses lazy JAX device detection, and documents the fallback in the public `PyDataset` docstring.

Checks run:
- `python -m ruff format --check keras/src/trainers/data_adapters/py_dataset_adapter.py keras/src/trainers/data_adapters/py_dataset_adapter_test.py`
- `python -m ruff check keras/src/trainers/data_adapters/py_dataset_adapter.py keras/src/trainers/data_adapters/py_dataset_adapter_test.py`
- `$env:KERAS_BACKEND='jax'; python -m pytest keras/src/trainers/data_adapters/py_dataset_adapter_test.py -k jax_gpu_multiprocessing_falls_back_to_threads` (blocked locally because `tensorflow` is not installed and the test module imports it during collection)
- Standalone JAX adapter verification script patching `_is_jax_gpu_backend=True` and asserting `OrderedEnqueuer` receives `use_multiprocessing=False` plus the fallback warning
- `git diff --check HEAD~1..HEAD`

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.