### PR TITLE
Vectorize torch scatter to fix slow IoU metrics

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -582,7 +582,7 @@ def associative_scan(f, elems, reverse=False, axis=0):
 
 
 def scatter(indices, values, shape):
-    indices = convert_to_tensor(indices)
+    indices = convert_to_tensor(indices, dtype="int64")
     values = convert_to_tensor(values)
     zeros = torch.zeros(shape, dtype=values.dtype, device=get_device())
 
@@ -591,9 +591,12 @@ def scatter(indices, values, shape):
     indices = torch.reshape(indices, [-1, index_length])
     values = torch.reshape(values, [-1] + list(value_shape))
 
-    for i in range(indices.shape[0]):
-        index = indices[i]
-        zeros[tuple(index)] += values[i]
+    # Vectorized scatter-add: index_put_ with accumulate=True applies all
+    # updates in one call and sums duplicate indices, instead of a Python loop
+    # over every index (which is very slow for metrics like MeanIoU that
+    # scatter one update per pixel).
+    idx = tuple(indices.transpose(0, 1))
+    zeros.index_put_(idx, values, accumulate=True)
     return zeros
 
 


### PR DESCRIPTION
On the torch backend `keras.ops.scatter` accumulates with a Python loop over every index, one iteration per scattered element. Since `confusion_matrix` scatters a single update per pixel, every IoU metric (`MeanIoU`, `IoU`, `OneHotMeanIoU`, and so on) ends up running that loop once per pixel, which makes them painfully slow and pins a single core on anything image-sized. The outputs are correct so it never tripped CI, but as reported in #19512 it's effectively unusable on real data.

The fix swaps the loop for a single `index_put_` with `accumulate=True`, which is the same vectorized scatter-add that `scatter_update` already uses a few lines further down in the same file, and `accumulate=True` sums duplicate indices which is exactly what `confusion_matrix` relies on. On my machine a few MeanIoU updates over 65k pixels drop from a couple of seconds to a few milliseconds, and the gap only grows from there.

I checked the result against `np.add.at` for duplicate and multi-dimensional indices, and the `scatter` op tests plus the IoU metric tests all pass on torch.

Fixes #19512.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
