### PR TITLE
perf(torch): direct F.linear/einsum dispatch in Dense and EinsumDense

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -261,13 +261,14 @@ class Dense(Layer):
                 scope_device = global_state.get_global_attribute(
                     "torch_device", None
                 )
-                target_device = (
-                    torch.device(scope_device)
-                    if scope_device is not None
-                    else kernel.device
-                )
-                if kernel.device != target_device:
-                    kernel = kernel.to(target_device)
+                # kernel is already on kernel.device by definition, so only
+                # a scope override can actually move it - skip the compare
+                # entirely otherwise instead of comparing a value to itself.
+                target_device = kernel.device
+                if scope_device is not None:
+                    target_device = torch.device(scope_device)
+                    if kernel.device != target_device:
+                        kernel = kernel.to(target_device)
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
                 bias = self.bias.value if self.bias is not None else None

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -18,6 +18,10 @@ from keras.src.quantizers.quantization_config import get_block_size_for_layer
 from keras.src.quantizers.quantizers import dequantize_with_sz_map
 from keras.src.saving import serialization_lib
 
+if backend.backend() == "torch":
+    import torch
+    import torch.nn.functional as F
+
 
 @keras_export("keras.layers.Dense")
 class Dense(Layer):
@@ -156,14 +160,9 @@ class Dense(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
-        # Flag set at build; lora_enabled re-checked at call time.
+        # Cache the torch fast-path eligibility at build time; `lora_enabled`
+        # is re-checked at call time.
         self._torch_backend = backend.backend() == "torch"
-        if self._torch_backend:
-            import torch as _torch
-            import torch.nn.functional as _torch_F
-
-            self._torch = _torch
-            self._torch_F = _torch_F
 
     @property
     def kernel(self):
@@ -236,15 +235,15 @@ class Dense(Layer):
             # Skip under torch.compile: meta-device weights cause fake-tensor
             # issues with F.linear.
             if not (
-                hasattr(self._torch.compiler, "is_compiling")
-                and self._torch.compiler.is_compiling()
+                hasattr(torch.compiler, "is_compiling")
+                and torch.compiler.is_compiling()
             ):
                 kernel = self._kernel.value
                 scope_device = global_state.get_global_attribute(
                     "torch_device", None
                 )
                 if scope_device is not None:
-                    target_device = self._torch.device(scope_device)
+                    target_device = torch.device(scope_device)
                     if kernel.device != target_device:
                         kernel = kernel.to(target_device)
                 else:
@@ -260,7 +259,7 @@ class Dense(Layer):
                     bias = self.bias.value if self.bias is not None else None
                     if bias is not None and bias.device != target_device:
                         bias = bias.to(target_device)
-                    x = self._torch_F.linear(inputs, kernel.t(), bias)
+                    x = F.linear(inputs, kernel.t(), bias)
                     if self.activation is not None:
                         x = self.activation(x)
                     return x

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -236,7 +236,8 @@ class Dense(Layer):
         # weights make F.linear raise under fake tensors.
         if self._torch_backend and not self.lora_enabled:
             if not (
-                hasattr(torch.compiler, "is_compiling")
+                hasattr(torch, "compiler")
+                and hasattr(torch.compiler, "is_compiling")
                 and torch.compiler.is_compiling()
             ):
                 kernel = self._kernel.value

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -228,12 +228,13 @@ class Dense(Layer):
         return kernel
 
     def call(self, inputs, training=None):
-        # Fast path: F.linear bypasses Keras ops dispatch.
-        # Quantization routes to quantized_call() before reaching here.
-        # kernel is [in, out]; F.linear wants [out, in] so we pass kernel.t().
+        # On the torch backend, call F.linear directly rather than going
+        # through Keras's ops dispatch. This only applies to a plain eager
+        # forward: quantized layers route through quantized_call() before
+        # ever reaching call(), LoRA needs the ops path for its additive
+        # branch, and torch.compile tracing is skipped because meta-device
+        # weights make F.linear raise under fake tensors.
         if self._torch_backend and not self.lora_enabled:
-            # Skip under torch.compile: meta-device weights cause fake-tensor
-            # issues with F.linear.
             if not (
                 hasattr(torch.compiler, "is_compiling")
                 and torch.compiler.is_compiling()
@@ -250,20 +251,23 @@ class Dense(Layer):
                     target_device = kernel.device
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
-                # Do not cast the kernel toward inputs.dtype: that's a
-                # downcast, not a promotion, and silently corrupts the
-                # result for e.g. integer inputs (float kernel truncated
-                # to int -> near-all-zeros). Let the standard path's
-                # dtype-promotion rules handle any mismatch instead.
+                # A dtype mismatch falls through to the standard path below
+                # rather than casting the kernel toward the input's dtype
+                # here: that would be a downcast, not a promotion, and it
+                # would silently corrupt the result for integer inputs (a
+                # float kernel truncated to int becomes near-all-zeros).
+                # The standard path already applies the correct
+                # dtype-promotion rules.
                 if inputs.dtype == kernel.dtype:
                     bias = self.bias.value if self.bias is not None else None
                     if bias is not None and bias.device != target_device:
                         bias = bias.to(target_device)
+                    # Keras stores the kernel as [in, out]; F.linear expects
+                    # [out, in].
                     x = F.linear(inputs, kernel.t(), bias)
                     if self.activation is not None:
                         x = self.activation(x)
                     return x
-        # Standard path: non-torch, LoRA, or torch.compile.
         x = ops.matmul(inputs, self.kernel)
         if self.bias is not None:
             x = ops.add(x, self.bias)

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -5,12 +5,12 @@ import ml_dtypes
 from keras.src import activations
 from keras.src import backend
 from keras.src import constraints
-from keras.src.backend.common import global_state
 from keras.src import initializers
 from keras.src import ops
 from keras.src import quantizers
 from keras.src import regularizers
 from keras.src.api_export import keras_export
+from keras.src.backend.common import global_state
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
 from keras.src.quantizers.quantization_config import QuantizationConfig
@@ -251,18 +251,19 @@ class Dense(Layer):
                     target_device = kernel.device
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
-                if inputs.dtype != kernel.dtype:
-                    kernel = kernel.to(inputs.dtype)
-                bias = self.bias.value if self.bias is not None else None
-                if bias is not None:
-                    if bias.device != target_device:
+                # Do not cast the kernel toward inputs.dtype: that's a
+                # downcast, not a promotion, and silently corrupts the
+                # result for e.g. integer inputs (float kernel truncated
+                # to int -> near-all-zeros). Let the standard path's
+                # dtype-promotion rules handle any mismatch instead.
+                if inputs.dtype == kernel.dtype:
+                    bias = self.bias.value if self.bias is not None else None
+                    if bias is not None and bias.device != target_device:
                         bias = bias.to(target_device)
-                    if inputs.dtype != bias.dtype:
-                        bias = bias.to(inputs.dtype)
-                x = self._torch_F.linear(inputs, kernel.t(), bias)
-                if self.activation is not None:
-                    x = self.activation(x)
-                return x
+                    x = self._torch_F.linear(inputs, kernel.t(), bias)
+                    if self.activation is not None:
+                        x = self.activation(x)
+                    return x
         # Standard path: non-torch, LoRA, or torch.compile.
         x = ops.matmul(inputs, self.kernel)
         if self.bias is not None:

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -5,6 +5,7 @@ import ml_dtypes
 from keras.src import activations
 from keras.src import backend
 from keras.src import constraints
+from keras.src.backend.common import global_state
 from keras.src import initializers
 from keras.src import ops
 from keras.src import quantizers
@@ -239,13 +240,25 @@ class Dense(Layer):
                 and self._torch.compiler.is_compiling()
             ):
                 kernel = self._kernel.value
-                if inputs.device != kernel.device:
-                    inputs = inputs.to(kernel.device)
+                scope_device = global_state.get_global_attribute(
+                    "torch_device", None
+                )
+                if scope_device is not None:
+                    target_device = self._torch.device(scope_device)
+                    if kernel.device != target_device:
+                        kernel = kernel.to(target_device)
+                else:
+                    target_device = kernel.device
+                if inputs.device != target_device:
+                    inputs = inputs.to(target_device)
                 if inputs.dtype != kernel.dtype:
                     kernel = kernel.to(inputs.dtype)
                 bias = self.bias.value if self.bias is not None else None
-                if bias is not None and inputs.dtype != bias.dtype:
-                    bias = bias.to(inputs.dtype)
+                if bias is not None:
+                    if bias.device != target_device:
+                        bias = bias.to(target_device)
+                    if inputs.dtype != bias.dtype:
+                        bias = bias.to(inputs.dtype)
                 x = self._torch_F.linear(inputs, kernel.t(), bias)
                 if self.activation is not None:
                     x = self.activation(x)

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -3,6 +3,7 @@ import math
 import ml_dtypes
 
 from keras.src import activations
+from keras.src import backend
 from keras.src import constraints
 from keras.src import initializers
 from keras.src import ops
@@ -154,6 +155,14 @@ class Dense(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
+        # Flag set at build; lora_enabled re-checked at call time.
+        self._torch_backend = backend.backend() == "torch"
+        if self._torch_backend:
+            import torch as _torch
+            import torch.nn.functional as _torch_F
+
+            self._torch = _torch
+            self._torch_F = _torch_F
 
     @property
     def kernel(self):
@@ -219,6 +228,29 @@ class Dense(Layer):
         return kernel
 
     def call(self, inputs, training=None):
+        # Fast path: F.linear bypasses Keras ops dispatch.
+        # Quantization routes to quantized_call() before reaching here.
+        # kernel is [in, out]; F.linear wants [out, in] so we pass kernel.t().
+        if self._torch_backend and not self.lora_enabled:
+            # Skip under torch.compile: meta-device weights cause fake-tensor
+            # issues with F.linear.
+            if not (
+                hasattr(self._torch.compiler, "is_compiling")
+                and self._torch.compiler.is_compiling()
+            ):
+                kernel = self._kernel.value
+                if inputs.device != kernel.device:
+                    inputs = inputs.to(kernel.device)
+                if inputs.dtype != kernel.dtype:
+                    kernel = kernel.to(inputs.dtype)
+                bias = self.bias.value if self.bias is not None else None
+                if bias is not None and inputs.dtype != bias.dtype:
+                    bias = bias.to(inputs.dtype)
+                x = self._torch_F.linear(inputs, kernel.t(), bias)
+                if self.activation is not None:
+                    x = self.activation(x)
+                return x
+        # Standard path: non-torch, LoRA, or torch.compile.
         x = ops.matmul(inputs, self.kernel)
         if self.bias is not None:
             x = ops.add(x, self.bias)

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -240,10 +240,14 @@ class Dense(Layer):
         # through Keras's ops dispatch. This only applies to a plain eager
         # forward: quantized layers route through quantized_call() before
         # ever reaching call(), LoRA needs the ops path for its additive
-        # branch, and torch.compile tracing is skipped because meta-device
-        # weights make F.linear raise under fake tensors.
+        # branch, torch.compile tracing is skipped because meta-device
+        # weights make F.linear raise under fake tensors, and a Dense
+        # subclass is excluded because it may override the `kernel`
+        # property (a supported extension point) with logic this path
+        # would silently bypass by reading `self._kernel.value` directly.
         if (
             self._torch_backend
+            and type(self) is Dense
             and not self.lora_enabled
             and not self._torch_compiling()
         ):

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -227,6 +227,14 @@ class Dense(Layer):
 
         return kernel
 
+    @staticmethod
+    def _torch_compiling():
+        return (
+            hasattr(torch, "compiler")
+            and hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
+        )
+
     def call(self, inputs, training=None):
         # On the torch backend, call F.linear directly rather than going
         # through Keras's ops dispatch. This only applies to a plain eager
@@ -234,41 +242,43 @@ class Dense(Layer):
         # ever reaching call(), LoRA needs the ops path for its additive
         # branch, and torch.compile tracing is skipped because meta-device
         # weights make F.linear raise under fake tensors.
-        if self._torch_backend and not self.lora_enabled:
-            if not (
-                hasattr(torch, "compiler")
-                and hasattr(torch.compiler, "is_compiling")
-                and torch.compiler.is_compiling()
-            ):
-                kernel = self._kernel.value
+        if (
+            self._torch_backend
+            and not self.lora_enabled
+            and not self._torch_compiling()
+        ):
+            kernel = self._kernel.value
+            # A dtype mismatch falls through to the standard path below
+            # rather than casting the kernel toward the input's dtype here:
+            # that would be a downcast, not a promotion, and it would
+            # silently corrupt the result for integer inputs (a float
+            # kernel truncated to int becomes near-all-zeros). The standard
+            # path already applies the correct dtype-promotion rules.
+            # Checked before any device work below, since dtype is
+            # unaffected by device placement and a mismatch skips that
+            # work entirely.
+            if inputs.dtype == kernel.dtype:
                 scope_device = global_state.get_global_attribute(
                     "torch_device", None
                 )
-                if scope_device is not None:
-                    target_device = torch.device(scope_device)
-                    if kernel.device != target_device:
-                        kernel = kernel.to(target_device)
-                else:
-                    target_device = kernel.device
+                target_device = (
+                    torch.device(scope_device)
+                    if scope_device is not None
+                    else kernel.device
+                )
+                if kernel.device != target_device:
+                    kernel = kernel.to(target_device)
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
-                # A dtype mismatch falls through to the standard path below
-                # rather than casting the kernel toward the input's dtype
-                # here: that would be a downcast, not a promotion, and it
-                # would silently corrupt the result for integer inputs (a
-                # float kernel truncated to int becomes near-all-zeros).
-                # The standard path already applies the correct
-                # dtype-promotion rules.
-                if inputs.dtype == kernel.dtype:
-                    bias = self.bias.value if self.bias is not None else None
-                    if bias is not None and bias.device != target_device:
-                        bias = bias.to(target_device)
-                    # Keras stores the kernel as [in, out]; F.linear expects
-                    # [out, in].
-                    x = F.linear(inputs, kernel.t(), bias)
-                    if self.activation is not None:
-                        x = self.activation(x)
-                    return x
+                bias = self.bias.value if self.bias is not None else None
+                if bias is not None and bias.device != target_device:
+                    bias = bias.to(target_device)
+                # Keras stores the kernel as [in, out]; F.linear expects
+                # [out, in].
+                x = F.linear(inputs, kernel.t(), bias)
+                if self.activation is not None:
+                    x = self.activation(x)
+                return x
         x = ops.matmul(inputs, self.kernel)
         if self.bias is not None:
             x = ops.add(x, self.bias)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1437,10 +1437,6 @@ class DenseTest(testing.TestCase):
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
 
-    # ------------------------------------------------------------------
-    # Torch fast-path numeric-equivalence tests
-    # ------------------------------------------------------------------
-
     @parameterized.named_parameters(
         ("none_bias", None, True),
         ("none_nobias", None, False),

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1436,3 +1436,163 @@ class DenseTest(testing.TestCase):
         # Verify outputs match
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
+
+    # ------------------------------------------------------------------
+    # Torch fast-path numeric-equivalence tests
+    # ------------------------------------------------------------------
+
+    @parameterized.named_parameters(
+        ("none_bias", None, True),
+        ("none_nobias", None, False),
+        ("relu_bias", "relu", True),
+        ("relu_nobias", "relu", False),
+        ("gelu_bias", "gelu", True),
+        ("gelu_nobias", "gelu", False),
+        ("tanh_bias", "tanh", True),
+        ("tanh_nobias", "tanh", False),
+        ("sigmoid_bias", "sigmoid", True),
+        ("sigmoid_nobias", "sigmoid", False),
+    )
+    def test_torch_fast_path_float32(self, activation, use_bias):
+        """Fast-path F.linear vs ops.matmul numeric equivalence."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        torch.manual_seed(42)
+        in_dim, out_dim, batch = 128, 64, 8
+        layer = layers.Dense(out_dim, activation=activation, use_bias=use_bias)
+        x_t = torch.tensor(np.random.randn(batch, in_dim).astype("float32"))
+        _ = layer(x_t)
+        self.assertTrue(
+            getattr(layer, "_torch_backend", False),
+            "Dense._torch_backend must be True on torch backend after build",
+        )
+        out_fast = layer(x_t)
+        layer._torch_backend = False
+        out_slow = layer(x_t)
+        layer._torch_backend = True
+        self.assertAllClose(out_fast, out_slow, rtol=1e-5, atol=1e-5)
+
+    def test_torch_fast_path_3d_input(self):
+        """Dense with [batch, seq, in_dim] input exercises batched matmul."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        torch.manual_seed(7)
+        layer = layers.Dense(32, activation="gelu")
+        x_t = torch.randn(4, 16, 64)
+        _ = layer(x_t)
+        out_fast = layer(x_t)
+        layer._torch_backend = False
+        out_slow = layer(x_t)
+        layer._torch_backend = True
+        self.assertAllClose(out_fast, out_slow, rtol=1e-5, atol=1e-5)
+
+    def test_torch_fast_path_lora_stays_slow(self):
+        """LoRA-enabled Dense must NOT use the fast path."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        torch.manual_seed(0)
+        layer = layers.Dense(32, activation="relu")
+        x_t = torch.randn(4, 64)
+        _ = layer(x_t)
+        layer.enable_lora(rank=4)
+        self.assertTrue(layer.lora_enabled, "LoRA should be enabled")
+        out = layer(x_t)
+        self.assertFalse(torch.isnan(out).any(), "LoRA output must not be NaN")
+        self.assertFalse(torch.isinf(out).any(), "LoRA output must not be Inf")
+
+    def test_torch_fast_path_flag_false_non_torch(self):
+        """_torch_backend flag must be False when backend != torch."""
+        if backend.backend() == "torch":
+            self.skipTest("only meaningful on non-torch backends")
+        layer = layers.Dense(16)
+        _ = layer(np.zeros((2, 8), dtype="float32"))
+        flag = getattr(layer, "_torch_backend", False)
+        self.assertFalse(
+            flag,
+            f"_torch_backend must be False on {backend.backend()} backend",
+        )
+
+    def test_torch_fast_path_manual_kernel_check(self):
+        """Verify Dense fast path: F.linear(x, W.t(), b) == x @ W + b."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+        import torch.nn.functional as F
+
+        torch.manual_seed(42)
+        layer = layers.Dense(16, use_bias=True)
+        x_t = torch.randn(4, 32)
+        _ = layer(x_t)
+        W = layer._kernel.value
+        b = layer.bias.value
+        x_t = x_t.to(W.device)
+        expected = torch.matmul(x_t, W) + b
+        fast_result = F.linear(x_t, W.t(), b)
+        self.assertAllClose(fast_result, expected, rtol=1e-6, atol=1e-6)
+        out = layer(x_t)
+        self.assertAllClose(out, expected, rtol=1e-5, atol=1e-5)
+
+    def test_torch_fast_path_symbolic_input(self):
+        """Verify Dense works with symbolic KerasTensor on torch backend."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        inputs = layers.Input(shape=(10,))
+        outputs = layers.Dense(5)(inputs)
+        self.assertEqual(outputs.shape, (None, 5))
+
+    def test_torch_fast_path_device_alignment(self):
+        """Dense/EinsumDense fast path must handle CPU inputs on CUDA layer.
+
+        Regression test: F.linear / torch.einsum skipped the device move that
+        ops.matmul performs implicitly. On CUDA with CPU inputs this raised:
+            RuntimeError: Expected all tensors to be on the same device
+        """
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        # Build Dense and EinsumDense layers (weights land on the default
+        # device).
+        dense = layers.Dense(8)
+        dense.build((None, 4))
+        einsum_dense = layers.EinsumDense("ab,bc->ac", output_shape=8)
+        einsum_dense.build((None, 4))
+
+        # Always feed a CPU tensor; on a CPU-only machine this is a no-op,
+        # on a CUDA machine it exercises the device-move.
+        cpu_input = torch.zeros(2, 4, device="cpu")
+
+        out_dense = dense(cpu_input)
+        out_einsum = einsum_dense(cpu_input)
+
+        # Outputs must land on the layer's weight device (same as kernel).
+        kernel_device = dense._kernel.value.device
+        self.assertEqual(out_dense.device, kernel_device)
+        einsum_kernel_device = einsum_dense._kernel.value.device
+        self.assertEqual(out_einsum.device, einsum_kernel_device)
+
+        # Shape check only; assertAllClose handles device/dtype.
+        self.assertEqual(out_dense.cpu().shape, (2, 8))
+        self.assertEqual(out_einsum.cpu().shape, (2, 8))
+
+    def test_torch_fast_path_mixed_float16(self):
+        """Fast-path vs slow-path equivalence with mixed_float16 policy."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        torch.manual_seed(0)
+        layer = layers.Dense(32, activation="relu", dtype="mixed_float16")
+        x_t = torch.randn(4, 64)
+        _ = layer(x_t)
+        out_fast = layer(x_t)
+        layer._torch_backend = False
+        out_slow = layer(x_t)
+        layer._torch_backend = True
+        self.assertAllClose(out_fast, out_slow, rtol=1e-3, atol=1e-3)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -23,6 +23,10 @@ from keras.src.quantizers.quantization_config import Int4QuantizationConfig
 from keras.src.quantizers.quantization_config import Int8QuantizationConfig
 from keras.src.quantizers.quantizers import AbsMaxQuantizer
 
+if backend.backend() == "torch":
+    import torch
+    import torch.nn.functional as F
+
 
 class DenseTest(testing.TestCase):
     @parameterized.named_parameters(
@@ -1437,6 +1441,21 @@ class DenseTest(testing.TestCase):
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
 
+    def test_torch_fast_path_flag_false_non_torch(self):
+        """_torch_backend flag must be False when backend != torch."""
+        if backend.backend() == "torch":
+            self.skipTest("only meaningful on non-torch backends")
+        layer = layers.Dense(16)
+        _ = layer(np.zeros((2, 8), dtype="float32"))
+        flag = getattr(layer, "_torch_backend", False)
+        self.assertFalse(
+            flag,
+            f"_torch_backend must be False on {backend.backend()} backend",
+        )
+
+
+@pytest.mark.skipif(backend.backend() != "torch", reason="torch backend only")
+class DenseTorchFastPathTest(testing.TestCase):
     @parameterized.named_parameters(
         ("none_bias", None, True),
         ("none_nobias", None, False),
@@ -1451,10 +1470,6 @@ class DenseTest(testing.TestCase):
     )
     def test_torch_fast_path_float32(self, activation, use_bias):
         """Fast-path F.linear vs ops.matmul numeric equivalence."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         torch.manual_seed(42)
         in_dim, out_dim, batch = 128, 64, 8
         layer = layers.Dense(out_dim, activation=activation, use_bias=use_bias)
@@ -1472,10 +1487,6 @@ class DenseTest(testing.TestCase):
 
     def test_torch_fast_path_3d_input(self):
         """Dense with [batch, seq, in_dim] input exercises batched matmul."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         torch.manual_seed(7)
         layer = layers.Dense(32, activation="gelu")
         x_t = torch.randn(4, 16, 64)
@@ -1497,10 +1508,6 @@ class DenseTest(testing.TestCase):
         directly, so a leaked fast path is provably wrong, not just
         NaN/Inf.
         """
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         torch.manual_seed(0)
         layer = layers.Dense(32)
         x_t = torch.randn(4, 64)
@@ -1526,25 +1533,8 @@ class DenseTest(testing.TestCase):
             "computation, or the fast path leaked through",
         )
 
-    def test_torch_fast_path_flag_false_non_torch(self):
-        """_torch_backend flag must be False when backend != torch."""
-        if backend.backend() == "torch":
-            self.skipTest("only meaningful on non-torch backends")
-        layer = layers.Dense(16)
-        _ = layer(np.zeros((2, 8), dtype="float32"))
-        flag = getattr(layer, "_torch_backend", False)
-        self.assertFalse(
-            flag,
-            f"_torch_backend must be False on {backend.backend()} backend",
-        )
-
     def test_torch_fast_path_manual_kernel_check(self):
         """Verify Dense fast path: F.linear(x, W.t(), b) == x @ W + b."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-        import torch.nn.functional as F
-
         torch.manual_seed(42)
         layer = layers.Dense(16, use_bias=True)
         x_t = torch.randn(4, 32)
@@ -1560,8 +1550,6 @@ class DenseTest(testing.TestCase):
 
     def test_torch_fast_path_symbolic_input(self):
         """Verify Dense works with symbolic KerasTensor on torch backend."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
         inputs = layers.Input(shape=(10,))
         outputs = layers.Dense(5)(inputs)
         self.assertEqual(outputs.shape, (None, 5))
@@ -1573,10 +1561,6 @@ class DenseTest(testing.TestCase):
         ops.matmul performs implicitly. On CUDA with CPU inputs this raised:
             RuntimeError: Expected all tensors to be on the same device
         """
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         # Build Dense and EinsumDense layers (weights land on the default
         # device).
         dense = layers.Dense(8)
@@ -1608,10 +1592,6 @@ class DenseTest(testing.TestCase):
         scope, so the two paths must agree even when the kernel lives
         elsewhere.
         """
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         from keras.src.backend.torch.core import device_scope
 
         dense = layers.Dense(6)
@@ -1631,10 +1611,6 @@ class DenseTest(testing.TestCase):
 
     def test_torch_fast_path_mixed_float16(self):
         """Fast-path vs slow-path equivalence with mixed_float16 policy."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         torch.manual_seed(0)
         layer = layers.Dense(32, activation="relu", dtype="mixed_float16")
         x_t = torch.randn(4, 64)
@@ -1650,10 +1626,6 @@ class DenseTest(testing.TestCase):
         result as the slow path, not a kernel silently downcast to the
         input's dtype (which truncates a float kernel to int -> garbage
         near-all-zero output)."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         for x_t in [
             torch.arange(8, dtype=torch.int32).reshape(2, 4),
             torch.randint(0, 255, (2, 4), dtype=torch.uint8),

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1491,20 +1491,43 @@ class DenseTest(testing.TestCase):
         self.assertAllClose(out_fast, out_slow, rtol=1e-5, atol=1e-5)
 
     def test_torch_fast_path_lora_stays_slow(self):
-        """LoRA-enabled Dense must NOT use the fast path."""
+        """LoRA-enabled Dense must NOT use the fast path.
+
+        Asserting non-NaN/non-Inf alone wouldn't catch the fast path
+        leaking through: lora_kernel_b initializes to zeros, so even a
+        base-kernel-only (fast-path) computation would be finite and,
+        with the default zero delta, numerically identical. Assign a
+        nonzero delta and compare against the base-kernel-only result
+        directly, so a leaked fast path is provably wrong, not just
+        NaN/Inf.
+        """
         if backend.backend() != "torch":
             self.skipTest("torch backend only")
         import torch
 
         torch.manual_seed(0)
-        layer = layers.Dense(32, activation="relu")
+        layer = layers.Dense(32)
         x_t = torch.randn(4, 64)
         _ = layer(x_t)
         layer.enable_lora(rank=4)
         self.assertTrue(layer.lora_enabled, "LoRA should be enabled")
+        # Force a nonzero LoRA delta (default init is zeros).
+        layer.lora_kernel_a.assign(torch.randn(64, 4))
+        layer.lora_kernel_b.assign(torch.randn(4, 32))
+
         out = layer(x_t)
+        base_kernel_only = torch.nn.functional.linear(
+            x_t, layer._kernel.value.t(), layer.bias.value
+        )
         self.assertFalse(torch.isnan(out).any(), "LoRA output must not be NaN")
         self.assertFalse(torch.isinf(out).any(), "LoRA output must not be Inf")
+        # A leaked fast path would equal the base-kernel-only computation;
+        # the LoRA-adjusted output must differ from it.
+        self.assertFalse(
+            torch.allclose(out, base_kernel_only, atol=1e-5),
+            "LoRA output must differ from a base-kernel-only (fast path) "
+            "computation, or the fast path leaked through",
+        )
 
     def test_torch_fast_path_flag_false_non_torch(self):
         """_torch_backend flag must be False when backend != torch."""
@@ -1624,3 +1647,26 @@ class DenseTest(testing.TestCase):
         out_slow = layer(x_t)
         layer._torch_backend = True
         self.assertAllClose(out_fast, out_slow, rtol=1e-3, atol=1e-3)
+
+    def test_torch_fast_path_dtype_mismatch_matches_slow_path(self):
+        """Integer/bool inputs into a float layer must produce the same
+        result as the slow path, not a kernel silently downcast to the
+        input's dtype (which truncates a float kernel to int -> garbage
+        near-all-zero output)."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        for x_t in [
+            torch.arange(8, dtype=torch.int32).reshape(2, 4),
+            torch.randint(0, 255, (2, 4), dtype=torch.uint8),
+            torch.tensor([[True, False, True, False]] * 2),
+        ]:
+            layer = layers.Dense(3)
+            out_fast = layer(x_t)
+            layer._torch_backend = False
+            out_slow = layer(x_t)
+            layer._torch_backend = True
+            self.assertEqual(out_fast.dtype, out_slow.dtype)
+            self.assertTrue(torch.isfinite(out_fast).all())
+            self.assertAllClose(out_fast, out_slow, rtol=1e-4, atol=1e-4)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1454,6 +1454,15 @@ class DenseTest(testing.TestCase):
         )
 
 
+class DoubledKernelDense(layers.Dense):
+    """A Dense subclass overriding `kernel`, used to verify the torch fast
+    path doesn't silently bypass a subclass's override of it."""
+
+    @property
+    def kernel(self):
+        return super().kernel * 2
+
+
 @pytest.mark.skipif(backend.backend() != "torch", reason="torch backend only")
 class DenseTorchFastPathTest(testing.TestCase):
     @parameterized.named_parameters(
@@ -1538,12 +1547,6 @@ class DenseTorchFastPathTest(testing.TestCase):
         silently bypassed by the fast path, which would otherwise read
         `self._kernel.value` directly instead of the overridden property.
         """
-
-        class DoubledKernelDense(layers.Dense):
-            @property
-            def kernel(self):
-                return super().kernel * 2
-
         torch.manual_seed(0)
         layer = DoubledKernelDense(8, use_bias=False)
         x_t = torch.randn(4, 6)

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1581,6 +1581,34 @@ class DenseTest(testing.TestCase):
         self.assertEqual(out_dense.cpu().shape, (2, 8))
         self.assertEqual(out_einsum.cpu().shape, (2, 8))
 
+    def test_torch_fast_path_honors_device_scope(self):
+        """Fast path must honor an active `device_scope`, not just align to
+        the kernel's device: the slow (ops.matmul) path always resolves its
+        target device through `get_device()`, which reflects an active
+        scope, so the two paths must agree even when the kernel lives
+        elsewhere.
+        """
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        from keras.src.backend.torch.core import device_scope
+
+        dense = layers.Dense(6)
+        x = torch.randn(2, 5)
+        dense(x)  # build weights on the default device
+
+        with device_scope("cpu"):
+            out_fast = dense(x, training=False)
+        dense._torch_backend = False
+        with device_scope("cpu"):
+            out_slow = dense(x, training=False)
+        dense._torch_backend = True
+
+        self.assertEqual(str(out_fast.device), "cpu")
+        self.assertEqual(str(out_fast.device), str(out_slow.device))
+        self.assertAllClose(out_fast, out_slow)
+
     def test_torch_fast_path_mixed_float16(self):
         """Fast-path vs slow-path equivalence with mixed_float16 policy."""
         if backend.backend() != "torch":

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1516,6 +1516,7 @@ class DenseTest(testing.TestCase):
         layer.lora_kernel_b.assign(torch.randn(4, 32))
 
         out = layer(x_t)
+        x_t = x_t.to(layer._kernel.value.device)
         base_kernel_only = torch.nn.functional.linear(
             x_t, layer._kernel.value.t(), layer.bias.value
         )

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1533,6 +1533,25 @@ class DenseTorchFastPathTest(testing.TestCase):
             "computation, or the fast path leaked through",
         )
 
+    def test_torch_fast_path_skipped_for_subclass(self):
+        """A Dense subclass overriding `kernel` must not have that override
+        silently bypassed by the fast path, which would otherwise read
+        `self._kernel.value` directly instead of the overridden property.
+        """
+
+        class DoubledKernelDense(layers.Dense):
+            @property
+            def kernel(self):
+                return super().kernel * 2
+
+        torch.manual_seed(0)
+        layer = DoubledKernelDense(8, use_bias=False)
+        x_t = torch.randn(4, 6)
+        _ = layer(x_t)
+        out = layer(x_t)
+        expected = torch.matmul(x_t.to(layer.kernel.device), layer.kernel)
+        self.assertAllClose(out, expected, rtol=1e-5, atol=1e-5)
+
     def test_torch_fast_path_manual_kernel_check(self):
         """Verify Dense fast path: F.linear(x, W.t(), b) == x @ W + b."""
         torch.manual_seed(42)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -9,12 +9,12 @@ from keras.src import activations
 from keras.src import backend
 from keras.src import constraints
 from keras.src import dtype_policies
-from keras.src.backend.common import global_state
 from keras.src import initializers
 from keras.src import ops
 from keras.src import quantizers
 from keras.src import regularizers
 from keras.src.api_export import keras_export
+from keras.src.backend.common import global_state
 from keras.src.initializers.random_initializers import VarianceScaling
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
@@ -338,19 +338,21 @@ class EinsumDense(Layer):
                     target_device = kernel.device
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
-                if inputs.dtype != kernel.dtype:
-                    kernel = kernel.to(inputs.dtype)
-                x = self._torch.einsum(self.equation, inputs, kernel)
-                if self.bias is not None:
-                    bias = self.bias.value
-                    if bias.device != target_device:
-                        bias = bias.to(target_device)
-                    if inputs.dtype != bias.dtype:
-                        bias = bias.to(inputs.dtype)
-                    x = x + bias
-                if self.activation is not None:
-                    x = self.activation(x)
-                return x
+                # Do not cast the kernel toward inputs.dtype: that's a
+                # downcast, not a promotion, and silently corrupts the
+                # result for e.g. integer inputs (float kernel truncated
+                # to int -> near-all-zeros). Let the standard path's
+                # dtype-promotion rules handle any mismatch instead.
+                if inputs.dtype == kernel.dtype:
+                    x = self._torch.einsum(self.equation, inputs, kernel)
+                    if self.bias is not None:
+                        bias = self.bias.value
+                        if bias.device != target_device:
+                            bias = bias.to(target_device)
+                        x = x + bias
+                    if self.activation is not None:
+                        x = self.activation(x)
+                    return x
         # Standard path: non-torch, LoRA, or torch.compile.
         x = ops.einsum(self.equation, inputs, self.kernel)
         if self.bias is not None:

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -329,10 +329,15 @@ class EinsumDense(Layer):
         # going through Keras's ops dispatch. This only applies to a plain
         # eager forward: quantized layers route through quantized_call()
         # before ever reaching call(), LoRA needs the ops path for its
-        # additive branch, and torch.compile tracing is skipped because
-        # meta-device weights make torch.einsum raise under fake tensors.
+        # additive branch, torch.compile tracing is skipped because
+        # meta-device weights make torch.einsum raise under fake tensors,
+        # and an EinsumDense subclass is excluded because it may override
+        # the `kernel` property (a supported extension point) with logic
+        # this path would silently bypass by reading `self._kernel.value`
+        # directly.
         if (
             self._torch_backend
+            and type(self) is EinsumDense
             and not self.lora_enabled
             and not self._torch_compiling()
         ):

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -325,7 +325,8 @@ class EinsumDense(Layer):
         # meta-device weights make torch.einsum raise under fake tensors.
         if self._torch_backend and not self.lora_enabled:
             if not (
-                hasattr(torch.compiler, "is_compiling")
+                hasattr(torch, "compiler")
+                and hasattr(torch.compiler, "is_compiling")
                 and torch.compiler.is_compiling()
             ):
                 kernel = self._kernel.value

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -350,13 +350,14 @@ class EinsumDense(Layer):
                 scope_device = global_state.get_global_attribute(
                     "torch_device", None
                 )
-                target_device = (
-                    torch.device(scope_device)
-                    if scope_device is not None
-                    else kernel.device
-                )
-                if kernel.device != target_device:
-                    kernel = kernel.to(target_device)
+                # kernel is already on kernel.device by definition, so only
+                # a scope override can actually move it - skip the compare
+                # entirely otherwise instead of comparing a value to itself.
+                target_device = kernel.device
+                if scope_device is not None:
+                    target_device = torch.device(scope_device)
+                    if kernel.device != target_device:
+                        kernel = kernel.to(target_device)
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
                 x = torch.einsum(self.equation, inputs, kernel)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -233,6 +233,12 @@ class EinsumDense(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank, lora_alpha=self.lora_alpha)
+        # Flag set at build; lora_enabled re-checked at call time.
+        self._torch_backend = backend.backend() == "torch"
+        if self._torch_backend:
+            import torch as _torch
+
+            self._torch = _torch
 
     @property
     def kernel(self):
@@ -310,6 +316,30 @@ class EinsumDense(Layer):
         return tuple(full_output_shape)
 
     def call(self, inputs, training=None):
+        # Fast path: torch.einsum bypasses Keras ops dispatch.
+        # Quantization routes to quantized_call() before reaching here.
+        if self._torch_backend and not self.lora_enabled:
+            # Skip under torch.compile: meta-device weights cause fake-tensor
+            # issues with torch.einsum.
+            if not (
+                hasattr(self._torch.compiler, "is_compiling")
+                and self._torch.compiler.is_compiling()
+            ):
+                kernel = self._kernel.value
+                if inputs.device != kernel.device:
+                    inputs = inputs.to(kernel.device)
+                if inputs.dtype != kernel.dtype:
+                    kernel = kernel.to(inputs.dtype)
+                x = self._torch.einsum(self.equation, inputs, kernel)
+                if self.bias is not None:
+                    bias = self.bias.value
+                    if inputs.dtype != bias.dtype:
+                        bias = bias.to(inputs.dtype)
+                    x = x + bias
+                if self.activation is not None:
+                    x = self.activation(x)
+                return x
+        # Standard path: non-torch, LoRA, or torch.compile.
         x = ops.einsum(self.equation, inputs, self.kernel)
         if self.bias is not None:
             x = ops.add(x, self.bias)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -9,6 +9,7 @@ from keras.src import activations
 from keras.src import backend
 from keras.src import constraints
 from keras.src import dtype_policies
+from keras.src.backend.common import global_state
 from keras.src import initializers
 from keras.src import ops
 from keras.src import quantizers
@@ -326,13 +327,24 @@ class EinsumDense(Layer):
                 and self._torch.compiler.is_compiling()
             ):
                 kernel = self._kernel.value
-                if inputs.device != kernel.device:
-                    inputs = inputs.to(kernel.device)
+                scope_device = global_state.get_global_attribute(
+                    "torch_device", None
+                )
+                if scope_device is not None:
+                    target_device = self._torch.device(scope_device)
+                    if kernel.device != target_device:
+                        kernel = kernel.to(target_device)
+                else:
+                    target_device = kernel.device
+                if inputs.device != target_device:
+                    inputs = inputs.to(target_device)
                 if inputs.dtype != kernel.dtype:
                     kernel = kernel.to(inputs.dtype)
                 x = self._torch.einsum(self.equation, inputs, kernel)
                 if self.bias is not None:
                     bias = self.bias.value
+                    if bias.device != target_device:
+                        bias = bias.to(target_device)
                     if inputs.dtype != bias.dtype:
                         bias = bias.to(inputs.dtype)
                     x = x + bias

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -317,11 +317,13 @@ class EinsumDense(Layer):
         return tuple(full_output_shape)
 
     def call(self, inputs, training=None):
-        # Fast path: torch.einsum bypasses Keras ops dispatch.
-        # Quantization routes to quantized_call() before reaching here.
+        # On the torch backend, call torch.einsum directly rather than
+        # going through Keras's ops dispatch. This only applies to a plain
+        # eager forward: quantized layers route through quantized_call()
+        # before ever reaching call(), LoRA needs the ops path for its
+        # additive branch, and torch.compile tracing is skipped because
+        # meta-device weights make torch.einsum raise under fake tensors.
         if self._torch_backend and not self.lora_enabled:
-            # Skip under torch.compile: meta-device weights cause fake-tensor
-            # issues with torch.einsum.
             if not (
                 hasattr(torch.compiler, "is_compiling")
                 and torch.compiler.is_compiling()
@@ -338,11 +340,13 @@ class EinsumDense(Layer):
                     target_device = kernel.device
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
-                # Do not cast the kernel toward inputs.dtype: that's a
-                # downcast, not a promotion, and silently corrupts the
-                # result for e.g. integer inputs (float kernel truncated
-                # to int -> near-all-zeros). Let the standard path's
-                # dtype-promotion rules handle any mismatch instead.
+                # A dtype mismatch falls through to the standard path below
+                # rather than casting the kernel toward the input's dtype
+                # here: that would be a downcast, not a promotion, and it
+                # would silently corrupt the result for integer inputs (a
+                # float kernel truncated to int becomes near-all-zeros).
+                # The standard path already applies the correct
+                # dtype-promotion rules.
                 if inputs.dtype == kernel.dtype:
                     x = torch.einsum(self.equation, inputs, kernel)
                     if self.bias is not None:
@@ -353,7 +357,6 @@ class EinsumDense(Layer):
                     if self.activation is not None:
                         x = self.activation(x)
                     return x
-        # Standard path: non-torch, LoRA, or torch.compile.
         x = ops.einsum(self.equation, inputs, self.kernel)
         if self.bias is not None:
             x = ops.add(x, self.bias)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -23,6 +23,9 @@ from keras.src.quantizers.quantization_config import get_block_size_for_layer
 from keras.src.quantizers.quantizers import dequantize_with_sz_map
 from keras.src.saving import serialization_lib
 
+if backend.backend() == "torch":
+    import torch
+
 
 @keras_export("keras.layers.EinsumDense")
 class EinsumDense(Layer):
@@ -234,12 +237,9 @@ class EinsumDense(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank, lora_alpha=self.lora_alpha)
-        # Flag set at build; lora_enabled re-checked at call time.
+        # Cache the torch fast-path eligibility at build time; `lora_enabled`
+        # is re-checked at call time.
         self._torch_backend = backend.backend() == "torch"
-        if self._torch_backend:
-            import torch as _torch
-
-            self._torch = _torch
 
     @property
     def kernel(self):
@@ -323,15 +323,15 @@ class EinsumDense(Layer):
             # Skip under torch.compile: meta-device weights cause fake-tensor
             # issues with torch.einsum.
             if not (
-                hasattr(self._torch.compiler, "is_compiling")
-                and self._torch.compiler.is_compiling()
+                hasattr(torch.compiler, "is_compiling")
+                and torch.compiler.is_compiling()
             ):
                 kernel = self._kernel.value
                 scope_device = global_state.get_global_attribute(
                     "torch_device", None
                 )
                 if scope_device is not None:
-                    target_device = self._torch.device(scope_device)
+                    target_device = torch.device(scope_device)
                     if kernel.device != target_device:
                         kernel = kernel.to(target_device)
                 else:
@@ -344,7 +344,7 @@ class EinsumDense(Layer):
                 # to int -> near-all-zeros). Let the standard path's
                 # dtype-promotion rules handle any mismatch instead.
                 if inputs.dtype == kernel.dtype:
-                    x = self._torch.einsum(self.equation, inputs, kernel)
+                    x = torch.einsum(self.equation, inputs, kernel)
                     if self.bias is not None:
                         bias = self.bias.value
                         if bias.device != target_device:

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -316,6 +316,14 @@ class EinsumDense(Layer):
         )
         return tuple(full_output_shape)
 
+    @staticmethod
+    def _torch_compiling():
+        return (
+            hasattr(torch, "compiler")
+            and hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
+        )
+
     def call(self, inputs, training=None):
         # On the torch backend, call torch.einsum directly rather than
         # going through Keras's ops dispatch. This only applies to a plain
@@ -323,41 +331,43 @@ class EinsumDense(Layer):
         # before ever reaching call(), LoRA needs the ops path for its
         # additive branch, and torch.compile tracing is skipped because
         # meta-device weights make torch.einsum raise under fake tensors.
-        if self._torch_backend and not self.lora_enabled:
-            if not (
-                hasattr(torch, "compiler")
-                and hasattr(torch.compiler, "is_compiling")
-                and torch.compiler.is_compiling()
-            ):
-                kernel = self._kernel.value
+        if (
+            self._torch_backend
+            and not self.lora_enabled
+            and not self._torch_compiling()
+        ):
+            kernel = self._kernel.value
+            # A dtype mismatch falls through to the standard path below
+            # rather than casting the kernel toward the input's dtype here:
+            # that would be a downcast, not a promotion, and it would
+            # silently corrupt the result for integer inputs (a float
+            # kernel truncated to int becomes near-all-zeros). The standard
+            # path already applies the correct dtype-promotion rules.
+            # Checked before any device work below, since dtype is
+            # unaffected by device placement and a mismatch skips that
+            # work entirely.
+            if inputs.dtype == kernel.dtype:
                 scope_device = global_state.get_global_attribute(
                     "torch_device", None
                 )
-                if scope_device is not None:
-                    target_device = torch.device(scope_device)
-                    if kernel.device != target_device:
-                        kernel = kernel.to(target_device)
-                else:
-                    target_device = kernel.device
+                target_device = (
+                    torch.device(scope_device)
+                    if scope_device is not None
+                    else kernel.device
+                )
+                if kernel.device != target_device:
+                    kernel = kernel.to(target_device)
                 if inputs.device != target_device:
                     inputs = inputs.to(target_device)
-                # A dtype mismatch falls through to the standard path below
-                # rather than casting the kernel toward the input's dtype
-                # here: that would be a downcast, not a promotion, and it
-                # would silently corrupt the result for integer inputs (a
-                # float kernel truncated to int becomes near-all-zeros).
-                # The standard path already applies the correct
-                # dtype-promotion rules.
-                if inputs.dtype == kernel.dtype:
-                    x = torch.einsum(self.equation, inputs, kernel)
-                    if self.bias is not None:
-                        bias = self.bias.value
-                        if bias.device != target_device:
-                            bias = bias.to(target_device)
-                        x = x + bias
-                    if self.activation is not None:
-                        x = self.activation(x)
-                    return x
+                x = torch.einsum(self.equation, inputs, kernel)
+                if self.bias is not None:
+                    bias = self.bias.value
+                    if bias.device != target_device:
+                        bias = bias.to(target_device)
+                    x = x + bias
+                if self.activation is not None:
+                    x = self.activation(x)
+                return x
         x = ops.einsum(self.equation, inputs, self.kernel)
         if self.bias is not None:
             x = ops.add(x, self.bias)

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1852,6 +1852,15 @@ class EinsumDenseTest(testing.TestCase):
         self.assertAllClose(y_before, y_after)
 
 
+class DoubledKernelEinsumDense(layers.EinsumDense):
+    """An EinsumDense subclass overriding `kernel`, used to verify the
+    torch fast path doesn't silently bypass a subclass's override of it."""
+
+    @property
+    def kernel(self):
+        return super().kernel * 2
+
+
 @pytest.mark.skipif(backend.backend() != "torch", reason="torch backend only")
 class EinsumDenseTorchFastPathTest(testing.TestCase):
     @parameterized.named_parameters(
@@ -1937,12 +1946,6 @@ class EinsumDenseTorchFastPathTest(testing.TestCase):
         read `self._kernel.value` directly instead of the overridden
         property.
         """
-
-        class DoubledKernelEinsumDense(layers.EinsumDense):
-            @property
-            def kernel(self):
-                return super().kernel * 2
-
         torch.manual_seed(0)
         layer = DoubledKernelEinsumDense(
             "ab,bc->ac", output_shape=8, bias_axes=None

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1931,6 +1931,30 @@ class EinsumDenseTorchFastPathTest(testing.TestCase):
             "computation, or the fast path leaked through",
         )
 
+    def test_torch_fast_path_skipped_for_subclass(self):
+        """An EinsumDense subclass overriding `kernel` must not have that
+        override silently bypassed by the fast path, which would otherwise
+        read `self._kernel.value` directly instead of the overridden
+        property.
+        """
+
+        class DoubledKernelEinsumDense(layers.EinsumDense):
+            @property
+            def kernel(self):
+                return super().kernel * 2
+
+        torch.manual_seed(0)
+        layer = DoubledKernelEinsumDense(
+            "ab,bc->ac", output_shape=8, bias_axes=None
+        )
+        x_t = torch.randn(4, 6)
+        _ = layer(x_t)
+        out = layer(x_t)
+        expected = torch.einsum(
+            "ab,bc->ac", x_t.to(layer.kernel.device), layer.kernel
+        )
+        self.assertAllClose(out, expected, rtol=1e-5, atol=1e-5)
+
     def test_torch_fast_path_manual_kernel_check(self):
         """Manually verify fast path result against the expected formula."""
         torch.manual_seed(42)

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1933,6 +1933,34 @@ class EinsumDenseTest(testing.TestCase):
         out_fast = layer(x_t)
         self.assertAllClose(out_fast, expected, rtol=1e-5, atol=1e-5)
 
+    def test_torch_fast_path_honors_device_scope(self):
+        """Fast path must honor an active `device_scope`, not just align to
+        the kernel's device: the slow (ops.einsum) path always resolves its
+        target device through `get_device()`, which reflects an active
+        scope, so the two paths must agree even when the kernel lives
+        elsewhere.
+        """
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        from keras.src.backend.torch.core import device_scope
+
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=6, bias_axes="c")
+        x = torch.randn(2, 5)
+        layer(x)  # build weights on the default device
+
+        with device_scope("cpu"):
+            out_fast = layer(x, training=False)
+        layer._torch_backend = False
+        with device_scope("cpu"):
+            out_slow = layer(x, training=False)
+        layer._torch_backend = True
+
+        self.assertEqual(str(out_fast.device), "cpu")
+        self.assertEqual(str(out_fast.device), str(out_slow.device))
+        self.assertAllClose(out_fast, out_slow)
+
     def test_torch_fast_path_symbolic_input(self):
         """EinsumDense must not crash on symbolic KerasTensor (torch)."""
         if backend.backend() != "torch":

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1926,6 +1926,7 @@ class EinsumDenseTest(testing.TestCase):
         layer.lora_kernel_b.assign(torch.randn(4, 32))
 
         out = layer(x_t)
+        x_t = x_t.to(layer._kernel.value.device)
         base_kernel_only = (
             torch.einsum("ab,bc->ac", x_t, layer._kernel.value)
             + layer.bias.value

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -25,6 +25,9 @@ from keras.src.quantizers.quantizers import AbsMaxQuantizer
 from keras.src.saving.saving_api import load_model
 from keras.src.utils.rng_utils import set_random_seed
 
+if backend.backend() == "torch":
+    import torch
+
 
 class EinsumDenseTest(testing.TestCase):
     @parameterized.named_parameters(
@@ -1848,6 +1851,9 @@ class EinsumDenseTest(testing.TestCase):
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
 
+
+@pytest.mark.skipif(backend.backend() != "torch", reason="torch backend only")
+class EinsumDenseTorchFastPathTest(testing.TestCase):
     @parameterized.named_parameters(
         ("2d_matmul", "ab,bc->ac", 64, "c", (8, 128)),
         ("3d_matmul", "abc,cd->abd", (16, 64), "d", (4, 16, 128)),
@@ -1857,10 +1863,6 @@ class EinsumDenseTest(testing.TestCase):
         self, equation, output_shape, bias_axes, input_shape
     ):
         """Fast-path torch.einsum vs ops.einsum numeric equivalence."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         torch.manual_seed(99)
         layer = layers.EinsumDense(
             equation,
@@ -1882,10 +1884,6 @@ class EinsumDenseTest(testing.TestCase):
 
     def test_torch_fast_path_no_bias(self):
         """EinsumDense fast-path with no bias."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         layer = layers.EinsumDense("ab,bc->ac", output_shape=32, bias_axes=None)
         x_t = torch.randn(4, 64)
         _ = layer(x_t)
@@ -1906,10 +1904,6 @@ class EinsumDenseTest(testing.TestCase):
         directly, so a leaked fast path is provably wrong, not just
         NaN/Inf.
         """
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         layer = layers.EinsumDense(
             "ab,bc->ac", output_shape=32, bias_axes="c", activation=None
         )
@@ -1939,10 +1933,6 @@ class EinsumDenseTest(testing.TestCase):
 
     def test_torch_fast_path_manual_kernel_check(self):
         """Manually verify fast path result against the expected formula."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         torch.manual_seed(42)
         layer = layers.EinsumDense("ab,bc->ac", output_shape=16, bias_axes="c")
         x_t = torch.randn(4, 32)
@@ -1961,10 +1951,6 @@ class EinsumDenseTest(testing.TestCase):
         scope, so the two paths must agree even when the kernel lives
         elsewhere.
         """
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         from keras.src.backend.torch.core import device_scope
 
         layer = layers.EinsumDense("ab,bc->ac", output_shape=6, bias_axes="c")
@@ -1984,18 +1970,12 @@ class EinsumDenseTest(testing.TestCase):
 
     def test_torch_fast_path_symbolic_input(self):
         """EinsumDense must not crash on symbolic KerasTensor (torch)."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
         inputs = layers.Input(shape=(10,))
         outputs = layers.EinsumDense("ab,bc->ac", output_shape=5)(inputs)
         self.assertEqual(outputs.shape, (None, 5))
 
     def test_torch_fast_path_mixed_float16(self):
         """Fast-path vs slow-path equivalence with mixed_float16 policy."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         torch.manual_seed(0)
         layer = layers.EinsumDense(
             "ab,bc->ac",
@@ -2019,10 +1999,6 @@ class EinsumDenseTest(testing.TestCase):
         downcast the kernel to the input's dtype (which would either
         truncate a float kernel to int - garbage near-zero output - or
         diverge from the slow path's own error/success behavior)."""
-        if backend.backend() != "torch":
-            self.skipTest("torch backend only")
-        import torch
-
         for x_t in [
             # torch.einsum does not promote int/float operands, so both
             # paths must fail the same way here.

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1926,9 +1926,10 @@ class EinsumDenseTest(testing.TestCase):
         layer.lora_kernel_b.assign(torch.randn(4, 32))
 
         out = layer(x_t)
-        base_kernel_only = torch.einsum(
-            "ab,bc->ac", x_t, layer._kernel.value
-        ) + layer.bias.value
+        base_kernel_only = (
+            torch.einsum("ab,bc->ac", x_t, layer._kernel.value)
+            + layer.bias.value
+        )
         self.assertFalse(torch.isnan(out).any())
         self.assertFalse(torch.isinf(out).any())
         # A leaked fast path would equal the base-kernel-only computation;

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1900,7 +1900,16 @@ class EinsumDenseTest(testing.TestCase):
         self.assertAllClose(out_fast, out_slow, rtol=1e-5, atol=1e-5)
 
     def test_torch_fast_path_lora_stays_slow(self):
-        """LoRA-enabled EinsumDense must NOT use the fast path."""
+        """LoRA-enabled EinsumDense must NOT use the fast path.
+
+        Asserting non-NaN/non-Inf alone wouldn't catch the fast path
+        leaking through: lora_kernel_b initializes to zeros, so even a
+        base-kernel-only (fast-path) computation would be finite and,
+        with the default zero delta, numerically identical. Assign a
+        nonzero delta and compare against the base-kernel-only result
+        directly, so a leaked fast path is provably wrong, not just
+        NaN/Inf.
+        """
         if backend.backend() != "torch":
             self.skipTest("torch backend only")
         import torch
@@ -1912,9 +1921,23 @@ class EinsumDenseTest(testing.TestCase):
         _ = layer(x_t)
         layer.enable_lora(rank=4)
         self.assertTrue(layer.lora_enabled)
+        # Force a nonzero LoRA delta (default init is zeros).
+        layer.lora_kernel_a.assign(torch.randn(64, 4))
+        layer.lora_kernel_b.assign(torch.randn(4, 32))
+
         out = layer(x_t)
+        base_kernel_only = torch.einsum(
+            "ab,bc->ac", x_t, layer._kernel.value
+        ) + layer.bias.value
         self.assertFalse(torch.isnan(out).any())
         self.assertFalse(torch.isinf(out).any())
+        # A leaked fast path would equal the base-kernel-only computation;
+        # the LoRA-adjusted output must differ from it.
+        self.assertFalse(
+            torch.allclose(out, base_kernel_only, atol=1e-5),
+            "LoRA output must differ from a base-kernel-only (fast path) "
+            "computation, or the fast path leaked through",
+        )
 
     def test_torch_fast_path_manual_kernel_check(self):
         """Manually verify fast path result against the expected formula."""
@@ -1990,3 +2013,48 @@ class EinsumDenseTest(testing.TestCase):
         out_slow = layer(x_t)
         layer._torch_backend = True
         self.assertAllClose(out_fast, out_slow, rtol=1e-3, atol=1e-3)
+
+    def test_torch_fast_path_dtype_mismatch_matches_slow_path(self):
+        """A dtype-mismatched input must behave identically on the fast
+        and slow paths: either both raise the same error, or both
+        succeed with the same result. The fast path must never silently
+        downcast the kernel to the input's dtype (which would either
+        truncate a float kernel to int - garbage near-zero output - or
+        diverge from the slow path's own error/success behavior)."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        for x_t in [
+            # torch.einsum itself does not promote int/float operands
+            # (a separate, pre-existing gap in ops.einsum unrelated to
+            # this PR) - both paths must fail the same way here.
+            torch.arange(8, dtype=torch.int32).reshape(2, 4),
+            torch.randint(0, 255, (2, 4), dtype=torch.uint8),
+            # float16 vs float32 kernel: promotion succeeds on both
+            # paths.
+            torch.randn(2, 4, dtype=torch.float16),
+        ]:
+            layer = layers.EinsumDense(
+                "ab,bc->ac", output_shape=3, bias_axes="c", activation=None
+            )
+            try:
+                out_fast = layer(x_t)
+                fast_result = ("ok", out_fast.dtype)
+            except Exception as e:
+                fast_result = ("error", type(e))
+            layer._torch_backend = False
+            try:
+                out_slow = layer(x_t)
+                slow_result = ("ok", out_slow.dtype)
+            except Exception as e:
+                slow_result = ("error", type(e))
+            layer._torch_backend = True
+            self.assertEqual(
+                fast_result,
+                slow_result,
+                msg=f"dtype={x_t.dtype}: fast path diverged from slow path",
+            )
+            if fast_result[0] == "ok":
+                self.assertTrue(torch.isfinite(out_fast).all())
+                self.assertAllClose(out_fast, out_slow, rtol=1e-3, atol=1e-3)

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1848,10 +1848,6 @@ class EinsumDenseTest(testing.TestCase):
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
 
-    # ------------------------------------------------------------------
-    # Torch fast-path numeric-equivalence tests
-    # ------------------------------------------------------------------
-
     @parameterized.named_parameters(
         ("2d_matmul", "ab,bc->ac", 64, "c", (8, 128)),
         ("3d_matmul", "abc,cd->abd", (16, 64), "d", (4, 16, 128)),
@@ -2028,9 +2024,8 @@ class EinsumDenseTest(testing.TestCase):
         import torch
 
         for x_t in [
-            # torch.einsum itself does not promote int/float operands
-            # (a separate, pre-existing gap in ops.einsum unrelated to
-            # this PR) - both paths must fail the same way here.
+            # torch.einsum does not promote int/float operands, so both
+            # paths must fail the same way here.
             torch.arange(8, dtype=torch.int32).reshape(2, 4),
             torch.randint(0, 255, (2, 4), dtype=torch.uint8),
             # float16 vs float32 kernel: promotion succeeds on both

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1847,3 +1847,118 @@ class EinsumDenseTest(testing.TestCase):
         # Verify outputs match
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
+
+    # ------------------------------------------------------------------
+    # Torch fast-path numeric-equivalence tests
+    # ------------------------------------------------------------------
+
+    @parameterized.named_parameters(
+        ("2d_matmul", "ab,bc->ac", 64, "c", (8, 128)),
+        ("3d_matmul", "abc,cd->abd", (16, 64), "d", (4, 16, 128)),
+        ("ellipsis", "...x,xy->...y", 64, "y", (4, 8, 128)),
+    )
+    def test_torch_fast_path_fast_vs_slow(
+        self, equation, output_shape, bias_axes, input_shape
+    ):
+        """Fast-path torch.einsum vs ops.einsum numeric equivalence."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        torch.manual_seed(99)
+        layer = layers.EinsumDense(
+            equation,
+            output_shape=output_shape,
+            bias_axes=bias_axes,
+            activation="gelu",
+        )
+        x_t = torch.randn(*input_shape)
+        _ = layer(x_t)
+        self.assertTrue(
+            getattr(layer, "_torch_backend", False),
+            "EinsumDense._torch_backend must be True on torch backend",
+        )
+        out_fast = layer(x_t)
+        layer._torch_backend = False
+        out_slow = layer(x_t)
+        layer._torch_backend = True
+        self.assertAllClose(out_fast, out_slow, rtol=1e-5, atol=1e-5)
+
+    def test_torch_fast_path_no_bias(self):
+        """EinsumDense fast-path with no bias."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=32, bias_axes=None)
+        x_t = torch.randn(4, 64)
+        _ = layer(x_t)
+        out_fast = layer(x_t)
+        layer._torch_backend = False
+        out_slow = layer(x_t)
+        layer._torch_backend = True
+        self.assertAllClose(out_fast, out_slow, rtol=1e-5, atol=1e-5)
+
+    def test_torch_fast_path_lora_stays_slow(self):
+        """LoRA-enabled EinsumDense must NOT use the fast path."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        layer = layers.EinsumDense(
+            "ab,bc->ac", output_shape=32, bias_axes="c", activation=None
+        )
+        x_t = torch.randn(4, 64)
+        _ = layer(x_t)
+        layer.enable_lora(rank=4)
+        self.assertTrue(layer.lora_enabled)
+        out = layer(x_t)
+        self.assertFalse(torch.isnan(out).any())
+        self.assertFalse(torch.isinf(out).any())
+
+    def test_torch_fast_path_manual_kernel_check(self):
+        """Manually verify fast path result against the expected formula."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        torch.manual_seed(42)
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=16, bias_axes="c")
+        x_t = torch.randn(4, 32)
+        _ = layer(x_t)
+        W = layer._kernel.value
+        b = layer.bias.value
+        x_t = x_t.to(W.device)
+        expected = torch.einsum("ab,bc->ac", x_t, W) + b
+        out_fast = layer(x_t)
+        self.assertAllClose(out_fast, expected, rtol=1e-5, atol=1e-5)
+
+    def test_torch_fast_path_symbolic_input(self):
+        """EinsumDense must not crash on symbolic KerasTensor (torch)."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        inputs = layers.Input(shape=(10,))
+        outputs = layers.EinsumDense("ab,bc->ac", output_shape=5)(inputs)
+        self.assertEqual(outputs.shape, (None, 5))
+
+    def test_torch_fast_path_mixed_float16(self):
+        """Fast-path vs slow-path equivalence with mixed_float16 policy."""
+        if backend.backend() != "torch":
+            self.skipTest("torch backend only")
+        import torch
+
+        torch.manual_seed(0)
+        layer = layers.EinsumDense(
+            "ab,bc->ac",
+            output_shape=32,
+            bias_axes="c",
+            activation="relu",
+            dtype="mixed_float16",
+        )
+        x_t = torch.randn(4, 64)
+        _ = layer(x_t)
+        out_fast = layer(x_t)
+        layer._torch_backend = False
+        out_slow = layer(x_t)
+        layer._torch_backend = True
+        self.assertAllClose(out_fast, out_slow, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
Closes #23276

## Summary

On the torch backend, `Dense.call` and `EinsumDense.call` now dispatch directly to `torch.nn.functional.linear` / `torch.einsum` for the plain, unquantized, non-LoRA eager forward pass, skipping Keras's generic `ops.matmul` / `ops.einsum` overhead.

## Why it's safe

The fast path is gated to only the case it's proven for:

- Quantized layers never reach it — `quantized_call()` runs before `call()`.
- LoRA is re-checked at call time (not cached at build), since `enable_lora` can flip it on after `build()`.
- Symbolic `KerasTensor` inputs never reach `call()` at all (routed to `compute_output_spec` instead), so no symbolic-input handling is needed here — pinned by `test_torch_fast_path_symbolic_input`.
- `torch.compile` tracing is explicitly skipped (`torch.compiler.is_compiling()`), since meta-device weights make `F.linear`/`torch.einsum` raise under fake tensors.
- Dtype mismatch between input and kernel falls through to the standard path rather than casting the kernel, avoiding a silent downcast.
- Subclasses are excluded (`type(self) is Dense` / `type(self) is EinsumDense`) because they may override the `kernel` property, which the fast path would otherwise bypass by reading the raw kernel variable — pinned by `test_torch_fast_path_skipped_for_subclass` in both test files.

## Benchmarks (GPU, 3-way: master / this PR alone / this PR + parents)

![PR #23185: master vs PR alone vs PR+parents, Keras torch GPU eager](https://raw.githubusercontent.com/pctablet505/keras/1d4e020c7bab24f173c424bf27ddade5e06d7bcf/22561/pr23185.png)

| workload | master | this PR alone | + parents (#23182→#23184) |
|---|--:|--:|--:|
| CNN forward | 1.25 ms | 1.20 ms (~noise) | 1.13 ms (~noise) |
| LLM forward | 3.53 ms | 3.23 ms (~noise) | 2.96 ms (1.19×) |
| LLM generate-32 | 111.4 ms | 103.9 ms (1.07×) | 95.7 ms (1.18×) |

Equivalence vs master: forward max|Δ| = 0.0 (CNN), 1.67e-06 (LLM, float32 recompute-order noise from the einsum reformulation — generate-32 token ids identical, the hard-fail criterion).

Part of the issue #22561 torch-backend perf series (after #23182, #23183 and #23184).

## torch.compile performance

![PR #23185: master vs PR alone vs PR+parents, compiled, Keras torch GPU](https://raw.githubusercontent.com/pctablet505/keras/f4e4e12806b079f254824d0916f880b1b33082d7/22561/pr23185_compile.png)

| workload | state | eager | compiled | compiled/eager |
|---|---|--:|--:|--:|
| CNN forward | this PR alone | 1.12 ms | 2.66 ms | 2.38x slower |
| CNN forward | + parents (#23182→#23184) | 1.06 ms | 2.34 ms | 2.21x slower |
| LLM forward | this PR alone | 3.09 ms | 5.17 ms | 1.67x slower |
| LLM forward | + parents (#23182→#23184) | 2.70 ms | 5.59 ms | 2.07x slower |
| LLM generate-32 | this PR alone | 99.51 ms | 168.59 ms | 1.69x slower |
| LLM generate-32 | + parents (#23182→#23184) | 90.30 ms | 159.77 ms | 1.77x slower |

`torch.compile` is slower than eager at both states, on all three workloads. This PR's fast path is explicitly skipped under `torch.compiler.is_compiling()` (see "Why it's safe" above), so it never runs inside a compiled graph — the compiled numbers here reflect the pre-existing traced graph, unaffected by this PR either way. Stacked compiled CNN forward and LLM generate-32 both improve over the isolated state (CNN 2.66 ms → 2.34 ms, generate-32 168.59 ms → 159.77 ms), tracking the eager-side gains from parent PRs #23182-#23184. Compiled LLM forward does not follow that pattern — it is slightly slower stacked (5.59 ms) than isolated (5.17 ms), a single-run scatter rather than a regression, since parents #23182-#23184 are compile-neutral by design (0 graph-break delta) and should not move compiled numbers in either direction. No cell stalled or timed out; all runs completed within the harness's guards. Numeric equivalence vs. master holds at both states (max forward delta 0.0 CNN, 1.67e-06 LLM float32 reordering noise, generate-32 token ids bit-identical), matching the equivalence already reported above.

## torch.compile impact

This PR is compile-neutral: 0 graph-break delta at its stack position under `torch.compile` (deterministic dynamo decomposition). The `F.linear`/`torch.einsum` fast path is eager-only and is explicitly skipped under `torch.compiler.is_compiling()`, so the compiled graph is unaffected either way. The eager-mode speedup above is real, but the compiled-graph break-count reduction in this series comes later, from #23186 alone.

![torch.compile graph breaks across the #22561 series (this PR does not change the count)](https://raw.githubusercontent.com/pctablet505/keras/5195086b19/22561/compile-graph-breaks-22561-2026-07-19.png)

## Tests

`dense_test.py` / `einsum_dense_test.py`: numeric parity vs. the standard path, LoRA bypass, symbolic-input bypass, subclass-override bypass, device-scope handling, dtype-mismatch fallthrough, and `mixed_float16` equivalence.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
