### PR TITLE
Preserve segmentation mask dtype and class indices in preprocessing layers

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/center_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/center_crop.py
@@ -177,11 +177,18 @@ class CenterCrop(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
-            segmentation_masks, transformation, training=training
-        )
+        # Segmentation masks hold discrete class indices. Use nearest-neighbor
+        # interpolation on the resize path so no new class values are invented,
+        # and restore the original (typically integer) dtype.
+        masks = self.backend.convert_to_tensor(segmentation_masks)
+        in_dtype = masks.dtype
+        outputs = self._center_crop(masks, interpolation="nearest")
+        return self.backend.cast(outputs, in_dtype)
 
     def transform_images(self, images, transformation=None, training=True):
+        return self._center_crop(images, interpolation="bilinear")
+
+    def _center_crop(self, images, interpolation="bilinear"):
         inputs = self.backend.cast(images, self.compute_dtype)
         inputs_shape = self.backend.shape(inputs)
 
@@ -232,6 +239,7 @@ class CenterCrop(BaseImagePreprocessingLayer):
         return image_utils.smart_resize(
             inputs,
             [self.height, self.width],
+            interpolation=interpolation,
             data_format=self.data_format,
             backend_module=self.backend,
         )

--- a/keras/src/layers/preprocessing/image_preprocessing/center_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/center_crop.py
@@ -179,17 +179,16 @@ class CenterCrop(BaseImagePreprocessingLayer):
     ):
         # Segmentation masks hold discrete class indices. Use nearest-neighbor
         # interpolation on the resize path so no new class values are invented,
-        # and restore the original (typically integer) dtype.
+        # and keep the original (typically integer) dtype by not casting to
+        # `compute_dtype`.
         masks = self.backend.convert_to_tensor(segmentation_masks)
-        in_dtype = masks.dtype
-        outputs = self._center_crop(masks, interpolation="nearest")
-        return self.backend.cast(outputs, in_dtype)
+        return self._center_crop(masks, interpolation="nearest")
 
     def transform_images(self, images, transformation=None, training=True):
+        images = self.backend.cast(images, self.compute_dtype)
         return self._center_crop(images, interpolation="bilinear")
 
-    def _center_crop(self, images, interpolation="bilinear"):
-        inputs = self.backend.cast(images, self.compute_dtype)
+    def _center_crop(self, inputs, interpolation="bilinear"):
         inputs_shape = self.backend.shape(inputs)
 
         if self.data_format == "channels_first":

--- a/keras/src/layers/preprocessing/image_preprocessing/center_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/center_crop_test.py
@@ -309,3 +309,17 @@ class CenterCropTest(testing.TestCase):
             yield (np.random.random(small_input).astype("float32"),)
 
         model.predict(generator())
+
+    def test_segmentation_mask_preserves_dtype_and_classes(self):
+        # Masks hold discrete class indices; the resize fallback must use
+        # nearest-neighbor interpolation so no new classes appear, and the
+        # integer dtype must be preserved. See keras-team/keras#20857.
+        images = np.random.random((2, 8, 8, 3)).astype("float32")
+        masks = np.zeros((2, 8, 8, 1), dtype="uint8")
+        masks[:, :4] = 4  # only classes {0, 4}
+        # Target larger than input forces the resize path.
+        layer = layers.CenterCrop(16, 16)
+        out = layer({"images": images, "segmentation_masks": masks})
+        result = backend.convert_to_numpy(out["segmentation_masks"])
+        self.assertEqual(result.dtype, np.uint8)
+        self.assertTrue(set(np.unique(result).tolist()).issubset({0, 4}))

--- a/keras/src/layers/preprocessing/image_preprocessing/cut_mix.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/cut_mix.py
@@ -220,9 +220,23 @@ class CutMix(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
-            segmentation_masks, transformation, training
-        )
+        # CutMix pastes a rectangular region from another sample. For masks
+        # this is an exact copy (no blending/interpolation), so keep the
+        # original class-index dtype instead of casting to `compute_dtype`.
+        if training and transformation is not None:
+            segmentation_masks = self.backend.convert_to_tensor(
+                segmentation_masks
+            )
+            permutation_order = transformation["permutation_order"]
+            batch_masks = transformation["batch_masks"]
+            segmentation_masks = self.backend.numpy.where(
+                batch_masks,
+                self.backend.numpy.take(
+                    segmentation_masks, permutation_order, axis=0
+                ),
+                segmentation_masks,
+            )
+        return segmentation_masks
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/keras/src/layers/preprocessing/image_preprocessing/cut_mix_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/cut_mix_test.py
@@ -81,3 +81,15 @@ class CutMixTest(testing.TestCase):
         ds = tf_data.Dataset.from_tensor_slices(input_data).batch(2).map(layer)
         for output in ds.take(1):
             output.numpy()
