### PR TITLE
Fix cdist dtype consistency across backends

### DIFF
--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -98,12 +98,13 @@ def logsumexp(x, axis=None, keepdims=False):
 def cdist(x, y):
     x = np.asarray(x)
     y = np.asarray(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype, float)
     if x.ndim < 2 or y.ndim < 2:
         raise ValueError("`cdist` inputs must have rank >= 2")
     if x.shape[-1] != y.shape[-1]:
         raise ValueError("Last dimension of inputs to `cdist` must match")
     diff = x[..., :, None, :] - y[..., None, :, :]
-    return np.sqrt(np.sum(diff * diff, axis=-1))
+    return np.sqrt(np.sum(diff * diff, axis=-1)).astype(dtype)
 
 
 def extract_sequences(x, sequence_length, sequence_stride):

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -99,12 +99,14 @@ def cdist(x, y):
     x = np.asarray(x)
     y = np.asarray(y)
     dtype = dtypes.result_type(x.dtype, y.dtype, float)
+    x = x.astype(dtype)
+    y = y.astype(dtype)
     if x.ndim < 2 or y.ndim < 2:
         raise ValueError("`cdist` inputs must have rank >= 2")
     if x.shape[-1] != y.shape[-1]:
         raise ValueError("Last dimension of inputs to `cdist` must match")
     diff = x[..., :, None, :] - y[..., None, :, :]
-    return np.sqrt(np.sum(diff * diff, axis=-1)).astype(dtype)
+    return np.sqrt(np.sum(diff * diff, axis=-1))
 
 
 def extract_sequences(x, sequence_length, sequence_stride):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -4,9 +4,12 @@ import openvino.opset17 as ov_opset17
 import scipy.signal
 from openvino import Type
 
+from keras.src.backend.common import dtypes
+from keras.src.backend.openvino.core import OPENVINO_DTYPES
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import cast
 from keras.src.backend.openvino.core import get_ov_output
+from keras.src.backend.openvino.core import ov_to_keras_type
 from keras.src.backend.openvino.core import standardize_dtype
 from keras.src.backend.openvino.numpy import stack
 
@@ -228,6 +231,14 @@ def logsumexp(x, axis=None, keepdims=False):
 def cdist(x, y):
     x = get_ov_output(x)
     y = get_ov_output(y)
+
+    x_type = ov_to_keras_type(x.get_element_type())
+    y_type = ov_to_keras_type(y.get_element_type())
+    result_type = dtypes.result_type(x_type, y_type, float)
+    result_type = OPENVINO_DTYPES[result_type]
+    x = ov_opset.convert(x, result_type).output(0)
+    y = ov_opset.convert(y, result_type).output(0)
+
     x_shape = x.get_partial_shape()
     y_shape = y.get_partial_shape()
     if x_shape.rank.is_static and x_shape.rank.get_length() < 2:

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 
 from keras.src.backend import standardize_dtype
+from keras.src.backend.common import dtypes
 from keras.src.backend.tensorflow.core import cast
 from keras.src.backend.tensorflow.core import convert_to_tensor
 
@@ -81,6 +82,9 @@ def logsumexp(x, axis=None, keepdims=False):
 def cdist(x, y):
     x = convert_to_tensor(x)
     y = convert_to_tensor(y)
+    dtype = dtypes.result_type(x.dtype, y.dtype, float)
+    x = cast(x, dtype)
+    y = cast(y, dtype)
     if x.shape.rank < 2 or y.shape.rank < 2:
         raise ValueError("`cdist` inputs must have rank >= 2")
     if x.shape[-1] != y.shape[-1]:

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1,3 +1,4 @@
+import itertools
 import math
 
 import jax.numpy as jnp
@@ -145,6 +146,13 @@ def _max_reduce(left, right):
 
 
 class MathOpsDynamicShapeTest(testing.TestCase):
+    def test_cdist(self):
+        x = KerasTensor((None, 2, 3))
+        y = KerasTensor((None, 4, 3))
+
+        z = kmath.cdist(x, y)
+        self.assertEqual(z.shape, (None, 2, 4))
+
     def test_erf(self):
         x = KerasTensor((None, 2, 3))
         y = kmath.erf(x)
@@ -353,6 +361,13 @@ class MathOpsDynamicShapeTest(testing.TestCase):
 
 
 class MathOpsStaticShapeTest(testing.TestCase):
+    def test_cdist(self):
+        x = KerasTensor((1, 2, 3))
+        y = KerasTensor((1, 4, 3))
+
+        z = kmath.cdist(x, y)
+        self.assertEqual(z.shape, (1, 2, 4))
+
     def test_erf(self):
         x = KerasTensor((1, 2, 3))
         y = kmath.erf(x)
@@ -1119,6 +1134,38 @@ class MathDtypeTest(testing.TestCase):
     if backend.backend() == "torch":
         ALL_DTYPES = [x for x in ALL_DTYPES if x not in ("uint16", "uint32")]
         INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint16", "uint32")]
+
+    @parameterized.named_parameters(
+        named_product(
+            dtypes=list(itertools.combinations(FLOAT_DTYPES + INT_DTYPES, 2))
+        )
+    )
+    def test_cdist(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+
+        x = knp.ones((2, 3), dtype=dtype1)
+        y = knp.ones((4, 3), dtype=dtype2)
+
+        x_jax = jnp.ones((2, 3), dtype=dtype1)
+        y_jax = jnp.ones((4, 3), dtype=dtype2)
+
+        expected_dtype = standardize_dtype(
+            jnp.linalg.norm(
+                x_jax[:, None, :] - y_jax[None, :, :],
+                axis=-1,
+            ).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(kmath.cdist(x, y).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(kmath.CDist().symbolic_call(x, y).dtype),
+            expected_dtype,
+        )
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_erf(self, dtype):


### PR DESCRIPTION
## Description
This PR fixes inconsistent dtype behavior in cdist across NumPy, TensorFlow, and OpenVINO by computing a shared result dtype using dtypes.result_type and applying appropriate casting in each backend.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
