### PR TITLE
perf(ops): inject traceback argument info on error only, not on every call

### DIFF
--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -1076,8 +1076,9 @@ class Cond(Operation):
                 return self.call(*args, **kwargs)
 
         if traceback_utils.is_traceback_filtering_enabled():
-            # Call directly; inject argument info only on exception.
-            # Avoids creating a closure wrapper on every call (hot path).
+            # Call call_fn directly; only inject argument info if it raises.
+            # Avoids wrapping it in an error-handling closure on every call
+            # (hot path).
             try:
                 return call_fn(*args, **kwargs)
             except Exception as e:

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -1084,7 +1084,7 @@ class Cond(Operation):
                 if not getattr(e, "_keras_call_info_injected", False):
                     augmented = traceback_utils.inject_argument_info_in_error(
                         e,
-                        call_fn,
+                        self.call,
                         args,
                         kwargs,
                         object_name=(f"{self.__class__.__name__}.call()"),

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -10,7 +10,6 @@ from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import slice_along_axis
 from keras.src.ops.operation import Operation
 from keras.src.saving import serialization_lib
-from keras.src.utils import traceback_utils
 
 
 class Map(Operation):
@@ -1067,38 +1066,6 @@ def convert_to_numpy(x):
 
 
 class Cond(Operation):
-    @traceback_utils.filter_traceback
-    def __call__(self, *args, **kwargs):
-        def call_fn(*args, **kwargs):
-            if any_symbolic_tensors(args, kwargs):
-                return self.symbolic_call(*args, **kwargs)
-            else:
-                return self.call(*args, **kwargs)
-
-        if traceback_utils.is_traceback_filtering_enabled():
-            # Call call_fn directly; only inject argument info if it raises.
-            # Avoids wrapping it in an error-handling closure on every call
-            # (hot path).
-            try:
-                return call_fn(*args, **kwargs)
-            except Exception as e:
-                if not getattr(e, "_keras_call_info_injected", False):
-                    augmented = traceback_utils.inject_argument_info_in_error(
-                        e,
-                        self.call,
-                        args,
-                        kwargs,
-                        object_name=(f"{self.__class__.__name__}.call()"),
-                    )
-                    if augmented is not None:
-                        raise augmented.with_traceback(
-                            e.__traceback__
-                        ) from None
-                raise
-
-        # Plain flow.
-        return call_fn(*args, **kwargs)
-
     def call(self, pred, true_fn, false_fn):
         return backend.core.cond(pred, true_fn, false_fn)
 

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -1076,12 +1076,24 @@ class Cond(Operation):
                 return self.call(*args, **kwargs)
 
         if traceback_utils.is_traceback_filtering_enabled():
-            # Wrap self.call to provide helpful info in case of exception
-            call_fn = traceback_utils.inject_argument_info_in_traceback(
-                call_fn,
-                object_name=(f"{self.__class__.__name__}.call()"),
-            )
-            return call_fn(*args, **kwargs)
+            # Call directly; inject argument info only on exception.
+            # Avoids creating a closure wrapper on every call (hot path).
+            try:
+                return call_fn(*args, **kwargs)
+            except Exception as e:
+                if not getattr(e, "_keras_call_info_injected", False):
+                    augmented = traceback_utils.inject_argument_info_in_error(
+                        e,
+                        call_fn,
+                        args,
+                        kwargs,
+                        object_name=(f"{self.__class__.__name__}.call()"),
+                    )
+                    if augmented is not None:
+                        raise augmented.with_traceback(
+                            e.__traceback__
+                        ) from None
+                raise
 
         # Plain flow.
         return call_fn(*args, **kwargs)

--- a/keras/src/ops/core.py
+++ b/keras/src/ops/core.py
@@ -10,6 +10,7 @@ from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import slice_along_axis
 from keras.src.ops.operation import Operation
 from keras.src.saving import serialization_lib
+from keras.src.utils import traceback_utils
 
 
 class Map(Operation):
@@ -1066,6 +1067,35 @@ def convert_to_numpy(x):
 
 
 class Cond(Operation):
+    @traceback_utils.filter_traceback
+    def __call__(self, *args, **kwargs):
+        # `Operation.__call__` routes through `rematerialized_call` whenever a
+        # `RematScope` is active, but `call` receives Python callables rather
+        # than tensors and rematerialization cannot trace those, so `Cond`
+        # dispatches on its own and stays out of that path.
+        def call_fn(*args, **kwargs):
+            if any_symbolic_tensors(args, kwargs):
+                return self.symbolic_call(*args, **kwargs)
+            else:
+                return self.call(*args, **kwargs)
+
+        if traceback_utils.is_traceback_filtering_enabled():
+            try:
+                return call_fn(*args, **kwargs)
+            except Exception as e:
+                if not getattr(e, "_keras_call_info_injected", False):
+                    raise traceback_utils.inject_argument_info_in_error(
+                        e,
+                        self.call,
+                        args,
+                        kwargs,
+                        object_name=(f"{self.__class__.__name__}.call()"),
+                    ) from None
+                raise
+
+        # Plain flow.
+        return call_fn(*args, **kwargs)
+
     def call(self, pred, true_fn, false_fn):
         return backend.core.cond(pred, true_fn, false_fn)
 

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -19,6 +19,7 @@ from keras.src.layers.core import input_layer
 from keras.src.ops import core
 from keras.src.saving import object_registration
 from keras.src.testing.test_utils import named_product
+from keras.src.utils import traceback_utils
 
 
 class CoreOpsDynamicShapeTest(testing.TestCase):
@@ -1780,6 +1781,33 @@ class CoreOpsBehaviorTests(testing.TestCase):
         mock_spec1 = KerasTensor(shape=(2, 2), dtype="float32")
         mock_spec2 = KerasTensor(shape=(2, 2), dtype="float32")
         self.assertTrue(core.Cond()._check_output_spec(mock_spec1, mock_spec2))
+
+    def test_cond_error_message_uses_real_call_signature(self):
+        """Regression test: exceptions raised inside `Cond.__call__` should
+        be augmented using `Cond.call`'s real parameter names (`pred`,
+        `true_fn`, `false_fn`), not the generic `args`/`kwargs` of the
+        internal `call_fn` closure used to dispatch between eager and
+        symbolic execution.
+        """
+        was_enabled = traceback_utils.is_traceback_filtering_enabled()
+        traceback_utils.enable_traceback_filtering()
+        try:
+
+            def raising_true_fn():
+                raise ValueError("boom")
+
+            with self.assertRaises(ValueError) as ctx:
+                core.cond(True, raising_true_fn, lambda: 0)
+            msg = str(ctx.exception)
+            self.assertIn("Cond.call()", msg)
+            self.assertIn("pred=", msg)
+            self.assertIn("true_fn=", msg)
+            self.assertIn("false_fn=", msg)
+            self.assertNotIn("args=", msg)
+            self.assertNotIn("kwargs=", msg)
+        finally:
+            if not was_enabled:
+                traceback_utils.disable_traceback_filtering()
 
     @pytest.mark.requires_trainable_backend
     def test_cond_raw_bool_compile(self):

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -15,6 +15,7 @@ from keras.src import testing
 from keras.src import tree
 from keras.src.backend.common import dtypes
 from keras.src.backend.common.keras_tensor import KerasTensor
+from keras.src.backend.common.remat import RematScope
 from keras.src.layers.core import input_layer
 from keras.src.ops import core
 from keras.src.saving import object_registration
@@ -1808,6 +1809,21 @@ class CoreOpsBehaviorTests(testing.TestCase):
         finally:
             if not was_enabled:
                 traceback_utils.disable_traceback_filtering()
+
+    @parameterized.named_parameters(
+        ("full", "full", {}),
+        ("larger_than", "larger_than", {"output_size_threshold": 1}),
+    )
+    def test_cond_is_not_rematerialized(self, mode, kwargs):
+        """`Cond.call` takes Python callables, which rematerialization cannot
+        trace, so `Cond` overrides `__call__` to stay out of that path. An
+        active `RematScope` must therefore leave `cond` working.
+        """
+        pred = ops.convert_to_tensor(True)
+        x = ops.convert_to_tensor([1.0, 2.0, 3.0])
+        with RematScope(mode=mode, **kwargs):
+            result = ops.cond(pred, lambda: x + 1.0, lambda: x - 1.0)
+        self.assertAllClose(result, [2.0, 3.0, 4.0])
 
     @pytest.mark.requires_trainable_backend
     def test_cond_raw_bool_compile(self):

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -36,7 +36,6 @@ class Operation(KerasSaveable):
     @traceback_utils.filter_traceback
     def __call__(self, *args, **kwargs):
         if traceback_utils.is_traceback_filtering_enabled():
-            # Wrap self.call to provide helpful info in case of exception
             if any_symbolic_tensors(args, kwargs):
                 call_fn = self.symbolic_call
             else:
@@ -56,8 +55,9 @@ class Operation(KerasSaveable):
                         call_fn = self.quantized_call
                     else:
                         call_fn = self.call
-            # Call directly; inject argument info only on exception.
-            # Avoids creating a closure wrapper on every call (hot path).
+            # Call call_fn directly; only inject argument info if it raises.
+            # Avoids wrapping it in an error-handling closure on every call
+            # (hot path).
             try:
                 return call_fn(*args, **kwargs)
             except Exception as e:

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -56,11 +56,24 @@ class Operation(KerasSaveable):
                         call_fn = self.quantized_call
                     else:
                         call_fn = self.call
-            call_fn = traceback_utils.inject_argument_info_in_traceback(
-                call_fn,
-                object_name=(f"{self.__class__.__name__}.call()"),
-            )
-            return call_fn(*args, **kwargs)
+            # Call directly; inject argument info only on exception.
+            # Avoids creating a closure wrapper on every call (hot path).
+            try:
+                return call_fn(*args, **kwargs)
+            except Exception as e:
+                if not getattr(e, "_keras_call_info_injected", False):
+                    augmented = traceback_utils.inject_argument_info_in_error(
+                        e,
+                        call_fn,
+                        args,
+                        kwargs,
+                        object_name=(f"{self.__class__.__name__}.call()"),
+                    )
+                    if augmented is not None:
+                        raise augmented.with_traceback(
+                            e.__traceback__
+                        ) from None
+                raise
 
         # Plain flow.
         if any_symbolic_tensors(args, kwargs):

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -62,17 +62,13 @@ class Operation(KerasSaveable):
                 return call_fn(*args, **kwargs)
             except Exception as e:
                 if not getattr(e, "_keras_call_info_injected", False):
-                    augmented = traceback_utils.inject_argument_info_in_error(
+                    raise traceback_utils.inject_argument_info_in_error(
                         e,
                         self.call,
                         args,
                         kwargs,
                         object_name=(f"{self.__class__.__name__}.call()"),
-                    )
-                    if augmented is not None:
-                        raise augmented.with_traceback(
-                            e.__traceback__
-                        ) from None
+                    ) from None
                 raise
 
         # Plain flow.

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -64,7 +64,7 @@ class Operation(KerasSaveable):
                 if not getattr(e, "_keras_call_info_injected", False):
                     augmented = traceback_utils.inject_argument_info_in_error(
                         e,
-                        call_fn,
+                        self.call,
                         args,
                         kwargs,
                         object_name=(f"{self.__class__.__name__}.call()"),

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -55,9 +55,6 @@ class Operation(KerasSaveable):
                         call_fn = self.quantized_call
                     else:
                         call_fn = self.call
-            # Call call_fn directly; only inject argument info if it raises.
-            # Avoids wrapping it in an error-handling closure on every call
-            # (hot path).
             try:
                 return call_fn(*args, **kwargs)
             except Exception as e:

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -130,11 +130,7 @@ def _format_raw_arguments_fallback(args, kwargs):
     """Best-effort `args=..., kwargs=...` dump for the error-message context.
 
     Used only when `inject_argument_info_in_error` cannot bind `args` and
-    `kwargs` to the callee's signature (e.g. a caller/callee arity mismatch,
-    or a third-party `call` override with a divergent signature), so that
-    some argument context is still surfaced instead of being silently
-    dropped. This only runs on the (already-slow) error path, so it adds no
-    hot-path cost.
+    `kwargs` to the callee's signature.
 
     Returns:
         A single string formatted like the normal per-parameter listing, or
@@ -207,10 +203,9 @@ def _build_augmented_exception(
 def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
     """Add call argument info to an already-caught exception.
 
-    Unlike the old `inject_argument_info_in_traceback`, this does not wrap
-    `fn`. It is meant to be called from an `except` block, after `fn` has
-    already raised, so that argument formatting only happens on the error
-    path and adds no overhead to the common, no-exception case.
+    Meant to be called from an `except` block, after `fn` has already raised,
+    so that argument formatting only happens on the error path and adds no
+    overhead to the common, no-exception case.
 
     Args:
         e: The exception that was raised by calling `fn(*args, **kwargs)`.
@@ -223,11 +218,9 @@ def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
             `fn.__name__`.
 
     Returns:
-        A new exception of the same type (or `RuntimeError` as a fallback)
-        with argument info added to its message. If `args`/`kwargs` cannot
-        be bound to `fn`'s signature, falls back to a raw `args=`/`kwargs=`
-        dump instead of the usual per-parameter listing. Returns `None` if
-        no argument info could be recovered at all.
+        An exception with argument info added to its message, or the
+        original exception unmodified if no argument info could be recovered.
+        The returned exception has its traceback set to `e.__traceback__`.
     """
     if backend.backend() == "tensorflow":
         from tensorflow import errors as tf_errors
@@ -240,36 +233,36 @@ def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
     except (ValueError, TypeError):
         arguments_context = _format_raw_arguments_fallback(args, kwargs)
         if arguments_context is None:
-            return None
-        return _build_augmented_exception(
-            e, fn, arguments_context, tf_errors, object_name
-        )
+            return e
+    else:
+        arguments_context = []
+        for arg in signature.parameters.values():
+            if arg.name in bound_signature.arguments:
+                try:
+                    value = tree.map_structure(
+                        format_argument_value,
+                        bound_signature.arguments[arg.name],
+                    )
+                except Exception:
+                    # Formatting this specific bound value failed. Retrying
+                    # via the raw args/kwargs fallback would call the same
+                    # `format_argument_value` on the same value and fail the
+                    # same way, so there is nothing to recover here.
+                    return e
+            else:
+                value = arg.default
+            arguments_context.append(f"  • {arg.name}={value}")
 
-    arguments_context = []
-    for arg in signature.parameters.values():
-        if arg.name in bound_signature.arguments:
-            try:
-                value = tree.map_structure(
-                    format_argument_value,
-                    bound_signature.arguments[arg.name],
-                )
-            except Exception:
-                # Formatting this specific bound value failed. Retrying via
-                # the raw args/kwargs fallback would call the same
-                # `format_argument_value` on the same value and fail the
-                # same way, so there is nothing to recover here.
-                return None
-        else:
-            value = arg.default
-        arguments_context.append(f"  • {arg.name}={value}")
+        if not arguments_context:
+            return e
+        arguments_context = "\n".join(arguments_context)
 
-    if not arguments_context:
-        return None
-
-    arguments_context = "\n".join(arguments_context)
-    return _build_augmented_exception(
+    augmented = _build_augmented_exception(
         e, fn, arguments_context, tf_errors, object_name
     )
+    if augmented is None:
+        return e
+    return augmented.with_traceback(e.__traceback__)
 
 
 def format_argument_value(value):

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -188,7 +188,7 @@ def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
     try:
         new_e._keras_call_info_injected = True
     except Exception:
-        pass
+        return None
     return new_e
 
 

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -126,44 +126,56 @@ def filter_traceback(fn):
     return error_handler
 
 
-def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
-    """Add call argument info to an already-caught exception.
+def _format_raw_arguments_fallback(args, kwargs):
+    """Best-effort `args=..., kwargs=...` dump for the error-message context.
 
-    Processes the exception in-place on the error path only, avoiding
-    per-call overhead on the happy path.
+    Used only when `inject_argument_info_in_error` cannot bind `args` and
+    `kwargs` to the callee's signature (e.g. a caller/callee arity mismatch,
+    or a third-party `call` override with a divergent signature), so that
+    some argument context is still surfaced instead of being silently
+    dropped. This only runs on the (already-slow) error path, so it adds no
+    hot-path cost.
 
-    Returns the augmented exception, or ``None`` if augmentation was not
-    possible (e.g. arguments could not be bound to the signature).
+    Returns:
+        A single string formatted like the normal per-parameter listing, or
+        `None` if there was nothing to report or the raw values could not
+        be formatted either.
     """
-    if backend.backend() == "tensorflow":
-        from tensorflow import errors as tf_errors
-    else:
-        tf_errors = None
-
+    if not args and not kwargs:
+        return None
     try:
-        signature = inspect.signature(fn)
-        bound_signature = signature.bind(*args, **kwargs)
-    except (ValueError, TypeError):
+        args_repr = ", ".join(
+            tree.map_structure(format_argument_value, arg) for arg in args
+        )
+        kwargs_repr = ", ".join(
+            f"{key}={tree.map_structure(format_argument_value, value)}"
+            for key, value in kwargs.items()
+        )
+    except Exception:
         return None
+    return f"  • args=({args_repr})\n  • kwargs={{{kwargs_repr}}}"
 
-    arguments_context = []
-    for arg in signature.parameters.values():
-        if arg.name in bound_signature.arguments:
-            try:
-                value = tree.map_structure(
-                    format_argument_value,
-                    bound_signature.arguments[arg.name],
-                )
-            except Exception:
-                return None
-        else:
-            value = arg.default
-        arguments_context.append(f"  • {arg.name}={value}")
 
-    if not arguments_context:
-        return None
+def _build_augmented_exception(
+    e, fn, arguments_context, tf_errors, object_name
+):
+    """Construct the augmented exception from a pre-formatted context string.
 
-    arguments_context = "\n".join(arguments_context)
+    Args:
+        e: The original exception.
+        fn: The function that was called, used as the fallback display name.
+        arguments_context: Pre-formatted `  • name=value` listing (one entry
+            per line) to append to the message.
+        tf_errors: The `tensorflow.errors` module, or `None` if the backend
+            is not TensorFlow.
+        object_name: String, display name of the class/function being
+            called. Defaults to `fn.__name__`.
+
+    Returns:
+        A new exception of the same type (or `RuntimeError` as a fallback)
+        with argument info added to its message, or `None` if the injected
+        flag could not be set on the new exception.
+    """
     if tf_errors is not None and isinstance(e, tf_errors.OpError):
         message = e.message
     elif e.args:
@@ -190,6 +202,74 @@ def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
     except Exception:
         return None
     return new_e
+
+
+def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
+    """Add call argument info to an already-caught exception.
+
+    Unlike the old `inject_argument_info_in_traceback`, this does not wrap
+    `fn`. It is meant to be called from an `except` block, after `fn` has
+    already raised, so that argument formatting only happens on the error
+    path and adds no overhead to the common, no-exception case.
+
+    Args:
+        e: The exception that was raised by calling `fn(*args, **kwargs)`.
+        fn: The function that was called, used to recover parameter names
+            via `inspect.signature` and as the fallback display name.
+        args: Positional arguments that `fn` was called with.
+        kwargs: Keyword arguments that `fn` was called with.
+        object_name: String, display name of the class/function being
+            called, e.g. `'layer "layer_name" (LayerClass)'`. Defaults to
+            `fn.__name__`.
+
+    Returns:
+        A new exception of the same type (or `RuntimeError` as a fallback)
+        with argument info added to its message. If `args`/`kwargs` cannot
+        be bound to `fn`'s signature, falls back to a raw `args=`/`kwargs=`
+        dump instead of the usual per-parameter listing. Returns `None` if
+        no argument info could be recovered at all.
+    """
+    if backend.backend() == "tensorflow":
+        from tensorflow import errors as tf_errors
+    else:
+        tf_errors = None
+
+    try:
+        signature = inspect.signature(fn)
+        bound_signature = signature.bind(*args, **kwargs)
+    except (ValueError, TypeError):
+        arguments_context = _format_raw_arguments_fallback(args, kwargs)
+        if arguments_context is None:
+            return None
+        return _build_augmented_exception(
+            e, fn, arguments_context, tf_errors, object_name
+        )
+
+    arguments_context = []
+    for arg in signature.parameters.values():
+        if arg.name in bound_signature.arguments:
+            try:
+                value = tree.map_structure(
+                    format_argument_value,
+                    bound_signature.arguments[arg.name],
+                )
+            except Exception:
+                # Formatting this specific bound value failed. Retrying via
+                # the raw args/kwargs fallback would call the same
+                # `format_argument_value` on the same value and fail the
+                # same way, so there is nothing to recover here.
+                return None
+        else:
+            value = arg.default
+        arguments_context.append(f"  • {arg.name}={value}")
+
+    if not arguments_context:
+        return None
+
+    arguments_context = "\n".join(arguments_context)
+    return _build_augmented_exception(
+        e, fn, arguments_context, tf_errors, object_name
+    )
 
 
 def format_argument_value(value):

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -126,97 +126,70 @@ def filter_traceback(fn):
     return error_handler
 
 
-def inject_argument_info_in_traceback(fn, object_name=None):
-    """Add information about call argument values to an error message.
+def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
+    """Add call argument info to an already-caught exception.
 
-    Arguments:
-        fn: Function to wrap. Exceptions raised by the this function will be
-            re-raised with additional information added to the error message,
-            displaying the values of the different arguments that the function
-            was called with.
-        object_name: String, display name of the class/function being called,
-            e.g. `'layer "layer_name" (LayerClass)'`.
+    Processes the exception in-place on the error path only, avoiding
+    per-call overhead on the happy path.
 
-    Returns:
-        A wrapped version of `fn`.
+    Returns the augmented exception, or ``None`` if augmentation was not
+    possible (e.g. arguments could not be bound to the signature).
     """
     if backend.backend() == "tensorflow":
         from tensorflow import errors as tf_errors
     else:
         tf_errors = None
 
-    @wraps(fn)
-    def error_handler(*args, **kwargs):
-        if not is_traceback_filtering_enabled():
-            return fn(*args, **kwargs)
+    try:
+        signature = inspect.signature(fn)
+        bound_signature = signature.bind(*args, **kwargs)
+    except (ValueError, TypeError):
+        return None
 
-        signature = None
-        bound_signature = None
-        try:
-            return fn(*args, **kwargs)
-        except Exception as e:
-            if hasattr(e, "_keras_call_info_injected"):
-                # Only inject info for the innermost failing call
-                raise e
-            signature = inspect.signature(fn)
+    arguments_context = []
+    for arg in signature.parameters.values():
+        if arg.name in bound_signature.arguments:
             try:
-                # The first argument is `self`, so filter it out
-                bound_signature = signature.bind(*args, **kwargs)
-            except TypeError:
-                # Likely unbindable arguments
-                raise e
-
-            # Add argument context
-            arguments_context = []
-            for arg in list(signature.parameters.values()):
-                if arg.name in bound_signature.arguments:
-                    value = tree.map_structure(
-                        format_argument_value,
-                        bound_signature.arguments[arg.name],
-                    )
-                else:
-                    value = arg.default
-                arguments_context.append(f"  • {arg.name}={value}")
-            if arguments_context:
-                arguments_context = "\n".join(arguments_context)
-                # Get original error message and append information to it.
-                if tf_errors is not None and isinstance(e, tf_errors.OpError):
-                    message = e.message
-                elif e.args:
-                    # Canonically, the 1st argument in an exception is the error
-                    # message. This works for all built-in Python exceptions.
-                    message = e.args[0]
-                else:
-                    message = ""
-                display_name = f"{object_name if object_name else fn.__name__}"
-                message = (
-                    f"Exception encountered when calling {display_name}.\n\n"
-                    f"\x1b[1m{message}\x1b[0m\n\n"
-                    f"Arguments received by {display_name}:\n"
-                    f"{arguments_context}"
+                value = tree.map_structure(
+                    format_argument_value,
+                    bound_signature.arguments[arg.name],
                 )
+            except Exception:
+                return None
+        else:
+            value = arg.default
+        arguments_context.append(f"  • {arg.name}={value}")
 
-                # Reraise exception, with added context
-                if tf_errors is not None and isinstance(e, tf_errors.OpError):
-                    new_e = e.__class__(e.node_def, e.op, message, e.error_code)
-                else:
-                    try:
-                        # For standard exceptions such as ValueError, TypeError,
-                        # etc.
-                        new_e = e.__class__(message)
-                    except TypeError:
-                        # For any custom error that doesn't have a standard
-                        # signature.
-                        new_e = RuntimeError(message)
-                new_e._keras_call_info_injected = True
-            else:
-                new_e = e
-            raise new_e.with_traceback(e.__traceback__) from None
-        finally:
-            del signature
-            del bound_signature
+    if not arguments_context:
+        return None
 
-    return error_handler
+    arguments_context = "\n".join(arguments_context)
+    if tf_errors is not None and isinstance(e, tf_errors.OpError):
+        message = e.message
+    elif e.args:
+        message = e.args[0]
+    else:
+        message = ""
+    display_name = f"{object_name if object_name else fn.__name__}"
+    message = (
+        f"Exception encountered when calling {display_name}.\n\n"
+        f"\x1b[1m{message}\x1b[0m\n\n"
+        f"Arguments received by {display_name}:\n"
+        f"{arguments_context}"
+    )
+
+    if tf_errors is not None and isinstance(e, tf_errors.OpError):
+        new_e = e.__class__(e.node_def, e.op, message, e.error_code)
+    else:
+        try:
+            new_e = e.__class__(message)
+        except Exception:
+            new_e = RuntimeError(message)
+    try:
+        new_e._keras_call_info_injected = True
+    except Exception:
+        pass
+    return new_e
 
 
 def format_argument_value(value):

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -140,11 +140,14 @@ def _format_raw_arguments_fallback(args, kwargs):
     if not args and not kwargs:
         return None
     try:
+        # `map_structure` mirrors the input structure, so a nested argument
+        # comes back as a list or dict rather than a string. `str` renders
+        # those without losing the per-leaf formatting.
         args_repr = ", ".join(
-            tree.map_structure(format_argument_value, arg) for arg in args
+            str(tree.map_structure(format_argument_value, arg)) for arg in args
         )
         kwargs_repr = ", ".join(
-            f"{key}={tree.map_structure(format_argument_value, value)}"
+            f"{key}={tree.map_structure(format_argument_value, value)!s}"
             for key, value in kwargs.items()
         )
     except Exception:

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -1,0 +1,186 @@
+"""Tests for the lazy inject_argument_info_in_error path in traceback_utils."""
+
+import numpy as np
+
+from keras.src import testing
+from keras.src.ops.operation import Operation
+from keras.src.utils import traceback_utils
+
+# ---------------------------------------------------------------------------
+# Helper layer definitions
+# ---------------------------------------------------------------------------
+
+
+class FailLayer(Operation):
+    """Operation whose call() raises a standard ValueError."""
+
+    def call(self, x, y=10):
+        raise ValueError("bad input")
+
+    def compute_output_spec(self, x, y=10):
+        return x
+
+
+class CustomExcLayer(Operation):
+    """Operation whose call() raises an exception with a non-standard ctor."""
+
+    def call(self, x):
+        raise _NonStandardError("oops", extra=42)
+
+    def compute_output_spec(self, x):
+        return x
+
+
+class HappyLayer(Operation):
+    """Operation whose call() always succeeds."""
+
+    def call(self, x):
+        return x
+
+    def compute_output_spec(self, x):
+        return x
+
+
+class _NonStandardError(Exception):
+    """Exception whose constructor does not accept a single positional arg."""
+
+    def __init__(self, message, extra):
+        super().__init__(message)
+        self.extra = extra
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TracebackUtilsTest(testing.TestCase):
+    """Tests for inject_argument_info_in_error (lazy, on-error-path only)."""
+
+    def setUp(self):
+        # Ensure filtering is enabled at start of each test; restore after.
+        self._was_enabled = traceback_utils.is_traceback_filtering_enabled()
+        traceback_utils.enable_traceback_filtering()
+
+    def tearDown(self):
+        if self._was_enabled:
+            traceback_utils.enable_traceback_filtering()
+        else:
+            traceback_utils.disable_traceback_filtering()
+
+    # ------------------------------------------------------------------
+    # 1. Happy path — no exception, no overhead
+    # ------------------------------------------------------------------
+
+    def test_happy_path_no_exception(self):
+        layer = HappyLayer()
+        x = np.ones((2, 3), dtype="float32")
+        result = layer(x)
+        self.assertIs(result, x)  # returned unchanged
+
+    # ------------------------------------------------------------------
+    # 2. Standard exception: type preserved, message augmented
+    # ------------------------------------------------------------------
+
+    def test_standard_exception_type_preserved(self):
+        layer = FailLayer()
+        x = np.ones((2,), dtype="float32")
+        with self.assertRaises(ValueError) as ctx:
+            layer(x, y=5)
+        e = ctx.exception
+        self.assertIsInstance(e, ValueError)
+        self.assertIn("Exception encountered when calling", str(e))
+        self.assertIn("bad input", str(e))
+        self.assertIn("FailLayer.call()", str(e))
+        self.assertTrue(getattr(e, "_keras_call_info_injected", False))
+
+    def test_standard_exception_arguments_in_message(self):
+        layer = FailLayer()
+        x = np.ones((2,), dtype="float32")
+        with self.assertRaises(ValueError) as ctx:
+            layer(x, y=99)
+        msg = str(ctx.exception)
+        # y=99 should appear in the argument listing
+        self.assertIn("y=", msg)
+        self.assertIn("99", msg)
+
+    # ------------------------------------------------------------------
+    # 3. Custom exception (non-standard ctor): falls back to RuntimeError
+    # ------------------------------------------------------------------
+
+    def test_custom_exception_falls_back_to_runtime_error(self):
+        layer = CustomExcLayer()
+        x = np.ones((2,), dtype="float32")
+        with self.assertRaises(RuntimeError) as ctx:
+            layer(x)
+        e = ctx.exception
+        self.assertIsInstance(e, RuntimeError)
+        self.assertIn("Exception encountered when calling", str(e))
+        self.assertIn("oops", str(e))
+        self.assertTrue(getattr(e, "_keras_call_info_injected", False))
+
+    # ------------------------------------------------------------------
+    # 4. Filtering disabled: original exception, no augmentation
+    # ------------------------------------------------------------------
+
+    def test_filtering_disabled_original_exception(self):
+        traceback_utils.disable_traceback_filtering()
+        layer = FailLayer()
+        x = np.ones((2,), dtype="float32")
+        with self.assertRaises(ValueError) as ctx:
+            layer(x)
+        e = ctx.exception
+        # Message should NOT be augmented
+        self.assertNotIn("Exception encountered when calling", str(e))
+        self.assertFalse(getattr(e, "_keras_call_info_injected", False))
+
+    # ------------------------------------------------------------------
+    # 5. Double-injection prevention via _keras_call_info_injected flag
+    # ------------------------------------------------------------------
+
+    def test_no_double_injection(self):
+        """inject_argument_info_in_error skips already-injected exceptions."""
+        original_msg = "already augmented"
+
+        def fake_fn(x):
+            pass
+
+        # Build a pre-injected exception
+        pre_injected = ValueError(original_msg)
+        pre_injected._keras_call_info_injected = True
+
+        # Calling inject_argument_info_in_error with a pre-injected exception
+        # should still produce a new augmented exception (the guard lives in
+        # operation.__call__), but let's verify the helper itself returns a
+        # new exception that carries the flag.
+        traceback_utils.inject_argument_info_in_error(
+            pre_injected, fake_fn, (1,), {}
+        )
+        # result may be None (unbindable) or a new exception — either way
+        # check that operation.__call__ would not double-inject.
+        # Simulate the guard logic from operation.py:
+        e = pre_injected
+        if not getattr(e, "_keras_call_info_injected", False):
+            augmented = traceback_utils.inject_argument_info_in_error(
+                e, fake_fn, (1,), {}
+            )
+        else:
+            augmented = None  # flag is set — skip injection
+        self.assertIsNone(augmented)  # guard prevented second injection
+
+    # ------------------------------------------------------------------
+    # 6. inject_argument_info_in_error returns None for unbindable args
+    # ------------------------------------------------------------------
+
+    def test_returns_none_for_unbindable_args(self):
+        def fn_no_args():
+            pass
+
+        e = ValueError("boom")
+        result = traceback_utils.inject_argument_info_in_error(
+            e,
+            fn_no_args,
+            (1, 2, 3),
+            {},  # too many positional args
+        )
+        self.assertIsNone(result)

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from keras.src import testing
+from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.ops.operation import Operation
 from keras.src.utils import traceback_utils
 
@@ -39,6 +40,17 @@ class HappyLayer(Operation):
 
     def compute_output_spec(self, x):
         return x
+
+
+class FailSymbolicLayer(Operation):
+    """Operation whose compute_output_spec() raises when dispatched through
+    `symbolic_call` (i.e. when called with a symbolic `KerasTensor`)."""
+
+    def call(self, x, y=10):
+        return x
+
+    def compute_output_spec(self, x, y=10):
+        raise ValueError("bad spec")
 
 
 class _NonStandardError(Exception):
@@ -103,6 +115,24 @@ class TracebackUtilsTest(testing.TestCase):
         # y=99 should appear in the argument listing
         self.assertIn("y=", msg)
         self.assertIn("99", msg)
+
+    def test_symbolic_call_uses_real_call_signature(self):
+        """Regression test: when dispatch goes through `symbolic_call`
+        (i.e. `any_symbolic_tensors` is True), the injected error message
+        must still reflect `call`'s real parameter names (`x`, `y`), not
+        the generic `args`/`kwargs` of `symbolic_call`'s own signature.
+        """
+        layer = FailSymbolicLayer()
+        x = KerasTensor((2, 3), name="x")
+        with self.assertRaises(ValueError) as ctx:
+            layer(x, y=99)
+        msg = str(ctx.exception)
+        self.assertIn("FailSymbolicLayer.call()", msg)
+        self.assertIn("x=", msg)
+        self.assertIn("y=", msg)
+        self.assertIn("99", msg)
+        self.assertNotIn("args=", msg)
+        self.assertNotIn("kwargs=", msg)
 
     # ------------------------------------------------------------------
     # 3. Custom exception (non-standard ctor): falls back to RuntimeError

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -1,15 +1,12 @@
-"""Tests for the lazy inject_argument_info_in_error path in traceback_utils."""
-
 import numpy as np
+import pytest
+import tensorflow as tf
 
+from keras.src import backend
 from keras.src import testing
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.ops.operation import Operation
 from keras.src.utils import traceback_utils
-
-# ---------------------------------------------------------------------------
-# Helper layer definitions
-# ---------------------------------------------------------------------------
 
 
 class FailLayer(Operation):
@@ -53,17 +50,23 @@ class FailSymbolicLayer(Operation):
         raise ValueError("bad spec")
 
 
+class TFOpErrorLayer(Operation):
+    """Operation whose call() raises a real `tf.errors.OpError`."""
+
+    def call(self, x):
+        tf.debugging.assert_positive(x, message="must be positive")
+        return x
+
+    def compute_output_spec(self, x):
+        return x
+
+
 class _NonStandardError(Exception):
     """Exception whose constructor does not accept a single positional arg."""
 
     def __init__(self, message, extra):
         super().__init__(message)
         self.extra = extra
-
-
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
 
 
 class TracebackUtilsTest(testing.TestCase):
@@ -80,19 +83,11 @@ class TracebackUtilsTest(testing.TestCase):
         else:
             traceback_utils.disable_traceback_filtering()
 
-    # ------------------------------------------------------------------
-    # 1. Happy path — no exception, no overhead
-    # ------------------------------------------------------------------
-
     def test_happy_path_no_exception(self):
         layer = HappyLayer()
         x = np.ones((2, 3), dtype="float32")
         result = layer(x)
         self.assertIs(result, x)  # returned unchanged
-
-    # ------------------------------------------------------------------
-    # 2. Standard exception: type preserved, message augmented
-    # ------------------------------------------------------------------
 
     def test_standard_exception_type_preserved(self):
         layer = FailLayer()
@@ -134,10 +129,6 @@ class TracebackUtilsTest(testing.TestCase):
         self.assertNotIn("args=", msg)
         self.assertNotIn("kwargs=", msg)
 
-    # ------------------------------------------------------------------
-    # 3. Custom exception (non-standard ctor): falls back to RuntimeError
-    # ------------------------------------------------------------------
-
     def test_custom_exception_falls_back_to_runtime_error(self):
         layer = CustomExcLayer()
         x = np.ones((2,), dtype="float32")
@@ -149,9 +140,27 @@ class TracebackUtilsTest(testing.TestCase):
         self.assertIn("oops", str(e))
         self.assertTrue(getattr(e, "_keras_call_info_injected", False))
 
-    # ------------------------------------------------------------------
-    # 4. Filtering disabled: original exception, no augmentation
-    # ------------------------------------------------------------------
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow", reason="Tensorflow error only"
+    )
+    def test_tf_op_error_preserves_type_and_error_code(self):
+        """Regression test for the `tf.errors.OpError` reconstruction branch
+        in `inject_argument_info_in_error`: a real `OpError` raised inside
+        `call()` must come back out as the same `OpError` subclass, with its
+        `error_code` preserved, and with the usual injected-context header
+        prepended to its message.
+        """
+        layer = TFOpErrorLayer()
+        x = tf.constant([-1, 2, 3])
+        with self.assertRaises(tf.errors.InvalidArgumentError) as ctx:
+            layer(x)
+        e = ctx.exception
+        self.assertIsInstance(e, tf.errors.OpError)
+        self.assertEqual(e.error_code, tf.errors.INVALID_ARGUMENT)
+        self.assertIn("Exception encountered when calling", str(e))
+        self.assertIn("TFOpErrorLayer.call()", str(e))
+        self.assertIn("must be positive", str(e))
+        self.assertTrue(getattr(e, "_keras_call_info_injected", False))
 
     def test_filtering_disabled_original_exception(self):
         traceback_utils.disable_traceback_filtering()
@@ -163,10 +172,6 @@ class TracebackUtilsTest(testing.TestCase):
         # Message should NOT be augmented
         self.assertNotIn("Exception encountered when calling", str(e))
         self.assertFalse(getattr(e, "_keras_call_info_injected", False))
-
-    # ------------------------------------------------------------------
-    # 5. Double-injection prevention via _keras_call_info_injected flag
-    # ------------------------------------------------------------------
 
     def test_no_double_injection(self):
         """inject_argument_info_in_error skips already-injected exceptions."""
@@ -198,11 +203,14 @@ class TracebackUtilsTest(testing.TestCase):
             augmented = None  # flag is set — skip injection
         self.assertIsNone(augmented)  # guard prevented second injection
 
-    # ------------------------------------------------------------------
-    # 6. inject_argument_info_in_error returns None for unbindable args
-    # ------------------------------------------------------------------
+    def test_unbindable_args_falls_back_to_raw_args_kwargs_dump(self):
+        """When `args`/`kwargs` cannot be bound to `fn`'s signature (e.g. a
+        symbolic-path arg-count mismatch, or a third-party `call` override
+        with a divergent signature), argument context is not silently
+        dropped: it falls back to a raw `args=`/`kwargs=` dump instead of
+        the usual per-parameter listing.
+        """
 
-    def test_returns_none_for_unbindable_args(self):
         def fn_no_args():
             pass
 
@@ -210,15 +218,32 @@ class TracebackUtilsTest(testing.TestCase):
         result = traceback_utils.inject_argument_info_in_error(
             e,
             fn_no_args,
-            (1, 2, 3),
-            {},  # too many positional args
+            (1, 2, 3),  # too many positional args -> unbindable
+            {"extra": "kw"},
+        )
+        self.assertIsNotNone(result)
+        msg = str(result)
+        self.assertIn("Exception encountered when calling", msg)
+        self.assertIn("boom", msg)
+        self.assertIn("args=(1, 2, 3)", msg)
+        self.assertIn("kwargs={extra='kw'}", msg)
+        self.assertTrue(getattr(result, "_keras_call_info_injected", False))
+
+    def test_unbindable_args_with_nothing_to_report_returns_none(self):
+        """If `args`/`kwargs` cannot be bound and are both empty (e.g. a
+        required positional argument is missing entirely), there is nothing
+        for the raw-dump fallback to report either, so augmentation is
+        skipped and the original exception surfaces unchanged.
+        """
+
+        def fn_requires_one_arg(x):
+            pass
+
+        e = ValueError("boom")
+        result = traceback_utils.inject_argument_info_in_error(
+            e, fn_requires_one_arg, (), {}
         )
         self.assertIsNone(result)
-
-    # ------------------------------------------------------------------
-    # 7. Failed flag-set must not duplicate the augmented message across
-    #    nested Operation calls.
-    # ------------------------------------------------------------------
 
     def test_setattr_failure_does_not_duplicate_message_across_nesting(self):
         """Regression test for duplicated augmentation text.

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -184,3 +184,62 @@ class TracebackUtilsTest(testing.TestCase):
             {},  # too many positional args
         )
         self.assertIsNone(result)
