### PR TITLE
Fix #23194: Validate finite values in affine_transform transformation matrix

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -447,6 +447,7 @@ class AffineTransform(Operation):
         self.data_format = backend.standardize_data_format(data_format)
 
     def call(self, images, transform):
+        _check_transform_finite(transform)
         return backend.image.affine_transform(
             images,
             transform,
@@ -470,6 +471,22 @@ class AffineTransform(Operation):
                 f"transform.shape={transform.shape}"
             )
         return KerasTensor(images.shape, dtype=images.dtype)
+
+
+def _check_transform_finite(transform):
+    import numpy as np
+
+    # Only validate plain Python/NumPy inputs to avoid:
+    # - Compilation crashes with symbolic tracers (jax.jit, tf.function)
+    # - Synchronous device-to-host copies with GPU/TPU tensors
+    if not isinstance(transform, (list, tuple, np.ndarray)):
+        return
+    transform = np.asarray(transform)
+    if not np.all(np.isfinite(transform)):
+        raise ValueError(
+            "Invalid transform: all values must be finite. "
+            "Received non-finite values (NaN or Inf) in the transform."
+        )
 
 
 @keras_export("keras.ops.image.affine_transform")
@@ -562,6 +579,7 @@ def affine_transform(
             fill_value=fill_value,
             data_format=data_format,
         ).symbolic_call(images, transform)
+    _check_transform_finite(transform)
     return backend.image.affine_transform(
         images,
         transform,

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -2639,6 +2639,37 @@ class ImageOpsBehaviorTests(testing.TestCase):
         ):
             kimage.affine_transform(images, invalid_transform)
 
+    def test_affine_transform_non_finite_transform(self):
+        images = np.ones((1, 64, 64, 3), dtype="float32")
+
+        # Test with NaN
+        transform_nan = np.array([[1.0, 0, 0, 0, 1.0, 0, np.nan, 0]])
+        with self.assertRaisesRegex(ValueError, "Invalid transform"):
+            kimage.affine_transform(images, transform_nan)
+        with self.assertRaisesRegex(ValueError, "Invalid transform"):
+            kimage.AffineTransform()(images, transform_nan)
+
+        # Test with Inf
+        transform_inf = np.array([[np.inf, 0, 0, 0, 1.0, 0, 0, 0]])
+        with self.assertRaisesRegex(ValueError, "Invalid transform"):
+            kimage.affine_transform(images, transform_inf)
+        with self.assertRaisesRegex(ValueError, "Invalid transform"):
+            kimage.AffineTransform()(images, transform_inf)
+
+        # Test with -Inf
+        transform_neginf = np.array([[-np.inf, 0, 0, 0, 1.0, 0, 0, 0]])
+        with self.assertRaisesRegex(ValueError, "Invalid transform"):
+            kimage.affine_transform(images, transform_neginf)
+        with self.assertRaisesRegex(ValueError, "Invalid transform"):
+            kimage.AffineTransform()(images, transform_neginf)
+
+        # Test valid transform works
+        valid_transform = np.array([[1.0, 0, 0, 0, 1.0, 0, 0, 0]])
+        try:
+            kimage.affine_transform(images, valid_transform)
+        except ValueError:
+            self.fail("affine_transform raised ValueError for valid transform")
+
     def test_extract_patches_invalid_size(self):
         size = "5"  # Invalid size type
         image = np.random.uniform(size=(2, 20, 20, 3))


### PR DESCRIPTION
## Summary

Fixes #23194.

This PR adds validation to ensure that the transformation matrix passed to `keras.ops.image.affine_transform` contains only finite values. If any `NaN`, `Inf`, or `-Inf` values are detected, a `ValueError` is raised instead of silently propagating invalid values through the output tensor.

## Changes

* Added a private helper `_check_transform_finite(transform)` in `keras/src/ops/image.py`.
* Applied finite-value validation in:

  * `AffineTransform.call()`
  * `affine_transform()`
* Added unit tests covering:

  * `NaN` values
  * `Inf` values
  * `-Inf` values
  * Valid transformation matrices (expected to execute successfully)

## Why

Previously, non-finite values in the transformation matrix were accepted without validation, resulting in output tensors filled with `NaN` values and allowing silent propagation of corrupted data. This change introduces early input validation to provide clear error reporting and improve API robustness.

## Testing

* Added tests verifying that `NaN`, `Inf`, and `-Inf` transformations raise `ValueError`.
* Verified that valid transformation matrices continue to work correctly.
* Confirmed that existing `affine_transform` tests continue to pass with the JAX backend.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.