### PR TITLE
perf(torch): SDPA is_causal dispatch + bounded causal-mask cache in MultiHeadAttention

### DIFF
--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -856,7 +856,9 @@ class MultiHeadAttention(Layer):
 
             # FIFO eviction once the cap is reached.
             if len(self._causal_mask_cache) >= 8:
-                self._causal_mask_cache.pop(next(iter(self._causal_mask_cache)))
+                evict_key = next(iter(self._causal_mask_cache), None)
+                if evict_key is not None:
+                    self._causal_mask_cache.pop(evict_key, None)
             self._causal_mask_cache[cache_key] = mask
             return mask
 

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -200,6 +200,14 @@ class MultiHeadAttention(Layer):
 
         self._inverse_sqrt_key_dim = 1.0 / math.sqrt(float(self._key_dim))
 
+        # Bounded cache for computed causal masks, keyed by
+        # (q_seq_len, kv_seq_len, device_str, "bool").
+        # Max 8 entries: typical models use 1-2 distinct lengths; the cap
+        # prevents unbounded growth during beam search or variable-length
+        # inference.  The mask is always bool, so dtype is not part of the
+        # key — float16 and float32 queries produce the same mask.
+        self._causal_mask_cache = {}
+
         # Check for flash attention constraints
         if self._flash_attention and self._dropout > 0.0:
             raise ValueError(
@@ -526,18 +534,39 @@ class MultiHeadAttention(Layer):
 
         if use_dot_product_attention:
             if use_causal_mask and attention_mask is None:
-                # Skip materializing the [T, S] mask and let the backend
-                # use its native causal kernel.
-                attention_output = ops.dot_product_attention(
-                    query=query,
-                    key=key,
-                    value=value,
-                    bias=None,
-                    mask=None,
-                    scale=self._inverse_sqrt_key_dim,
-                    is_causal=True,
-                    flash_attention=self._flash_attention,
-                )
+                # Torch SDPA causal fast path: avoids materialising a [T, S]
+                # mask and enables the causal-only SDPA kernel.
+                if (
+                    backend.backend() == "torch"
+                    and backend.is_tensor(query)
+                    and not self._flash_attention
+                ):
+                    import torch
+
+                    # SDPA expects (B, N, T, H); inputs arrive as (B, T, N, H).
+                    attention_output = (
+                        torch.nn.functional.scaled_dot_product_attention(
+                            query.transpose(1, 2),
+                            key.transpose(1, 2),
+                            value.transpose(1, 2),
+                            attn_mask=None,
+                            dropout_p=0.0,
+                            is_causal=True,
+                            scale=self._inverse_sqrt_key_dim,
+                        ).transpose(1, 2)
+                    )
+                else:
+                    # Non-torch or flash_attention=True: fall through to ops.
+                    attention_output = ops.dot_product_attention(
+                        query=query,
+                        key=key,
+                        value=value,
+                        bias=None,
+                        mask=None,
+                        scale=self._inverse_sqrt_key_dim,
+                        is_causal=True,
+                        flash_attention=self._flash_attention,
+                    )
                 return attention_output, None
             if attention_mask is not None:
                 # Ensure attention_mask has the correct shape for broadcasting
@@ -800,6 +829,38 @@ class MultiHeadAttention(Layer):
         """
         q_seq_length = ops.shape(query)[1]
         v_seq_length = q_seq_length if value is None else ops.shape(value)[1]
+
+        # Cache masks only on the torch backend with static Python int shapes.
+        # On JAX/TF, ops.ones/cumsum return symbolic tensors or Tracers even
+        # when the lengths happen to be Python ints (e.g. inside jax.jit or
+        # tf.function).  Caching and reusing those across tracing contexts
+        # triggers UnexpectedTracerError (JAX) or graph-mismatch errors (TF).
+        # JAX and TF constant-fold the mask at compile time anyway, so the
+        # cache buys nothing on those backends.
+        if (
+            backend.backend() == "torch"
+            and isinstance(q_seq_length, int)
+            and isinstance(v_seq_length, int)
+            and backend.is_tensor(query)
+        ):
+            device_key = str(query.device)
+            cache_key = (q_seq_length, v_seq_length, device_key, "bool")
+            cached = self._causal_mask_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+            ones_mask = ops.ones((1, q_seq_length, v_seq_length), dtype="int32")
+            row_index = ops.cumsum(ones_mask, axis=-2)
+            col_index = ops.cumsum(ones_mask, axis=-1)
+            mask = ops.greater_equal(row_index, col_index)
+
+            # FIFO eviction once the cap is reached.
+            if len(self._causal_mask_cache) >= 8:
+                self._causal_mask_cache.pop(next(iter(self._causal_mask_cache)))
+            self._causal_mask_cache[cache_key] = mask
+            return mask
+
+        # Non-torch backend or dynamic shapes: recompute on every call.
         ones_mask = ops.ones((1, q_seq_length, v_seq_length), dtype="int32")
         row_index = ops.cumsum(ones_mask, axis=-2)
         col_index = ops.cumsum(ones_mask, axis=-1)

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -534,8 +534,10 @@ class MultiHeadAttention(Layer):
 
         if use_dot_product_attention:
             if use_causal_mask and attention_mask is None:
-                # Torch SDPA causal fast path: avoids materialising a [T, S]
-                # mask and enables the causal-only SDPA kernel.
+                # On torch, dispatch straight to the native causal SDPA
+                # kernel. This avoids materialising a [T, S] mask and skips the
+                # ops.dot_product_attention dispatch overhead for the common
+                # eager causal self-attention case.
                 if (
                     backend.backend() == "torch"
                     and backend.is_tensor(query)
@@ -556,7 +558,8 @@ class MultiHeadAttention(Layer):
                         ).transpose(1, 2)
                     )
                 else:
-                    # Non-torch or flash_attention=True: fall through to ops.
+                    # Other backends, or flash attention, fall through to the
+                    # ops path which handles the causal kernel selection.
                     attention_output = ops.dot_product_attention(
                         query=query,
                         key=key,

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -204,7 +204,7 @@ class MultiHeadAttention(Layer):
         # (q_seq_len, kv_seq_len, device_str, "bool").
         # Max 8 entries: typical models use 1-2 distinct lengths; the cap
         # prevents unbounded growth during beam search or variable-length
-        # inference.  The mask is always bool, so dtype is not part of the
+        # inference. The mask is always bool, so dtype is not part of the
         # key — float16 and float32 queries produce the same mask.
         self._causal_mask_cache = {}
 
@@ -836,7 +836,7 @@ class MultiHeadAttention(Layer):
         # Cache masks only on the torch backend with static Python int shapes.
         # On JAX/TF, ops.ones/cumsum return symbolic tensors or Tracers even
         # when the lengths happen to be Python ints (e.g. inside jax.jit or
-        # tf.function).  Caching and reusing those across tracing contexts
+        # tf.function). Caching and reusing those across tracing contexts
         # triggers UnexpectedTracerError (JAX) or graph-mismatch errors (TF).
         # JAX and TF constant-fold the mask at compile time anyway, so the
         # cache buys nothing on those backends.

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -1,5 +1,6 @@
 import math
 import string
+from collections import OrderedDict
 
 import numpy as np
 
@@ -200,13 +201,15 @@ class MultiHeadAttention(Layer):
 
         self._inverse_sqrt_key_dim = 1.0 / math.sqrt(float(self._key_dim))
 
-        # Bounded cache for computed causal masks, keyed by
+        # Bounded FIFO cache for computed causal masks, keyed by
         # (q_seq_len, kv_seq_len, device_str, "bool").
         # Max 8 entries: typical models use 1-2 distinct lengths; the cap
         # prevents unbounded growth during beam search or variable-length
         # inference. The mask is always bool, so dtype is not part of the
-        # key — float16 and float32 queries produce the same mask.
-        self._causal_mask_cache = {}
+        # key — float16 and float32 queries produce the same mask. An
+        # OrderedDict lets the oldest entry be evicted with a single atomic
+        # popitem, avoiding a live-dict iteration in the eviction path.
+        self._causal_mask_cache = OrderedDict()
 
         # Check for flash attention constraints
         if self._flash_attention and self._dropout > 0.0:
@@ -840,10 +843,14 @@ class MultiHeadAttention(Layer):
         # triggers UnexpectedTracerError (JAX) or graph-mismatch errors (TF).
         # JAX and TF constant-fold the mask at compile time anyway, so the
         # cache buys nothing on those backends.
+        # The lengths must be exact Python ints: under torch.compile the shape
+        # can be a symbolic torch.SymInt, which is unhashable and would raise
+        # if used as a cache key. `type() is int` excludes SymInt (and bool),
+        # so symbolic tracing falls through to the recompute path below.
         if (
             backend.backend() == "torch"
-            and isinstance(q_seq_length, int)
-            and isinstance(v_seq_length, int)
+            and type(q_seq_length) is int
+            and type(v_seq_length) is int
             and backend.is_tensor(query)
         ):
             device_key = str(query.device)
@@ -857,11 +864,11 @@ class MultiHeadAttention(Layer):
             col_index = ops.cumsum(ones_mask, axis=-1)
             mask = ops.greater_equal(row_index, col_index)
 
-            # FIFO eviction once the cap is reached.
+            # Evict the oldest entry once the cap is reached.
+            # popitem(last=False) is a single atomic pop, so it never iterates
+            # a dict that another thread might resize concurrently.
             if len(self._causal_mask_cache) >= 8:
-                evict_key = next(iter(self._causal_mask_cache), None)
-                if evict_key is not None:
-                    self._causal_mask_cache.pop(evict_key, None)
+                self._causal_mask_cache.popitem(last=False)
             self._causal_mask_cache[cache_key] = mask
             return mask
 

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -1046,8 +1046,6 @@ class MultiHeadAttentionTest(testing.TestCase):
         self.assertDType(layer._gate_dense._kernel, "int8")
         self.assertDType(layer._output_dense._kernel, "int8")
 
-    # P7: SDPA is_causal fast-path and mask-cache coverage
-
     @pytest.mark.skipif(
         backend.backend() != "torch",
         reason="SDPA is_causal fast-path is torch-only",

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -21,6 +21,25 @@ from keras.src.backend.config import enable_flash_attention
 from keras.src.backend.config import is_flash_attention_enabled
 
 
+def _get_backed_symint(hint=2):
+    """Create a backed SymInt via torch.export dynamic shapes."""
+    import torch
+
+    class _M(torch.nn.Module):
+        def forward(self, x):
+            return x + x.shape[0]
+
+    ep = torch.export.export(
+        _M(),
+        (torch.randn(hint, 3),),
+        dynamic_shapes={"x": {0: torch.export.Dim("batch")}},
+    )
+    for node in ep.graph.nodes:
+        if node.op == "placeholder":
+            return node.meta["val"].shape[0]
+    raise RuntimeError("Could not extract SymInt from exported program")
+
+
 class MultiHeadAttentionTest(testing.TestCase):
     def setUp(self):
         super().setUp()
@@ -1232,3 +1251,56 @@ class MultiHeadAttentionTest(testing.TestCase):
             atol=1e-5,
             rtol=1e-5,
         )
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="Causal mask cache is torch-only",
+    )
+    def test_causal_mask_cache_skips_symbolic_length(self):
+        """Symbolic (SymInt) sequence lengths must not enter the mask cache.
+
+        Under torch.compile the shape returned by ops.shape can be a
+        torch.SymInt, which is unhashable and cannot serve as a cache key.
+        The cache guard uses `type(x) is int`, so a symbolic length falls
+        through to the recompute path and nothing is cached. Reverting the
+        guard to isinstance would admit an int-subclass symbolic length and
+        cache it, which this test guards against.
+        """
+        from unittest import mock
+
+        from keras.src.layers.attention import multi_head_attention as mha_mod
+
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        q = ops.convert_to_tensor(
+            np.random.default_rng(0).random((1, 6, 8)).astype("float32")
+        )
+        layer(q, q)  # build weights
+
+        sym = _get_backed_symint(6)
+        real_shape = mha_mod.ops.shape
+
+        def sym_shape(x):
+            dims = list(real_shape(x))
+            if len(dims) >= 2:
+                dims[1] = sym
+            return tuple(dims)
+
+        # ops.ones is stubbed only so the non-traced recompute branch does not
+        # error on a bare SymInt; the assertion is about the caching decision.
+        with (
+            mock.patch.object(mha_mod.ops, "shape", side_effect=sym_shape),
+            mock.patch.object(
+                mha_mod.ops,
+                "ones",
+                return_value=ops.zeros((1, 1, 1), dtype="int32"),
+            ),
+        ):
+            layer._compute_causal_mask(q)
+        self.assertEqual(len(layer._causal_mask_cache), 0)
+
+        # A concrete int length is cached, and every key is an exact int.
+        layer(q, q, use_causal_mask=True, return_attention_scores=True)
+        self.assertGreaterEqual(len(layer._causal_mask_cache), 1)
+        for key in layer._causal_mask_cache:
+            self.assertIs(type(key[0]), int)
+            self.assertIs(type(key[1]), int)

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -1045,3 +1045,192 @@ class MultiHeadAttentionTest(testing.TestCase):
         self.assertDType(layer._value_dense._kernel, "int8")
         self.assertDType(layer._gate_dense._kernel, "int8")
         self.assertDType(layer._output_dense._kernel, "int8")
+
+    # P7: SDPA is_causal fast-path and mask-cache coverage
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="SDPA is_causal fast-path is torch-only",
+    )
+    def test_sdpa_causal_numeric_equivalence(self):
+        """torch SDPA is_causal=True output must match explicit-softmax path.
+
+        When use_causal_mask=True and no other mask is present, the torch
+        backend routes through
+        torch.nn.functional.scaled_dot_product_attention(is_causal=True).
+        Passing return_attention_scores=True forces the layer off that fast
+        path (use_dot_product_attention becomes False) onto the full explicit-
+        softmax causal path.  Both must agree within float32 tolerance.
+        """
+        import torch
+
+        rng = np.random.default_rng(1234)
+        batch, seq, feat = 2, 8, 16
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        q = torch.tensor(rng.random((batch, seq, feat)).astype("float32"))
+        v = q.clone()
+
+        # Fast path: torch SDPA with is_causal=True.
+        out_sdpa = layer(q, v, use_causal_mask=True)
+
+        # Reference: return_attention_scores=True → use_dot_product_attention
+        # is False → explicit softmax with materialised causal mask.
+        out_explicit, _ = layer(
+            q, v, use_causal_mask=True, return_attention_scores=True
+        )
+
+        self.assertAllClose(out_sdpa, out_explicit, atol=1e-5, rtol=1e-5)
+
+    def test_sdpa_causal_fallback_return_attention_scores(self):
+        """return_attention_scores=True must not crash and return valid shapes.
+
+        This exercises the fallback branch where use_dot_product_attention is
+        False (because return_attention_scores is True).
+        """
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        rng = np.random.default_rng(0)
+        q = rng.random((2, 6, 16)).astype("float32")
+        v = q.copy()
+        out, scores = layer(
+            q, v, use_causal_mask=True, return_attention_scores=True
+        )
+        self.assertEqual(tuple(out.shape), (2, 6, 16))
+        self.assertIsNotNone(scores)
+        # scores: (batch, num_heads, query_len, key_len)
+        self.assertEqual(len(scores.shape), 4)
+        self.assertEqual(scores.shape[0], 2)  # batch
+        self.assertEqual(scores.shape[1], 2)  # num_heads
+
+    def test_sdpa_causal_fallback_non_causal(self):
+        """Non-causal call (use_causal_mask=False) must not crash or regress."""
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        rng = np.random.default_rng(1)
+        q = rng.random((2, 4, 8)).astype("float32")
+        v = q.copy()
+        out = layer(q, v, use_causal_mask=False)
+        self.assertEqual(tuple(out.shape), (2, 4, 8))
+
+    def test_sdpa_causal_fallback_explicit_attention_mask(self):
+        """Explicit attention_mask bypasses SDPA is_causal fast path.
+
+        When attention_mask is provided, causal_only is False in call(), so
+        _compute_attention_mask is called and the result is passed into
+        _compute_attention.  The fast path (use_causal_mask and
+        attention_mask is None) is skipped.  Must not crash.
+        """
+        batch, seq, feat = 2, 5, 16
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        rng = np.random.default_rng(2)
+        q = rng.random((batch, seq, feat)).astype("float32")
+        v = q.copy()
+        # All-True boolean padding mask: attend everywhere.
+        mask = np.ones((batch, seq, seq), dtype="bool")
+        out = layer(q, v, attention_mask=mask)
+        self.assertEqual(tuple(out.shape), (batch, seq, feat))
+
+    def test_sdpa_causal_fallback_cross_attention(self):
+        """Cross-attention (query_len != value_len) must not crash."""
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        rng = np.random.default_rng(3)
+        q = rng.random((2, 6, 16)).astype("float32")
+        v = rng.random((2, 4, 16)).astype("float32")
+        out = layer(q, v, use_causal_mask=True)
+        self.assertEqual(tuple(out.shape), (2, 6, 16))
+
+    def test_causal_mask_cache_same_shape_consistent(self):
+        """Calling MHA twice with same inputs must give identical outputs.
+
+        Verifies that the mask cache does not corrupt results across calls.
+        """
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        q = random.uniform((2, 8, 16))
+        out1 = layer(q, q, use_causal_mask=True)
+        out2 = layer(q, q, use_causal_mask=True)
+        self.assertAllClose(out1, out2)
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="Causal mask cache is torch-only",
+    )
+    def test_causal_mask_cache_fifo_eviction_bounded(self):
+        """Mask cache must not grow beyond 8 entries (FIFO eviction).
+
+        Creates 10 distinct sequence lengths, each of which produces a
+        distinct cache key, overflowing the 8-entry cap.
+
+        return_attention_scores=True forces use_dot_product_attention=False,
+        routing through the manual softmax path that calls _compute_causal_mask
+        and fills the cache.  The SDPA is_causal=True fast path skips the
+        cache entirely, so using it here would leave the cache empty and test
+        nothing.
+        """
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        feat = 8
+        for seq_len in range(4, 14):  # 10 distinct lengths
+            q = random.uniform((1, seq_len, feat))
+            # Force the ops fallback path (use_dot_product_attention=False)
+            # so that _compute_causal_mask is called and the cache fills.
+            _, _ = layer(
+                q, q, use_causal_mask=True, return_attention_scores=True
+            )
+        self.assertGreater(len(layer._causal_mask_cache), 0)
+        self.assertLessEqual(len(layer._causal_mask_cache), 8)
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="SDPA causal fast path is torch-only",
+    )
+    def test_sdpa_causal_fast_path_bypasses_ops(self):
+        # On torch, use_causal_mask=True with no other masks routes directly
+        # through torch SDPA, bypassing ops.dot_product_attention entirely.
+        # Patching ops to raise confirms the bypass.
+        from unittest.mock import patch
+
+        import torch
+
+        rng = np.random.default_rng(0)
+        q_np = rng.random((2, 6, 16)).astype("float32")
+        q_t = torch.tensor(q_np)
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        layer(q_t, q_t)  # build weights
+
+        def _no_ops_call(*args, **kwargs):
+            raise AssertionError(
+                "ops.dot_product_attention unexpectedly called"
+            )
+
+        with patch.object(ops, "dot_product_attention", _no_ops_call):
+            out = layer(q_t, q_t, use_causal_mask=True)
+        self.assertEqual(tuple(out.shape), (2, 6, 16))
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="SDPA causal fast path is torch-only",
+    )
+    def test_sdpa_cross_attention_tneqs_equivalence(self):
+        # T != S: SDPA fast path (is_causal=True) must match the explicit-mask
+        # path numerically. Inputs are constructed as numpy and moved to CPU
+        # torch tensors; outputs compared via .cpu().numpy().
+        import torch
+
+        rng = np.random.default_rng(7)
+        batch, t_len, s_len, feat = 2, 6, 4, 16
+        layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
+        q_np = rng.random((batch, t_len, feat)).astype("float32")
+        v_np = rng.random((batch, s_len, feat)).astype("float32")
+        q_t = torch.tensor(q_np)
+        v_t = torch.tensor(v_np)
+
+        # Fast path: torch SDPA with is_causal=True.
+        out_fast = layer(q_t, v_t, use_causal_mask=True)
+
+        # Reference: explicit lower-triangular mask bypasses causal_only branch.
+        causal = np.tril(np.ones((t_len, s_len), dtype="bool"))[None]
+        out_ref = layer(q_t, v_t, attention_mask=causal)
+
+        self.assertAllClose(
+            out_fast.detach().cpu().numpy(),
+            out_ref.detach().cpu().numpy(),
+            atol=1e-5,
+            rtol=1e-5,
+        )

--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -1058,7 +1058,7 @@ class MultiHeadAttentionTest(testing.TestCase):
         torch.nn.functional.scaled_dot_product_attention(is_causal=True).
         Passing return_attention_scores=True forces the layer off that fast
         path (use_dot_product_attention becomes False) onto the full explicit-
-        softmax causal path.  Both must agree within float32 tolerance.
+        softmax causal path. Both must agree within float32 tolerance.
         """
         import torch
 
@@ -1113,8 +1113,8 @@ class MultiHeadAttentionTest(testing.TestCase):
 
         When attention_mask is provided, causal_only is False in call(), so
         _compute_attention_mask is called and the result is passed into
-        _compute_attention.  The fast path (use_causal_mask and
-        attention_mask is None) is skipped.  Must not crash.
+        _compute_attention. The fast path (use_causal_mask and
+        attention_mask is None) is skipped. Must not crash.
         """
         batch, seq, feat = 2, 5, 16
         layer = layers.MultiHeadAttention(num_heads=2, key_dim=4)
@@ -1158,7 +1158,7 @@ class MultiHeadAttentionTest(testing.TestCase):
 
         return_attention_scores=True forces use_dot_product_attention=False,
         routing through the manual softmax path that calls _compute_causal_mask
-        and fills the cache.  The SDPA is_causal=True fast path skips the
+        and fills the cache. The SDPA is_causal=True fast path skips the
         cache entirely, so using it here would leave the cache empty and test
         nothing.
         """


### PR DESCRIPTION
Closes #23277

Torch backend: when `MultiHeadAttention` does eager causal self-attention with no explicit mask, dispatch straight to `torch.nn.functional.scaled_dot_product_attention(..., is_causal=True)` — skipping the `[T, S]` mask materialization and the `ops.dot_product_attention` dispatch layer. Off that fast path, the fallback causal mask is cached (bounded at 8 entries) instead of rebuilt on every call.

## Why it's safe

- The SDPA path is tightly gated: torch backend, concrete tensors only, `use_causal_mask=True`, no explicit `attention_mask`, zero dropout, no `return_attention_scores`, flash attention off. Anything else falls through to the existing path untouched, so other backends and configurations cannot regress.
- Numerics: the only transform is transposing `(B, T, N, H)` to SDPA's `(B, N, T, H)` layout and back. The head dimension stays contiguous, so no `.contiguous()` copy is needed, and results match the explicit lower-triangular-mask path (verified, including a T ≠ S case).
- The cache key is `(q_len, kv_len, device, "bool")`; dtype is deliberately omitted since the bool mask depends only on lengths and device. Only exact Python `int` lengths are cached — under `torch.compile` lengths become symbolic `SymInt`s (unhashable), which simply fall through to recomputation, so compiled models keep working. JAX and TF are excluded entirely: caching there would leak a tracer across `jit`/`tf.function` traces, and those backends constant-fold the mask anyway.
- Quantization and LoRA apply inside the `_query_dense`/`_key_dense`/`_value_dense`/`_output_dense` projection sublayers, not in this code. The attention computation modified here consumes those sublayers' float outputs identically regardless of which path ran, so the fast path is orthogonal to quantized/LoRA usage — it doesn't need to special-case them, and they don't bypass it.

## Benchmarks (GPU, 3-way: master / this PR alone / this PR + parents #23182→#23185)

![PR #23186: master vs PR alone vs PR+parents, Keras torch GPU eager](https://raw.githubusercontent.com/pctablet505/keras/1d4e020c7bab24f173c424bf27ddade5e06d7bcf/22561/pr23186.png)

| workload | master | this PR alone | + parents (#23182→#23185) |
|---|--:|--:|--:|
| CNN forward | 1.21 ms | 1.24 ms (~noise) | 1.09 ms (~noise) |
| LLM forward | 3.48 ms | 3.37 ms (~noise) | 2.82 ms (1.21×) |
| LLM generate-32 | 110.9 ms | 108.0 ms (~noise) | 90.7 ms (1.21×) |

Interleaved A/B process pairs against an A/A null calibration; "~noise" means below the measured noise floor, not claimed as a win. Forward outputs are bit-identical to master with this PR in isolation, and generate-32 token ids match in all states (the small stacked-state float32 delta, 1.67e-06, comes from a parent PR's einsum reordering already accepted there). torch 2.13.0+cu130, RTX 4050 Laptop GPU, master a2f8eac8.

## torch.compile performance

![PR #23186: master vs PR alone vs PR+parents, compiled, Keras torch GPU](https://raw.githubusercontent.com/pctablet505/keras/4d4fd0b4b12037026dea3f9b370b42805050b8b1/22561/pr23186_compile.png)

| workload | state | eager | compiled | result |
|---|---|--:|--:|---|
| CNN forward | this PR alone | 2.08 ms | 3.26 ms | compile 1.6× slower |
| CNN forward | + parents (#23182→#23185) | 1.03 ms | 2.31 ms | compile 2.2× slower |
| LLM forward | this PR alone | 3.94 ms | 1.03 ms | compile 3.8× faster |
| LLM forward | + parents (#23182→#23185) | 2.58 ms | 0.85 ms | compile 3.0× faster |
| LLM generate-32 | this PR alone | 128.77 ms | stalled | dynamo recompile-limit hit, unmeasurable |
| LLM generate-32 | + parents (#23182→#23185) | 88.08 ms | stalled | dynamo recompile-limit hit, unmeasurable |

Compiled LLM forward flips from slower-than-eager at the master baseline (6.34 ms compiled vs 3.73 ms eager) to clearly faster-than-eager at both states above, isolating the effect to this PR's SDPA dispatch. Compiled CNN forward is still slower than eager at both states, consistent with master — this PR doesn't touch CNN-relevant code, so no change there is expected. Compiled generate-32 stalled at both states: `torch._dynamo` hit its recompile limit (8) on a per-token guard a few tokens in, then the compiled resume frame timed out against this harness's 180-second guard. That is the same recompile-storm pattern already seen at other positions in the series (see the graph-break census below), not a regression introduced by this PR — both numbers are reported as stalled rather than estimated.

## torch.compile graph breaks

This is the only PR in the combined 22561 series that reduces `torch.compile` graph breaks; one later PR in the series (#23288) adds one LLM break back, tracked separately there.

`torch._dynamo.explain()` census (CPU, deterministic, toy LLM workload, 2,105,344 params) shows the attention-path graph breaks drop exactly at this PR:

| state | LLM graph breaks | LLM graph count |
|---|--:|--:|
| parents #23182→#23185 (pre-PR) | 11 | 12 |
| + this PR (#23186) | **7** | **8** |

The fused SDPA dispatch removes the polyfill user-class-instantiation, `Signature._bind`, and tree-flattening break events that previously fired on the attention call path, leaving `convert_to_tensor` as the only remaining LLM break site. Within the 13-PR combined series, this is the entire master→combined-series LLM break reduction — no other PR in that series moves this number.

![torch.compile graph breaks across the #22561 series; the only drop is at this PR](https://raw.githubusercontent.com/pctablet505/keras/5195086b19/22561/compile-graph-breaks-22561-2026-07-19.png)

CNN forward breaks are unchanged by this PR (9 breaks / 10 graphs, both before and after).

**Caveat**: the graph-break reduction and the forward-pass timing above are two different things. LLM single-forward `torch.compile` now measures faster than eager at this PR, both in isolation and with parents stacked, so compile is a genuine win for that workload here. Compiled generation is a separate story: `generate-32` under compile stalls on a recompile-limit storm at both states, so end-to-end generation under `torch.compile` still doesn't run, let alone win. Closing the remaining graph breaks and the generation recompile storm is tracked separately in #22561.

## Tests

New unit tests cover fast-path activation, numeric equivalence with the explicit-mask path, every fallback gate (non-torch backend, flash attention, attention scores, explicit mask), the cache size bound, and `SymInt` exclusion.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
