### PR TITLE
Re-enable NASNetMobile on torch backend

### DIFF
--- a/keras/src/applications/applications_test.py
+++ b/keras/src/applications/applications_test.py
@@ -150,10 +150,6 @@ class ApplicationsTest(testing.TestCase):
     def test_application_notop_variable_input_channels(
         self, app, last_dim, _, image_data_format
     ):
-        if app == nasnet.NASNetMobile and backend.backend() == "torch":
-            self.skipTest(
-                "NASNetMobile pretrained incorrect with torch backend."
-            )
         self.skip_if_invalid_image_data_format_for_model(app, image_data_format)
         backend.set_image_data_format(image_data_format)
 
@@ -183,10 +179,6 @@ class ApplicationsTest(testing.TestCase):
     def test_application_base(self, app, _, app_module, image_data_format):
         import tensorflow as tf
 
-        if app == nasnet.NASNetMobile and backend.backend() == "torch":
-            self.skipTest(
-                "NASNetMobile pretrained incorrect with torch backend."
-            )
         if (
             image_data_format == "channels_first"
             and len(tf.config.list_physical_devices("GPU")) == 0
@@ -224,10 +216,6 @@ class ApplicationsTest(testing.TestCase):
     def test_application_notop_custom_input_shape(
         self, app, last_dim, _, image_data_format
     ):
-        if app == nasnet.NASNetMobile and backend.backend() == "torch":
-            self.skipTest(
-                "NASNetMobile pretrained incorrect with torch backend."
-            )
         self.skip_if_invalid_image_data_format_for_model(app, image_data_format)
         backend.set_image_data_format(image_data_format)
 
@@ -245,10 +233,6 @@ class ApplicationsTest(testing.TestCase):
     def test_application_notop_custom_input_tensor(
         self, app, last_dim, _, image_data_format
     ):
-        if app == nasnet.NASNetMobile and backend.backend() == "torch":
-            self.skipTest(
-                "NASNetMobile pretrained incorrect with torch backend."
-            )
         self.skip_if_invalid_image_data_format_for_model(app, image_data_format)
         backend.set_image_data_format(image_data_format)
 
@@ -269,10 +253,6 @@ class ApplicationsTest(testing.TestCase):
 
     @parameterized.named_parameters(test_parameters)
     def test_application_pooling(self, app, last_dim, _, image_data_format):
-        if app == nasnet.NASNetMobile and backend.backend() == "torch":
-            self.skipTest(
-                "NASNetMobile pretrained incorrect with torch backend."
-            )
         self.skip_if_invalid_image_data_format_for_model(app, image_data_format)
         backend.set_image_data_format(image_data_format)
 
@@ -282,11 +262,6 @@ class ApplicationsTest(testing.TestCase):
 
     @parameterized.named_parameters(test_parameters)
     def test_application_classifier_activation(self, app, *_):
-        if app == nasnet.NASNetMobile and backend.backend() == "torch":
-            self.skipTest(
-                "NASNetMobile pretrained incorrect with torch backend."
-            )
-
         model = app(
             weights=None, include_top=True, classifier_activation="softmax"
         )

--- a/keras/src/applications/nasnet.py
+++ b/keras/src/applications/nasnet.py
@@ -381,12 +381,6 @@ def NASNetMobile(
     Returns:
         A Keras model instance.
     """
-    if backend.backend() == "torch":
-        raise ValueError(
-            "NASNetMobile is not available with the torch backend "
-            "at this time due to an outstanding bug. "
-            "If interested, please open a PR."
-        )
     if not include_top and input_shape is None:
         input_shape = (224, 224, 3)
     return NASNet(


### PR DESCRIPTION
## Description
Closes #18451.

This removes the stale Torch backend guard around `NASNetMobile(weights="imagenet")` and re-enables the NASNetMobile application tests for Torch. The guard was added for incorrect pretrained inference, but the Torch backend now has adaptive/global pooling support across backends via #21820, which covers the pooling path NASNetMobile relies on.

This PR intentionally contains no new NASNet logic; it only removes the stale skip/guard so the existing application coverage runs on Torch again.

Checks run:
- `python -m ruff format --check keras/src/applications/applications_test.py keras/src/applications/nasnet.py`
- `python -m ruff check keras/src/applications/applications_test.py keras/src/applications/nasnet.py`
- `$env:KERAS_BACKEND='torch'; python -m pytest keras/src/applications/applications_test.py::ApplicationsTest::test_application_base_NASNetMobile_channels_last` (blocked locally because `tensorflow` is not installed and the test imports it during execution)
- Standalone Torch NASNetMobile ImageNet inference check returned `['African_elephant', 'tusker', 'Indian_elephant']`
- `git diff --check HEAD~1..HEAD`

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.