+
+    # ------------------------------------------------------------------
+    # 7. Failed flag-set must not duplicate the augmented message across
+    #    nested Operation calls.
+    # ------------------------------------------------------------------
+
+    def test_setattr_failure_does_not_duplicate_message_across_nesting(self):
+        """Regression test for duplicated augmentation text.
+
+        If the exception's flag attribute cannot be set (e.g. its type
+        rejects new attributes once constructed), a naive implementation
+        still returns the augmented-but-unmarked exception. Each nested
+        Operation.__call__ then re-augments it again since the flag was
+        never actually persisted, duplicating the "Exception encountered
+        when calling ..." text once per nesting level. The fix makes a
+        failed flag-set fall back to the plain original exception so the
+        text never appears more than once.
+        """
+
+        class _LockedError(Exception):
+            """Exception whose __setattr__ rejects new attributes once
+            construction has completed."""
+
+            def __init__(self, message):
+                super().__init__(message)
+                object.__setattr__(self, "_locked", True)
+
+            def __setattr__(self, name, value):
+                if getattr(self, "_locked", False) and name != "args":
+                    raise AttributeError(f"cannot set {name!r}")
+                object.__setattr__(self, name, value)
+
+        class InnerLockedLayer(Operation):
+            def call(self, x):
+                raise _LockedError("bad input")
+
+            def compute_output_spec(self, x):
+                return x
+
+        class OuterLockedLayer(Operation):
+            def __init__(self):
+                super().__init__()
+                self.inner = InnerLockedLayer()
+
+            def call(self, x):
+                return self.inner(x)
+
+            def compute_output_spec(self, x):
+                return x
+
+        layer = OuterLockedLayer()
+        x = np.ones((2,), dtype="float32")
+        with self.assertRaises(_LockedError) as ctx:
+            layer(x)
+        msg = str(ctx.exception)
+        occurrences = msg.count("Exception encountered when calling")
+        # Previously this was 2 (one augmentation per nesting level).
+        self.assertLessEqual(occurrences, 1)
+        self.assertIn("bad input", msg)

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -29,16 +29,6 @@ class CustomExcLayer(Operation):
         return x
 
 