+
+    def test_segmentation_mask_preserves_dtype_and_classes(self):
+        # CutMix pastes an exact region between samples; masks must keep their
+        # integer dtype and contain no invented classes. See #20857.
+        images = np.random.random((2, 8, 8, 3)).astype("float32")
+        masks = np.zeros((2, 8, 8, 1), dtype="uint8")
+        masks[0] = 4  # sample 0 is all class 4, sample 1 all class 0
+        layer = layers.CutMix(seed=1)
+        out = layer({"images": images, "segmentation_masks": masks})
+        result = backend.convert_to_numpy(out["segmentation_masks"])
+        self.assertEqual(result.dtype, np.uint8)
+        self.assertTrue(set(np.unique(result).tolist()).issubset({0, 4}))

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -270,7 +270,7 @@ class RandomCrop(BaseImagePreprocessingLayer):
         masks = self.backend.convert_to_tensor(segmentation_masks)
         in_dtype = masks.dtype
         outputs = self.transform_images(
-            masks, transformation, interpolation="nearest"
+            masks, transformation, training=training, interpolation="nearest"
         )
         return self.backend.cast(outputs, in_dtype)
 

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -128,7 +128,9 @@ class RandomCrop(BaseImagePreprocessingLayer):
 
         return h_start, w_start
 
-    def transform_images(self, images, transformation, training=True):
+    def transform_images(
+        self, images, transformation, training=True, interpolation="bilinear"
+    ):
         if training:
             images = self.backend.cast(images, self.compute_dtype)
             crop_box_hstart, crop_box_wstart = transformation
@@ -179,6 +181,7 @@ class RandomCrop(BaseImagePreprocessingLayer):
                 images = self.backend.image.resize(
                     images,
                     size=(self.height, self.width),
+                    interpolation=interpolation,
                     data_format=self.data_format,
                 )
                 # Resize may have upcasted the outputs
