### PR TITLE
Fix get_training_or_validation_split returning empty training set when validation rounds to 0

### DIFF
--- a/keras/src/utils/dataset_utils.py
+++ b/keras/src/utils/dataset_utils.py
@@ -907,18 +907,17 @@ def get_training_or_validation_split(samples, labels, validation_split, subset):
         return samples, labels
 
     num_val_samples = int(validation_split * len(samples))
+    num_train_samples = len(samples) - num_val_samples
     if subset == "training":
-        io_utils.print_msg(
-            f"Using {len(samples) - num_val_samples} files for training."
-        )
-        samples = samples[:-num_val_samples]
+        io_utils.print_msg(f"Using {num_train_samples} files for training.")
+        samples = samples[:num_train_samples]
         if labels is not None:
-            labels = labels[:-num_val_samples]
+            labels = labels[:num_train_samples]
     elif subset == "validation":
         io_utils.print_msg(f"Using {num_val_samples} files for validation.")
-        samples = samples[-num_val_samples:]
+        samples = samples[num_train_samples:]
         if labels is not None:
-            labels = labels[-num_val_samples:]
+            labels = labels[num_train_samples:]
     else:
         raise ValueError(
             '`subset` must be either "training" '

--- a/keras/src/utils/dataset_utils_test.py
+++ b/keras/src/utils/dataset_utils_test.py
@@ -9,6 +9,7 @@ from torch.utils.data import Dataset as TorchDataset
 from keras.src import backend
 from keras.src.testing import test_case
 from keras.src.testing.test_utils import named_product
+from keras.src.utils.dataset_utils import get_training_or_validation_split
 from keras.src.utils.dataset_utils import split_dataset
 from keras.src.utils.module_utils import tensorflow as tf
 
@@ -158,3 +159,31 @@ class DatasetUtilsTest(test_case.TestCase):
             self.assertEqual(x.shape, (2,))
             self.assertEqual(y.shape, (10, 2))
             self.assertEqual(labels.shape, (1,))
+
+    def test_get_training_or_validation_split_small_validation_split(self):
+        # When int(validation_split * len(samples)) rounds down to 0, the
+        # training subset must keep all samples (not the empty `[:-0]` slice)
+        # and the validation subset must be empty (not the full `[-0:]` slice).
+        samples = list(range(10))
+        train, _ = get_training_or_validation_split(
+            samples, None, validation_split=0.05, subset="training"
+        )
+        val, _ = get_training_or_validation_split(
+            samples, None, validation_split=0.05, subset="validation"
+        )
+        self.assertEqual(train, samples)
+        self.assertEqual(val, [])
+
+    def test_get_training_or_validation_split_regular(self):
+        samples = list(range(10))
+        labels = list(range(10))
+        train_s, train_l = get_training_or_validation_split(
+            samples, labels, validation_split=0.2, subset="training"
+        )
+        val_s, val_l = get_training_or_validation_split(
+            samples, labels, validation_split=0.2, subset="validation"
+        )
+        self.assertEqual(train_s, list(range(8)))
+        self.assertEqual(train_l, list(range(8)))
+        self.assertEqual(val_s, [8, 9])
+        self.assertEqual(val_l, [8, 9])


### PR DESCRIPTION
### Summary

`get_training_or_validation_split` (in `keras/src/utils/dataset_utils.py`) splits a list of samples/labels into a training or validation subset. It computes `num_val_samples = int(validation_split * len(samples))` and then slices with **negative** indices:

```python
samples = samples[:-num_val_samples]   # training
samples = samples[-num_val_samples:]   # validation
```

When `int(validation_split * len(samples))` rounds down to **0** — a small dataset and/or a small `validation_split` — these become `samples[:-0]` (== `samples[:0]`, **empty**) and `samples[-0:]` (== `samples[0:]`, **everything**). So:

- the **training** subset comes back **empty** (while `print_msg` claims *"Using N files for training."*), and
- the **validation** subset wrongly contains **all** the samples.

This is reachable through the public `image_dataset_from_directory` / `text_dataset_from_directory` / `audio_dataset_from_directory` APIs (`check_validation_split_arg` only enforces `0 < validation_split < 1`). The empty training split then trips a misleading `ValueError("No images found in directory ...")` even though files exist.

**Before** (10 samples, `validation_split=0.05` → `num_val_samples = int(0.5) = 0`):

```
subset="training"   -> []          (logged "Using 10 files for training.")
subset="validation" -> [0..9]      (all 10)
```

### Fix

Compute `num_train_samples = len(samples) - num_val_samples` and slice with positive indices, which avoids the negative-zero slice in both branches:

```python
num_train_samples = len(samples) - num_val_samples
# training:   samples[:num_train_samples]
# validation: samples[num_train_samples:]
```

**After:**

```
subset="training"   -> [0..9]      (all 10, matches the log)
subset="validation" -> []          (correctly empty)
# validation_split=0.2 unchanged: training [0..7], validation [8, 9]
```

### Tests

Added `test_get_training_or_validation_split_small_validation_split` (the rounds-to-zero case) and `test_get_training_or_validation_split_regular` to `keras/src/utils/dataset_utils_test.py`. The first fails on the current code and passes with the fix; `ruff check`/`ruff format` are clean.

### AI-Assisted Contribution Policy disclosure

Per the policy: AI assistance was used to help **discover** this edge case and to **verify** it (reproducing the empty-split behavior and cross-checking the slice arithmetic). I reviewed and fully understand the bug and the fix, wrote/tested the change myself, and take full responsibility for it.