-class HappyLayer(Operation):
-    """Operation whose call() always succeeds."""
-
-    def call(self, x):
-        return x
-
-    def compute_output_spec(self, x):
-        return x
-
-
 class FailSymbolicLayer(Operation):
     """Operation whose compute_output_spec() raises when dispatched through
     `symbolic_call` (i.e. when called with a symbolic `KerasTensor`)."""
@@ -112,6 +102,7 @@ class TracebackUtilsTest(testing.TestCase):
     """Tests for inject_argument_info_in_error (lazy, on-error-path only)."""
 
     def setUp(self):
+        super().setUp()
         # Ensure filtering is enabled at start of each test; restore after.
         self._was_enabled = traceback_utils.is_traceback_filtering_enabled()
         traceback_utils.enable_traceback_filtering()
@@ -121,12 +112,7 @@ class TracebackUtilsTest(testing.TestCase):
             traceback_utils.enable_traceback_filtering()
         else:
             traceback_utils.disable_traceback_filtering()
-
-    def test_happy_path_no_exception(self):
-        layer = HappyLayer()
-        x = np.ones((2, 3), dtype="float32")
-        result = layer(x)
-        self.assertIs(result, x)  # returned unchanged
+        super().tearDown()
 
     def test_standard_exception_type_preserved(self):
         layer = FailLayer()
