### PR TITLE
Fix: Validate trainable parameter as boolean in deserialize_keras_object

### DIFF
--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -771,6 +771,14 @@ def deserialize_keras_object(
     custom_obj_scope = object_registration.CustomObjectScope(custom_objects)
     safe_mode_scope = SafeModeScope(safe_mode)
     with custom_obj_scope, safe_mode_scope:
+        if "trainable" in inner_config and not isinstance(
+            inner_config["trainable"], bool
+        ):
+            raise TypeError(
+                "Invalid type for `trainable` field. "
+                f"Expected bool. Received: {inner_config['trainable']} "
+                f"of type {type(inner_config['trainable'])}."
+            )
         try:
             instance = cls.from_config(inner_config)
         except TypeError as e:

--- a/keras/src/saving/serialization_lib_test.py
+++ b/keras/src/saving/serialization_lib_test.py
@@ -448,6 +448,23 @@ class SerializationLibTest(testing.TestCase):
             restored_dense_relu_string.activation, keras.activations.relu
         )
 
+    def test_trainable_validation(self):
+        """Tests that invalid `trainable` types raise a TypeError."""
+        layer = keras.layers.Dense(units=4)
+        config = keras.saving.serialize_keras_object(layer)
+
+        # Test valid boolean
+        config["config"]["trainable"] = True
+        restored = keras.saving.deserialize_keras_object(config)
+        self.assertTrue(restored.trainable)
+
+        # Test invalid type (string)
+        config["config"]["trainable"] = "true"
+        with self.assertRaisesRegex(
+            TypeError, "Invalid type for `trainable` field"
+        ):
+            keras.saving.deserialize_keras_object(config)
+
     def test_missing_name_for_sequential_model(self):
         """Tests serialization when sequential model has no name."""
         serialized = {


### PR DESCRIPTION
## Description
This PR addresses issue #22699 where `deserialize_keras_object` accepts non-boolean values for the `trainable` field without validation.

### Fix details
In `keras/src/saving/serialization_lib.py`, we add a type check just before `cls.from_config(inner_config)` is called. If the `trainable` parameter is present in `inner_config` but is not of type `bool`, a `TypeError` will be raised.

I also added a unit test `test_trainable_validation` in `keras/src/saving/serialization_lib_test.py` verifying that invalid trainable types raise a `TypeError` during deserialization.

Fixes #22699

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
