### PR TITLE
Fix #23110: GPU memory leak in torch tree utilities (closure captures tensor containers)

### DIFF
--- a/keras/src/tree/optree_impl.py
+++ b/keras/src/tree/optree_impl.py
@@ -46,10 +46,12 @@ def is_nested(structure):
 
 def traverse(func, structure, top_down=True):
     # From https://github.com/google/jax/pull/19695
+    structure_id = id(structure)
+
     def traverse_children():
         children, treedef = optree.tree_flatten(
             structure,
-            is_leaf=lambda x: x is not structure,
+            is_leaf=lambda x: id(x) != structure_id,
             none_is_leaf=True,
             namespace="keras",
         )

--- a/keras/src/tree/torchtree_impl.py
+++ b/keras/src/tree/torchtree_impl.py
@@ -33,10 +33,12 @@ def _dict_to_ordered_dict(structure):
             )
         return None
 
+    structure_id = id(structure)
+
     def traverse_children():
         children, treedef = torch_tree.tree_flatten(
             structure,
-            is_leaf=lambda x: x is not structure,
+            is_leaf=lambda x: id(x) != structure_id,
         )
         if treedef.num_nodes == 1 and treedef.num_leaves == 1:
             return structure
@@ -62,7 +64,7 @@ def traverse(func, structure, top_down=True):
     def traverse_children():
         children, treedef = torch_tree.tree_flatten(
             structure,
-            is_leaf=lambda x: x is not structure,
+            is_leaf=lambda x: id(x) != structure_id,
         )
         if treedef.num_nodes == 1 and treedef.num_leaves == 1:
             return structure
@@ -73,6 +75,7 @@ def traverse(func, structure, top_down=True):
             )
 
     structure = _dict_to_ordered_dict(structure)
+    structure_id = id(structure)
     if top_down:
         ret = func(structure)
         if ret is None:


### PR DESCRIPTION
## Description

Fixes #23110.

Fixes a GPU memory leak caused by lambda closures capturing tensor containers in `torchtree_impl.py` and `optree_impl.py`.

## Root cause

Both `_dict_to_ordered_dict` and `traverse` in `torchtree_impl.py`, and `traverse` in `optree_impl.py` use:

```python
is_leaf=lambda x: x is not structure
```

The lambda captures `structure` (which holds GPU tensors) by reference. PyTorch's `tree_flatten` internally creates a self-referential helper closure that captures this `is_leaf` lambda, forming a reference cycle:

```
tree_flatten.helper → is_leaf lambda → structure (GPU tensors)
     ↑                                      /
     └──────── captures self ←──────────────┘
```

Python's reference counting cannot break cycles, so GPU tensors remain allocated until the cyclic GC runs, which is infrequent in tight inference loops.

## Fix

Replace with:

```python
structure_id = id(structure)
is_leaf=lambda x: id(x) != structure_id
```

The integer `id()` doesn't reference the container, so GPU tensors are excluded from the cycle and can be freed promptly.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.