@@ -268,11 +254,11 @@ class TracebackUtilsTest(testing.TestCase):
         self.assertIn("kwargs={extra='kw'}", msg)
         self.assertTrue(getattr(result, "_keras_call_info_injected", False))
 
-    def test_unbindable_args_with_nothing_to_report_returns_none(self):
+    def test_unbindable_args_with_nothing_to_report_returns_original(self):
         """If `args`/`kwargs` cannot be bound and are both empty (e.g. a
         required positional argument is missing entirely), there is nothing
-        for the raw-dump fallback to report either, so augmentation is
-        skipped and the original exception surfaces unchanged.
+        for the raw-dump fallback to report either, so the original
+        exception is returned unmodified.
         """
 
         def fn_requires_one_arg(x):
@@ -282,7 +268,7 @@ class TracebackUtilsTest(testing.TestCase):
         result = traceback_utils.inject_argument_info_in_error(
             e, fn_requires_one_arg, (), {}
         )
-        self.assertIsNone(result)
+        self.assertIs(result, e)
 
     def test_setattr_failure_does_not_duplicate_message_across_nesting(self):
         """Regression test for duplicated augmentation text.
@@ -302,6 +288,5 @@ class TracebackUtilsTest(testing.TestCase):
             layer(x)
         msg = str(ctx.exception)
         occurrences = msg.count("Exception encountered when calling")
-        # Previously this was 2 (one augmentation per nesting level).
         self.assertLessEqual(occurrences, 1)
         self.assertIn("bad input", msg)

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -69,6 +69,45 @@ class _NonStandardError(Exception):
         self.extra = extra
 
 
+class _LockedError(Exception):
+    """Exception whose __setattr__ rejects new attributes once construction
+    has completed."""
+
+    def __init__(self, message):
+        super().__init__(message)
+        object.__setattr__(self, "_locked", True)
+
+    def __setattr__(self, name, value):
+        if getattr(self, "_locked", False) and name != "args":
+            raise AttributeError(f"cannot set {name!r}")
+        object.__setattr__(self, name, value)
+
+
+class InnerLockedLayer(Operation):
+    """Operation whose call() raises a `_LockedError`."""
+
+    def call(self, x):
+        raise _LockedError("bad input")
+
+    def compute_output_spec(self, x):
+        return x
+
+
+class OuterLockedLayer(Operation):
+    """Operation that delegates to `InnerLockedLayer`, to exercise
+    re-augmentation across nested `Operation.__call__` levels."""
+
+    def __init__(self):
+        super().__init__()
+        self.inner = InnerLockedLayer()
+
+    def call(self, x):
+        return self.inner(x)
+
+    def compute_output_spec(self, x):
+        return x
+
+
 class TracebackUtilsTest(testing.TestCase):
     """Tests for inject_argument_info_in_error (lazy, on-error-path only)."""
 
@@ -257,38 +296,6 @@ class TracebackUtilsTest(testing.TestCase):
         failed flag-set fall back to the plain original exception so the
         text never appears more than once.
         """
