### PR TITLE
Fix graph-mode evaluate() metric mismatch for fixed-batch tf.data datasets

### DIFF
--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -231,8 +231,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         def function(iterator):
             if isinstance(
-                iterator,
-                (tf.data.Iterator, tf.distribute.DistributedIterator),
+                iterator, (tf.data.Iterator, tf.distribute.DistributedIterator)
             ):
                 if self.steps_per_execution == 1:
                     next_optional_inputs = iterator.get_next_as_optional()

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -149,15 +149,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         @tf.autograph.experimental.do_not_convert
         def multi_step_on_iterator(iterator):
-            if self.steps_per_execution == 1:
-                return tf.experimental.Optional.from_value(
-                    one_step_on_data(iterator.get_next())
-                )
-
-            # Delay initialization of the Optional element_spec until the first
-            # successful iteration. This avoids additional tracing when using
-            # datasets with fully-defined batch dimensions while preserving the
-            # correct output specification for subsequent iterations.
+            # the spec is set lazily during the tracing of `tf.while_loop`
             empty_outputs = tf.experimental.Optional.empty(None)
 
             def cond(execution_step, optional_outputs, next_optional_inputs):
@@ -242,11 +234,6 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 iterator,
                 (tf.data.Iterator, tf.distribute.DistributedIterator),
             ):
-                # Fast path for the common case.
-                # Avoid routing single-step execution
-                # through the multi-step iterator helper,
-                # which is only needed when
-                # steps_per_execution > 1.
                 if self.steps_per_execution == 1:
                     next_optional_inputs = iterator.get_next_as_optional()
                     if not next_optional_inputs.has_value():
@@ -257,7 +244,6 @@ class TensorFlowTrainer(base_trainer.Trainer):
                 if not opt_outputs.has_value():
                     raise StopIteration
                 return opt_outputs.get_value()
-
             else:
                 for _, data in zip(
                     range(self.steps_per_execution),

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -231,7 +231,8 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         def function(iterator):
             if isinstance(
-                iterator,(tf.data.Iterator, tf.distribute.DistributedIterator),
+                iterator,
+                (tf.data.Iterator, tf.distribute.DistributedIterator),
             ):
                 if self.steps_per_execution == 1:
                     next_optional_inputs = iterator.get_next_as_optional()

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -154,7 +154,10 @@ class TensorFlowTrainer(base_trainer.Trainer):
                     one_step_on_data(iterator.get_next())
                 )
 
-            # the spec is set lazily during the tracing of `tf.while_loop`
+            # Delay initialization of the Optional element_spec until the first
+            # successful iteration. This avoids additional tracing when using
+            # datasets with fully-defined batch dimensions while preserving the
+            # correct output specification for subsequent iterations.
             empty_outputs = tf.experimental.Optional.empty(None)
 
             def cond(execution_step, optional_outputs, next_optional_inputs):
@@ -236,15 +239,29 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         def function(iterator):
             if isinstance(
-                iterator, (tf.data.Iterator, tf.distribute.DistributedIterator)
+                iterator,
+                (tf.data.Iterator, tf.distribute.DistributedIterator),
             ):
+                # Fast path for the common case.
+                # Avoid routing single-step execution
+                # through the multi-step iterator helper,
+                # which is only needed when
+                # steps_per_execution > 1.
+                if self.steps_per_execution == 1:
+                    next_optional_inputs = iterator.get_next_as_optional()
+                    if not next_optional_inputs.has_value():
+                        raise StopIteration
+                    return one_step_on_data(next_optional_inputs.get_value())
+
                 opt_outputs = multi_step_on_iterator(iterator)
                 if not opt_outputs.has_value():
                     raise StopIteration
                 return opt_outputs.get_value()
+
             else:
