### PR TITLE
Support strides>1 with dilation_rate>1 in TensorFlow backend conv

### DIFF
--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -807,6 +807,26 @@ def conv(
     data_format=None,
     dilation_rate=1,
 ):
+    data_format = backend.standardize_data_format(data_format)
+    inputs = convert_to_tensor(inputs)
+    kernel = convert_to_tensor(kernel)
+    num_spatial_dims = len(inputs.shape) - 2
+    if isinstance(strides, int):
+        strides = (strides,) * num_spatial_dims
+    else:
+        strides = tuple(strides)
+    if isinstance(dilation_rate, int):
+        dilation_rate = (dilation_rate,) * num_spatial_dims
+    else:
+        dilation_rate = tuple(dilation_rate)
+    # `tf.nn.convolution` rejects `strides > 1` together with
+    # `dilation_rate > 1`. Decompose into a dilated stride-1 conv plus
+    # subsampling, matching the JAX/Torch backends and the symbolic path.
+    if _needs_depthwise_stride_dilation_decomposition(strides, dilation_rate):
+        return _conv_stride_dilation_decomposition(
+            inputs, kernel, strides, padding, data_format, dilation_rate
+        )
+
     def _conv():
         tf_data_format = _convert_data_format(data_format, len(inputs.shape))
         result = tf.nn.convolution(
@@ -842,7 +862,6 @@ def conv(
     # Channels first "NCDHW" (3d convolutions) are broken on CPU without XLA.
     needs_xla = data_format == "channels_first" and len(inputs.shape) == 5
     # grouped convolutions are broken on CPU without XLA.
-    data_format = backend.standardize_data_format(data_format)
     if data_format == "channels_last":
         channels = inputs.shape[-1]
     else:
@@ -949,6 +968,49 @@ def _depthwise_conv_stride_dilation_decomposition(
 
     if num_spatial_dims == 1:
         outputs = tf.squeeze(outputs, [1])
+
+    if data_format == "channels_first":
+        outputs = _transpose_spatial_outputs(outputs)
+
+    return outputs
+
+
+def _conv_stride_dilation_decomposition(
+    inputs, kernel, strides, padding, data_format, dilation_rate
+):
+    # Compute a regular conv with both stride > 1 and dilation > 1 by running
+    # the dilated conv at stride 1 (which `tf.nn.convolution` supports) and
+    # subsampling the result. Always computed in `channels_last` layout.
+    num_spatial_dims = len(inputs.shape) - 2
+    padding = padding.upper()
+
+    if data_format == "channels_first":
+        inputs = _transpose_spatial_inputs(inputs)
+
+    kernel_size = tuple(int(i) for i in kernel.shape[:num_spatial_dims])
+
+    if padding == "SAME":
+        inputs = _pad_same_spatial_channels_last(
+            inputs, kernel_size, strides, dilation_rate
+        )
+    elif padding != "VALID":
+        raise ValueError(
+            f"`padding` must be 'valid' or 'same'. Received: padding={padding}"
+        )
+
+    outputs = tf.nn.convolution(
+        inputs,
+        kernel,
+        strides=1,
+        padding="VALID",
+        data_format=_convert_data_format("channels_last", num_spatial_dims + 2),
+        dilations=dilation_rate,
+    )
+
+    slices = [slice(None)]
+    slices.extend(slice(None, None, s) for s in strides)
+    slices.append(slice(None))
+    outputs = outputs[tuple(slices)]
 
     if data_format == "channels_first":
         outputs = _transpose_spatial_outputs(outputs)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -998,14 +998,24 @@ def _conv_stride_dilation_decomposition(
             f"`padding` must be 'valid' or 'same'. Received: padding={padding}"
         )
 
-    outputs = tf.nn.convolution(
-        inputs,
-        kernel,
-        strides=1,
-        padding="VALID",
-        data_format=_convert_data_format("channels_last", num_spatial_dims + 2),
-        dilations=dilation_rate,
-    )
+    def _run_conv():
+        return tf.nn.convolution(
+            inputs,
+            kernel,
+            strides=1,
+            padding="VALID",
+            data_format=_convert_data_format(
+                "channels_last", num_spatial_dims + 2
+            ),
+            dilations=dilation_rate,
+        )
+
+    # Grouped convolutions are broken on CPU without XLA (see `conv`).
+    # `inputs` is already `channels_last` at this point.
+    if inputs.shape[-1] != kernel.shape[-2]:
+        outputs = tf.function(_run_conv, jit_compile=True)()
+    else:
+        outputs = _run_conv()
 
     slices = [slice(None)]
     slices.extend(slice(None, None, s) for s in strides)

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -1679,13 +1679,6 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             strides_h, strides_w = patch_h, patch_w
         else:
             strides_h, strides_w = strides[0], strides[1]
-        if (
-            backend.backend() == "tensorflow"
-            and strides_h > 1
-            or strides_w > 1
-            and dilation_rate > 1
-        ):
-            pytest.skip("dilation_rate>1 with strides>1 not supported with TF")
 
         # Test channels_last
         image = np.random.uniform(size=(1, 20, 20, 3)).astype("float32")
@@ -3072,45 +3065,35 @@ class ExtractPatches3DTest(testing.TestCase):
         else:
             volume = np.random.rand(1, 2, 64, 64, 64).astype(dtype)
 
-        if backend.backend() == "tensorflow":
-            # TensorFlow backend does not support dilation > 1 and strides > 1
-            with self.assertRaises(ValueError):
-                kimage.extract_patches_3d(
-                    volume,
-                    size=(3, 3, 3),
-                    strides=(8, 8, 8),
-                    dilation_rate=(2, 2, 2),
-                    data_format=data_format,
-                )
-        else:
-            # Runs without error; check shape
-            patches = kimage.extract_patches_3d(
-                volume,
-                size=(3, 3, 3),
-                strides=(8, 8, 8),
-                dilation_rate=(2, 2, 2),
-                data_format=data_format,
+        # All backends (including TensorFlow) support dilation > 1 combined
+        # with strides > 1.
+        patches = kimage.extract_patches_3d(
+            volume,
+            size=(3, 3, 3),
+            strides=(8, 8, 8),
+            dilation_rate=(2, 2, 2),
+            data_format=data_format,
+        )
+        # eff_p = 3 + (3 - 1) * (2 - 1) = 5
+        # out = (64 - 5) // 8 + 1 = 8
+        expected_patches = 8
+        if data_format == "channels_last":
+            expected_shape = (
+                1,
+                expected_patches,
+                expected_patches,
+                expected_patches,
+                54,  # 2*3*3*3
             )
-            # eff_p = 3 + (3 - 1) * (2 - 1) = 5
-            # out = (64 - 5) // 8 + 1 = 8
-            expected_patches = 8
-            if data_format == "channels_last":
-                expected_shape = (
-                    1,
-                    expected_patches,
-                    expected_patches,
-                    expected_patches,
-                    54,  # 2*3*3*3
-                )
-            else:
-                expected_shape = (
-                    1,
-                    54,  # 2*3*3*3
-                    expected_patches,
-                    expected_patches,
-                    expected_patches,
-                )
-            self.assertEqual(patches.shape, expected_shape)
+        else:
+            expected_shape = (
+                1,
+                54,  # 2*3*3*3
+                expected_patches,
+                expected_patches,
+                expected_patches,
+            )
+        self.assertEqual(patches.shape, expected_shape)
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_extract_patches_3d_overlapping(self, dtype):

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1778,9 +1778,6 @@ class NNOpsCorrectnessTest(testing.TestCase):
         dilation_rate=(1, 2),
     )
     def test_conv_1d(self, strides, padding, dilation_rate):
-        if strides > 1 and dilation_rate > 1:
-            pytest.skip("Unsupported configuration")
-
         if backend.config.image_data_format() == "channels_last":
             input_shape = (2, 20, 3)
         else:
@@ -1831,13 +1828,6 @@ class NNOpsCorrectnessTest(testing.TestCase):
 
     @parameterized.product(strides=(1, 2), dilation_rate=(1, (2, 1)))
     def test_conv_2d_group_2(self, strides, dilation_rate):
-        if (
-            backend.backend() == "tensorflow"
-            and strides == 2
-            and dilation_rate == (2, 1)
-        ):
-            # This case is not supported by the TF backend.
-            return
         if backend.config.image_data_format() == "channels_last":
             input_shape = (2, 10, 10, 4)
         else:


### PR DESCRIPTION
## Description

Fixes #23028.

On the TensorFlow backend, `keras.ops.conv` raised when `strides > 1` and
`dilation_rate > 1` were combined, while the JAX and Torch backends compute it
and the symbolic shape path is correct:

```python
import numpy as np, keras
from keras import ops
x = np.zeros((1, 8, 8, 3), "float32")
k = np.zeros((3, 3, 3, 4), "float32")
ops.conv(ops.convert_to_tensor(x), k, strides=2, padding="valid", dilation_rate=2)
# ValueError: `strides > 1` not supported in conjunction with `dilation_rate > 1`
```

### Root cause

`tf.nn.convolution` rejects `strides > 1` together with `dilation_rate > 1` at
trace time (XLA does not lift the restriction). This is the regular-conv
sibling of the depthwise/separable case already fixed in #23027 / #22515.

### Fix

Apply the same decomposition used for depthwise/separable convs: when both
`strides > 1` and `dilation_rate > 1` are requested, run the dilated conv at
stride 1 (which TF supports) and then subsample the result, emulating
`padding="same"` with explicit padding via the existing
`_pad_same_spatial_channels_last` helper. The new
`_conv_stride_dilation_decomposition` handles 1D/2D/3D, `channels_first` /
`channels_last`, grouped convolutions, and asymmetric strides/dilations.

Verified the eager output matches the NumPy backend (and the symbolic shape)
across all of those cases.

### Tests

- `test_conv_1d` and `test_conv_2d_group_2` previously skipped this exact
  configuration on TensorFlow; both skips are removed so they now cover it.
- `extract_patches` / `extract_patches_3d` route through `conv`, so their tests
  previously documented the TF limitation (a skip in `test_extract_patches` and
  an `assertRaises(ValueError)` branch in `test_extract_patches_3d_with_dilation`).
  Both are updated to exercise the now-supported path on TensorFlow.

All conv ops, Conv-layer, and extract_patches tests pass on the TensorFlow and
NumPy backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.