-
-        class _LockedError(Exception):
-            """Exception whose __setattr__ rejects new attributes once
-            construction has completed."""
-
-            def __init__(self, message):
-                super().__init__(message)
-                object.__setattr__(self, "_locked", True)
-
-            def __setattr__(self, name, value):
-                if getattr(self, "_locked", False) and name != "args":
-                    raise AttributeError(f"cannot set {name!r}")
-                object.__setattr__(self, name, value)
-
-        class InnerLockedLayer(Operation):
-            def call(self, x):
-                raise _LockedError("bad input")
-
-            def compute_output_spec(self, x):
-                return x
-
-        class OuterLockedLayer(Operation):
-            def __init__(self):
-                super().__init__()
-                self.inner = InnerLockedLayer()
-
-            def call(self, x):
-                return self.inner(x)
-
-            def compute_output_spec(self, x):
-                return x
-
         layer = OuterLockedLayer()
         x = np.ones((2,), dtype="float32")
         with self.assertRaises(_LockedError) as ctx:

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -230,8 +230,7 @@ class TracebackUtilsTest(testing.TestCase):
 
     def test_unbindable_args_falls_back_to_raw_args_kwargs_dump(self):
         """When `args`/`kwargs` cannot be bound to `fn`'s signature (e.g. a
-        symbolic-path arg-count mismatch, or a third-party `call` override
-        with a divergent signature), argument context is not silently
+        symbolic-path arg-count mismatch), argument context is not silently
         dropped: it falls back to a raw `args=`/`kwargs=` dump instead of
         the usual per-parameter listing.
         """