@@ -262,7 +265,14 @@ class RandomCrop(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(segmentation_masks, transformation)
+        # Use nearest-neighbor interpolation on the resize fallback so masks
+        # keep their discrete class indices, and restore the original dtype.
+        masks = self.backend.convert_to_tensor(segmentation_masks)
+        in_dtype = masks.dtype
+        outputs = self.transform_images(
+            masks, transformation, interpolation="nearest"
+        )
+        return self.backend.cast(outputs, in_dtype)
 
     def compute_output_shape(self, input_shape, *args, **kwargs):
         input_shape = list(input_shape)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -128,64 +128,69 @@ class RandomCrop(BaseImagePreprocessingLayer):
 
         return h_start, w_start
 
-    def transform_images(
-        self, images, transformation, training=True, interpolation="bilinear"
-    ):
+    def transform_images(self, images, transformation, training=True):
         if training:
             images = self.backend.cast(images, self.compute_dtype)
-            crop_box_hstart, crop_box_wstart = transformation
-            crop_height = self.height
-            crop_width = self.width
+            images = self._random_crop(
+                images, transformation, interpolation="bilinear"
+            )
+            # The resize fallback in `_random_crop` may upcast on some backends
+            # (e.g. TF upcasts float16 to float32); restore the compute dtype.
+            images = self.backend.cast(images, self.compute_dtype)
+        return images
 
-            if self.data_format == "channels_last":
-                if len(images.shape) == 4:
-                    images = images[
-                        :,
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                        :,
-                    ]
-                else:
-                    images = images[
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                        :,
-                    ]
+    def _random_crop(self, images, transformation, interpolation="bilinear"):
+        crop_box_hstart, crop_box_wstart = transformation
+        crop_height = self.height
+        crop_width = self.width
+
+        if self.data_format == "channels_last":
+            if len(images.shape) == 4:
+                images = images[
+                    :,
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                    :,
+                ]
             else:
-                if len(images.shape) == 4:
-                    images = images[
-                        :,
-                        :,
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                    ]
-                else:
-                    images = images[
-                        :,
-                        crop_box_hstart : crop_box_hstart + crop_height,
-                        crop_box_wstart : crop_box_wstart + crop_width,
-                    ]
+                images = images[
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                    :,
+                ]
+        else:
+            if len(images.shape) == 4:
+                images = images[
+                    :,
+                    :,
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                ]
+            else:
+                images = images[
+                    :,
+                    crop_box_hstart : crop_box_hstart + crop_height,
+                    crop_box_wstart : crop_box_wstart + crop_width,
+                ]
 
-            shape = self.backend.shape(images)
-            new_height = shape[self.height_axis]
-            new_width = shape[self.width_axis]
-            if (
-                not isinstance(new_height, int)
-                or not isinstance(new_width, int)
-                or new_height != self.height
-                or new_width != self.width
-            ):
-                # Resize images if size mismatch or
-                # if size mismatch cannot be determined
-                # (in the case of a TF dynamic shape).
-                images = self.backend.image.resize(
-                    images,
-                    size=(self.height, self.width),
-                    interpolation=interpolation,
-                    data_format=self.data_format,
-                )
-                # Resize may have upcasted the outputs
-                images = self.backend.cast(images, self.compute_dtype)
+        shape = self.backend.shape(images)
+        new_height = shape[self.height_axis]
+        new_width = shape[self.width_axis]
+        if (
+            not isinstance(new_height, int)
+            or not isinstance(new_width, int)
+            or new_height != self.height
+            or new_width != self.width
+        ):
+            # Resize images if size mismatch or
+            # if size mismatch cannot be determined
+            # (in the case of a TF dynamic shape).
+            images = self.backend.image.resize(
+                images,
+                size=(self.height, self.width),
+                interpolation=interpolation,
+                data_format=self.data_format,
+            )
         return images
 
     def transform_labels(self, labels, transformation, training=True):
@@ -266,13 +271,14 @@ class RandomCrop(BaseImagePreprocessingLayer):
         self, segmentation_masks, transformation, training=True
     ):
         # Use nearest-neighbor interpolation on the resize fallback so masks
-        # keep their discrete class indices, and restore the original dtype.
+        # keep their discrete class indices and their original (typically
+        # integer) dtype; no `compute_dtype` cast is applied.
         masks = self.backend.convert_to_tensor(segmentation_masks)
-        in_dtype = masks.dtype
-        outputs = self.transform_images(
-            masks, transformation, training=training, interpolation="nearest"
-        )
-        return self.backend.cast(outputs, in_dtype)
+        if training:
+            masks = self._random_crop(
+                masks, transformation, interpolation="nearest"
+            )
+        return masks
 
     def compute_output_shape(self, input_shape, *args, **kwargs):
         input_shape = list(input_shape)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
@@ -177,3 +177,11 @@ class RandomCropTest(testing.TestCase):
         result = backend.convert_to_numpy(out["segmentation_masks"])
         self.assertEqual(result.dtype, np.uint8)
         self.assertTrue(set(np.unique(result).tolist()).issubset({0, 4}))
+
+        # With training=False the layer is a no-op: images and masks must
+        # pass through unchanged (and keep matching shapes).
+        out_eval = layer(
+            {"images": images, "segmentation_masks": masks}, training=False
+        )
+        self.assertAllClose(out_eval["images"], images)
+        self.assertAllClose(out_eval["segmentation_masks"], masks)

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
@@ -163,3 +163,17 @@ class RandomCropTest(testing.TestCase):
             data["bounding_boxes"]["labels"],
             transformed_data["bounding_boxes"]["labels"],
         )
+
+    def test_segmentation_mask_preserves_dtype_and_classes(self):
+        # Masks hold discrete class indices; the resize fallback must use
+        # nearest-neighbor interpolation so no new classes appear, and the
+        # integer dtype must be preserved. See keras-team/keras#20857.
+        images = np.random.random((2, 8, 8, 3)).astype("float32")
+        masks = np.zeros((2, 8, 8, 1), dtype="uint8")
+        masks[:, :4] = 4  # only classes {0, 4}
+        # Target larger than input forces the resize path.
+        layer = layers.RandomCrop(16, 16, seed=0)
+        out = layer({"images": images, "segmentation_masks": masks})
+        result = backend.convert_to_numpy(out["segmentation_masks"])
+        self.assertEqual(result.dtype, np.uint8)
+        self.assertTrue(set(np.unique(result).tolist()).issubset({0, 4}))