-                for step, data in zip(
-                    range(self.steps_per_execution), iterator
+                for _, data in zip(
+                    range(self.steps_per_execution),
+                    iterator,
                 ):
                     outputs = one_step_on_data(data)
                 return outputs

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -231,8 +231,7 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         def function(iterator):
             if isinstance(
-                iterator,
-                (tf.data.Iterator, tf.distribute.DistributedIterator),
+                iterator,(tf.data.Iterator, tf.distribute.DistributedIterator),
             ):
                 if self.steps_per_execution == 1:
                     next_optional_inputs = iterator.get_next_as_optional()

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 import jax
 import numpy as np
 import pytest
+import tensorflow as tf
 from absl.testing import parameterized
 
 import keras
@@ -1764,6 +1765,66 @@ class TestTrainer(testing.TestCase):
         loss1 = model.evaluate(x, y, batch_size=80)
         loss2 = model.evaluate(x, y, batch_size=100)
         self.assertAllClose(loss1, loss2)
+
+    def test_evaluate_fixed_batch_dim_graph_matches_eager(self):
+        batch_size = 4
+        num_samples = 32
+
+        x_data = np.random.randn(num_samples, 4).astype(np.float32)
+        y_data = np.random.randn(num_samples, 1).astype(np.float32)
+
+        def make_dataset():
+            def gen():
+                for i in range(0, num_samples, batch_size):
+                    yield (
+                        x_data[i : i + batch_size],
+                        y_data[i : i + batch_size],
+                    )
+
+            return tf.data.Dataset.from_generator(
+                gen,
+                output_signature=(
+                    tf.TensorSpec((batch_size, 4), tf.float32),
+                    tf.TensorSpec((batch_size, 1), tf.float32),
+                ),
+            )
+
+        # Graph mode
+        model_graph = ExampleModel(units=1)
+        model_graph.compile(
+            loss="mse",
+            metrics=["mae"],
+            run_eagerly=False,
+        )
+
+        graph_result = model_graph.evaluate(
+            make_dataset(),
+            verbose=0,
+        )
+
+        # Eager mode
+        model_eager = ExampleModel(units=1)
+        model_eager.compile(
+            loss="mse",
+            metrics=["mae"],
+            run_eagerly=True,
+        )
+
+        eager_result = model_eager.evaluate(
+            make_dataset(),
+            verbose=0,
+        )
+
+        self.assertAllClose(
+            graph_result["mae"]
+            if isinstance(graph_result, dict)
+            else graph_result,
+            eager_result["mae"]
+            if isinstance(eager_result, dict)
+            else eager_result,
+            atol=1e-5,
+            rtol=1e-5,
+        )
 
     @pytest.mark.requires_trainable_backend
     def test_adds_loss_scaling_optimizer(self):

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -1792,37 +1792,21 @@ class TestTrainer(testing.TestCase):
 
         # Graph mode
         model_graph = ExampleModel(units=1)
-        model_graph.compile(
-            loss="mse",
-            metrics=["mae"],
-            run_eagerly=False,
-        )
-
+        model_graph.compile(loss="mse", metrics=["mae"], run_eagerly=False)
         graph_result = model_graph.evaluate(
-            make_dataset(),
-            verbose=0,
+            make_dataset(), verbose=0, return_dict=True
         )
 
         # Eager mode
         model_eager = ExampleModel(units=1)
-        model_eager.compile(
-            loss="mse",
-            metrics=["mae"],
-            run_eagerly=True,
-        )
-
+        model_eager.compile(loss="mse", metrics=["mae"], run_eagerly=True)
         eager_result = model_eager.evaluate(
-            make_dataset(),
-            verbose=0,
+            make_dataset(), verbose=0, return_dict=True
         )
 
         self.assertAllClose(
-            graph_result["mae"]
-            if isinstance(graph_result, dict)
-            else graph_result,
-            eager_result["mae"]
-            if isinstance(eager_result, dict)
-            else eager_result,
+            graph_result["mae"],
+            eager_result["mae"],
             atol=1e-5,
             rtol=1e-5,
         )

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -3,7 +3,6 @@ from unittest import mock
 import jax
 import numpy as np
 import pytest
-import tensorflow as tf
 from absl.testing import parameterized
 
 import keras
@@ -1767,6 +1766,8 @@ class TestTrainer(testing.TestCase):
         self.assertAllClose(loss1, loss2)
 
     def test_evaluate_fixed_batch_dim_graph_matches_eager(self):
+        import tensorflow as tf
+
         batch_size = 4
         num_samples = 32
 


### PR DESCRIPTION
This PR fixes incorrect metric values in `model.evaluate()` when running in graph mode (`run_eagerly=False`) on datasets created using` tf.data.Dataset.from_generato`r with a fixed batch size in the output_signature.

In these cases, stateful metrics (like MeanAbsoluteError) can return lower (diluted) values compared to eager mode.
This problem only happens in graph mode and does not appear when:
 - run_eagerly=True, or
 - using datasets with dynamic batch sizes (None), such as from_tensor_slices().batch(...)
 
The issue happens in the graph-mode evaluation path. During evaluation, TensorFlow uses a graph-based execution flow (tf.function) and loop logic to process the dataset.

For datasets with a fixed batch size, this graph execution can interact incorrectly with the iterator logic during tracing. As a result, metrics may get updated one extra time during the execution process.

This leads to:
 - higher metric counts than expected
 - lower (diluted) final metric values
 - mismatch between graph mode and eager mode results

Reference PR - [stinodego#1](https://github.com/stinodego/keras/pull/1)

Fixes: [#23084](https://github.com/keras-team/keras/issues/23084)

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
