### PR TITLE
Reject decompression-bomb config/metadata members in KerasFileEditor

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -82,10 +82,17 @@ class KerasFileEditor:
                 archive=zf,
                 mode="r",
             )
-            with zf.open(saving_lib._CONFIG_FILENAME, "r") as f:
-                config_json = f.read()
-            with zf.open(saving_lib._METADATA_FILENAME, "r") as f:
-                metadata_json = f.read()
+            # Read through `_safe_zip_read` so a decompression-bomb member
+            # (tiny on disk, gigabytes uncompressed) is rejected before it is
+            # materialized in memory -- the same guard the loader applies to
+            # these members. A raw `zf.open(...).read()` would read the whole
+            # decompressed payload into memory.
+            config_json = saving_lib._safe_zip_read(
+                zf, saving_lib._CONFIG_FILENAME
+            )
+            metadata_json = saving_lib._safe_zip_read(
+                zf, saving_lib._METADATA_FILENAME
+            )
             self.config = json.loads(config_json)
             self.metadata = json.loads(metadata_json)
 

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -161,3 +161,35 @@ class SavingTest(testing.TestCase):
 
         with self.assertRaisesRegex(ValueError, "virtual"):
             KerasFileEditor(virtual_fpath)
+
+    def test_rejects_config_decompression_bomb(self):
+        # A `config.json` / `metadata.json` member that decompresses to far
+        # more than it stores on disk must be rejected before the editor
+        # materializes it in memory (the editor reads these through the
+        # loader's decompression-bomb guard, not a raw read).
+        import zipfile
+        from unittest import mock
+
+        from keras.src.saving import saving_lib
+
+        model = keras.Sequential(
+            [keras.Input((4,)), keras.layers.Dense(3, name="d")]
+        )
+        good_fpath = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(good_fpath)
+        with zipfile.ZipFile(good_fpath) as zin:
+            members = {n: zin.read(n) for n in zin.namelist()}
+
+        for bomb in ("config.json", "metadata.json"):
+            evil_fpath = os.path.join(self.get_temp_dir(), f"evil_{bomb}.keras")
+            with zipfile.ZipFile(evil_fpath, "w", zipfile.ZIP_DEFLATED) as zout:
+                for name, data in members.items():
+                    # The bombed member stores ~nothing but declares 200 KiB.
+                    zout.writestr(
+                        name, b" " * 200_000 if name == bomb else data
+                    )
+            with mock.patch.object(
+                saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64
+            ):
+                with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                    KerasFileEditor(evil_fpath)


### PR DESCRIPTION
## Description

`KerasFileEditor.__init__` reads the `config.json` and `metadata.json` members
of a `.keras` archive with a raw `zf.open(name).read()`:

```python
with zf.open(saving_lib._CONFIG_FILENAME, "r") as f:
    config_json = f.read()
with zf.open(saving_lib._METADATA_FILENAME, "r") as f:
    metadata_json = f.read()
```

This bypasses the `_safe_zip_read` decompression-bomb guard that the model
loader applies to the same members in `_load_model_from_fileobj` (#23010). A
member that stores a few hundred KB on disk but declares/decompresses to
gigabytes therefore makes `KerasFileEditor()` materialize the whole
decompressed payload in host memory before anything is parsed — a
memory-exhaustion DoS from a few-hundred-KB file, under no special flags. The
editor is the tool a security-conscious user reaches for to inspect an
untrusted model *before* loading it, so a bomb here defeats exactly that
workflow. Neither #23010 (which covers the loader) nor the editor's HDF5
weight-read path covers these two members — `config.json` / `metadata.json`
are not weight datasets.

This routes both reads through `saving_lib._safe_zip_read`, so the editor
rejects decompression bombs the same way the loader does. Legitimate models are
unaffected.

Adds a regression test: a `config.json` / `metadata.json` member that
decompresses to far more than it stores is rejected when the file is opened in
the editor.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