@@ -252,6 +251,29 @@ class TracebackUtilsTest(testing.TestCase):
         self.assertIn("boom", msg)
         self.assertIn("args=(1, 2, 3)", msg)
         self.assertIn("kwargs={extra='kw'}", msg)
+        self.assertTrue(getattr(result, "_keras_call_info_injected", False))
+
+    def test_unbindable_nested_args_fall_back_to_raw_dump(self):
+        """A nested argument comes back from `map_structure` as a structure
+        rather than a string, so the raw dump has to render it before
+        joining. Otherwise the join raises and the whole fallback is lost.
+        """
+
+        def fn_no_args():
+            pass
+
+        e = ValueError("boom")
+        result = traceback_utils.inject_argument_info_in_error(
+            e,
+            fn_no_args,
+            ([1, 2], 3),
+            {"nested": {"a": 4}},
+        )
+        self.assertIsNotNone(result)
+        msg = str(result)
+        self.assertIn("boom", msg)
+        self.assertIn("args=(", msg)
+        self.assertIn("nested=", msg)
         self.assertTrue(getattr(result, "_keras_call_info_injected", False))
 
     def test_unbindable_args_with_nothing_to_report_returns_original(self):

--- a/keras/src/utils/traceback_utils_test.py
+++ b/keras/src/utils/traceback_utils_test.py
@@ -99,7 +99,7 @@ class OuterLockedLayer(Operation):
 
 
 class TracebackUtilsTest(testing.TestCase):