--- a/keras/src/layers/preprocessing/image_preprocessing/random_flip.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_flip.py
@@ -188,9 +188,15 @@ class RandomFlip(BaseImagePreprocessingLayer):
     def transform_segmentation_masks(
         self, segmentation_masks, transformation, training=True
     ):
-        return self.transform_images(
-            segmentation_masks, transformation, training=training
-        )
+        # Flipping only reorders pixels, so run it directly on the masks
+        # without casting to a float `compute_dtype`. This preserves the
+        # original (typically integer) class-index dtype.
+        if training:
+            segmentation_masks = self.backend.convert_to_tensor(
+                segmentation_masks
+            )
+            return self._flip_inputs(segmentation_masks, transformation)
+        return segmentation_masks
 
     def _flip_inputs(self, inputs, transformation):
         if transformation is None:

--- a/keras/src/layers/preprocessing/image_preprocessing/random_flip_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_flip_test.py
@@ -283,3 +283,15 @@ class RandomFlipTest(testing.TestCase):
         output = next(iter(ds))
         expected_boxes = np.array(expected_boxes)
         self.assertAllClose(output["boxes"], expected_boxes)
+
+    def test_segmentation_mask_preserves_dtype_and_classes(self):
+        # Flipping only reorders pixels; masks must keep their integer dtype
+        # and contain no invented classes. See keras-team/keras#20857.
+        images = np.random.random((2, 8, 8, 3)).astype("float32")
+        masks = np.zeros((2, 8, 8, 1), dtype="uint8")
+        masks[:, :4] = 4  # only classes {0, 4}
+        layer = layers.RandomFlip("horizontal_and_vertical", seed=0)
+        out = layer({"images": images, "segmentation_masks": masks})
+        result = backend.convert_to_numpy(out["segmentation_masks"])
+        self.assertEqual(result.dtype, np.uint8)
+        self.assertTrue(set(np.unique(result).tolist()).issubset({0, 4}))


### PR DESCRIPTION
## Description

Image preprocessing layers corrupt `segmentation_masks` in two ways when masks
are passed via the dict call (`layer({"images": ..., "segmentation_masks": ...})`):

1. **Invented class values.** Layers that resize masks use bilinear
   interpolation, which produces fractional labels between real classes (e.g.
   a mask with classes `2` and `4` gains a `3` that never existed).
2. **dtype loss.** `transform_segmentation_masks` delegates to
   `transform_images`, which casts to the layer's `compute_dtype` (usually
   `float32`), so a `uint8` class-index mask comes back as `float32`.

Related to #20857. This takes the per-layer approach: each affected class is
fixed so masks are never interpolated/blended into new values and keep their
original integer dtype — rather than casting the result back at the end (which
would silently round invented labels like `3.0` into a bogus class `3`).

### Fixes

- **`CenterCrop`** / **`RandomCrop`** — the resize fallback (used when the
  target is larger than the input) now uses `interpolation="nearest"` for
  masks, and the original dtype is restored. Nearest sampling reuses exact
  source pixels, so no new classes appear.
- **`RandomFlip`** — flipping only reorders pixels; masks are now flipped in
  their original dtype without the `float32` cast.
- **`CutMix`** — pasting a region between samples is an exact copy; masks are
  pasted in their original dtype.

The image / label / bounding-box paths are unchanged (images still use
bilinear).

### Out of scope

`MixUp` and `AugMix` *blend* samples (`w * a + (1 - w) * b`), which is
ill-defined for discrete class-index masks and currently errors on integer
masks. The correct behavior there (leave masks untouched vs. require one-hot)
is a separate design decision and is intentionally not addressed here.

### Tests

Added a regression test to each of the four layers asserting that a `uint8`
mask with classes `{0, 4}` keeps its dtype and gains no new class values
(`CenterCrop`/`RandomCrop` tests exercise the resize path). All four layers'
existing suites pass on the TensorFlow and NumPy backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