-    """Tests for inject_argument_info_in_error (lazy, on-error-path only)."""
+    """Tests for inject_argument_info_in_error."""
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Closes #23270

## Summary

`Operation.__call__` and `Cond.__call__` built a fresh `inject_argument_info_in_traceback` closure (via `functools.wraps`) on every single call, even though it only ever did work on the exception path. This PR moves that wrapping into the `except` block itself, so the happy path is just a plain call with no closure allocation.

## Why this is safe

- No behavior change on error: the new `inject_argument_info_in_error` helper (in `traceback_utils.py`) produces the same augmented exception, double-injection guard (`_keras_call_info_injected`), and TF `OpError` handling as before.
- When `signature.bind()` cannot match args against `fn`'s real signature (e.g. a symbolic-path arg-count mismatch), `_format_raw_arguments_fallback` dumps raw `args`/`kwargs` rather than dropping the argument context. It is only reachable from inside the `except` block, so it cannot affect the hot path.
- Guards the `_keras_call_info_injected` attribute set against slotted exception types, avoiding a secondary `AttributeError`.
- `inject_argument_info_in_traceback` is deleted; no callers remain.

## Benchmarks (GPU, 3-way: master / this PR alone / this PR + parents)

![PR #23183: master vs PR alone vs PR+parents, Keras torch GPU eager](https://raw.githubusercontent.com/pctablet505/keras/1d4e020c7bab24f173c424bf27ddade5e06d7bcf/22561/pr23183.png)

| workload | master | this PR alone | + parents (#23182→#23183) |
|---|--:|--:|--:|
| CNN forward | 1.25 ms | 1.22 ms (~noise) | 1.16 ms (~noise) |
| LLM forward | 3.55 ms | 3.40 ms (~noise) | 3.20 ms (~noise) |
| LLM generate-32 | 113.4 ms | 108.1 ms (~noise) | 103.7 ms (1.08x) |

In isolation this lands in noise at the whole-model level, as expected — removing one per-call closure allocation is a small fraction of a forward pass. The primary evidence is the deterministic call-count reduction on the fast path itself. Stacked on #23182, LLM generate-32 crosses into a real, measured win (7/8 paired runs agree, ~8.5% off master past the noise threshold), showing the compounding effect of the two per-call fixes together. Outputs are bit-identical to master in both configs (max|Δ| = 0.0, generated token ids identical).

## torch.compile performance

![PR #23183: master vs PR alone vs PR+parents, compiled, Keras torch GPU](https://raw.githubusercontent.com/pctablet505/keras/f4e4e12806b079f254824d0916f880b1b33082d7/22561/pr23183_compile.png)

| workload | state | eager_ms | compile_ms | speedup |
|---|---|--:|--:|--:|
| CNN forward | isolated (PR alone) | 1.12 | 2.68 | 0.42x (2.39x slower compiled) |
| CNN forward | stacked (+ parents) | 1.11 | 2.41 | 0.46x (2.17x slower compiled) |
| LLM forward | isolated (PR alone) | 3.26 | 5.01 | 0.65x (1.54x slower compiled) |
| LLM forward | stacked (+ parents) | 3.07 | 6.28 | 0.49x (2.05x slower compiled) |
| LLM generate-32 | isolated (PR alone) | 98.2 | 181.4 | 0.54x (1.85x slower compiled) |
| LLM generate-32 | stacked (+ parents) | 129.6 | 166.8 | 0.78x (1.29x slower compiled) |

Compiled mode is slower than eager on every workload, in both states, on this hardware — this PR does not change that. That is not a regression this PR introduces: master itself is 1.58x–2.32x slower under `torch.compile` than eager on the same three workloads on this harness, so a compiled-slower-than-eager result is a pre-existing characteristic of these small synthetic benchmarks (short sequences, small batch, few iterations) under `torch.compile`, not something this PR's change to the traceback path could plausibly move. The eager-vs-compiled ratios above are the only numbers that should be read across (within-run pairs); the isolated and stacked runs were captured in separate processes at different times under different ambient load, so raw absolute milliseconds should not be compared state-to-state — e.g. stacked eager LLM generate-32 (129.6 ms) reads higher than isolated eager LLM generate-32 (98.2 ms) here purely from run-to-run noise, not from adding a compile-neutral parent PR; that same magnitude of spread shows up on master's own repeated runs and on sibling PR #23182's compile runs. Equivalence checks against master (bit-exact outputs) passed for both states.

Part of the perf series starting at #23182; recommended merge order #23182 → #23183 → #23184 → ... → #23190.

## Tests

`keras/src/utils/traceback_utils_test.py` (11 tests): error message content, double-injection guard, signature-bind-failure fallback including nested arguments, and TF `OpError` preservation. `keras/src/ops/core_test.py` adds two `Cond` tests: errors use `Cond.call()`'s real parameter names (`pred`/`true_fn`/`false_fn`), and `cond` keeps working inside a `RematScope`, which covers why `Cond` overrides `__call__` at all.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.


## torch.compile impact

This PR is compile-neutral: deterministic dynamo decomposition shows a 0 graph-break delta at its position in the stack. That's expected — moving the traceback-injection closure into the `except` block only changes eager-mode dispatch and never touches the compiled graph itself. The compile-side win comes from removing the attention graph break in the torch backend (#23327), not from this PR.

![torch.compile graph breaks across the #22561 series (this PR does not change the count)](https://raw.githubusercontent.com/pctablet505/keras/5195086b19/22561/compile-graph-breaks-22561-2026-07-19.png)
