### PR TITLE
Fix flaky int4 EinsumDense quantization test by seeding the RNG

### DIFF
--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -678,10 +678,6 @@ class EinsumDenseTest(testing.TestCase):
         input_shape,
         error_threshold,
     ):
-        # Seed so both the kernel init and the input draw are deterministic.
-        # The int4 cases use tiny tensors (as few as 8 output elements), so
-        # with an unseeded RNG the MSE occasionally crosses the tolerance and
-        # the test flakes (~1% of draws for the smallest equations).
         set_random_seed(1337)
         layer = layers.EinsumDense(equation=equation, output_shape=output_shape)
         layer.build(input_shape)

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -23,6 +23,7 @@ from keras.src.quantizers.quantization_config import Int4QuantizationConfig
 from keras.src.quantizers.quantization_config import Int8QuantizationConfig
 from keras.src.quantizers.quantizers import AbsMaxQuantizer
 from keras.src.saving.saving_api import load_model
+from keras.src.utils.rng_utils import set_random_seed
 
 
 class EinsumDenseTest(testing.TestCase):
@@ -677,6 +678,11 @@ class EinsumDenseTest(testing.TestCase):
         input_shape,
         error_threshold,
     ):
+        # Seed so both the kernel init and the input draw are deterministic.
+        # The int4 cases use tiny tensors (as few as 8 output elements), so
+        # with an unseeded RNG the MSE occasionally crosses the tolerance and
+        # the test flakes (~1% of draws for the smallest equations).
+        set_random_seed(1337)
         layer = layers.EinsumDense(equation=equation, output_shape=output_shape)
         layer.build(input_shape)
         x = ops.random.uniform(input_shape)


### PR DESCRIPTION
## Summary

`EinsumDenseTest::test_quantize_with_specific_equations` is intermittently failing on the `numpy` and `openvino` CI legs, e.g.:

```
AssertionError: np.float32(0.0051268092) not less than 0.004
keras/src/layers/core/einsum_dense_test.py:688: AssertionError
```

This is a flaky test, not a regression — it fails the same way on unrelated PRs and on `master` itself.

## Root cause

The test draws **both** the layer kernel (via `layer.build()`) and the input `x` from the global RNG, and `TestCase.setUp` does not seed it, so every run uses different random data. The `int4` cases run on very small tensors (the `btd,df->btf` case produces only ~8 output elements), and int4 has just 16 quantization levels, so the per-run MSE has high variance.

Measured MSE distribution over 400 unseeded draws (numpy backend):

| int4 case | ~output elems | median MSE | max | threshold | P(MSE > threshold) |
|---|---|---|---|---|---|
| `btnh,nhd->btd` | 32 | 0.00100 | 0.00522 | 4e-3 | 0.8% |
| `btd,ndh->btnh` | 16 | 0.00026 | 0.00072 | 4e-3 | 0.0% |
| `btd,df->btf` | 8 | 0.00074 | 0.00599 | 4e-3 | 1.0% |

The typical MSE sits ~5x below the tolerance, but roughly 1% of draws exceed it — enough to flake CI regularly.

## Fix

Seed the RNG with `set_random_seed(1337)` at the start of the test so both the kernel init and the input draw are deterministic. This removes only the random tail; because the typical case already passes with a wide margin, this is not loosening the check.

Verified across **all five backends** (numpy, openvino, torch, tensorflow, jax): all six `int8`/`int4` parameterizations pass, with the worst-case MSE still more than 2x under its threshold (jax int4 `btd,df->btf`: 0.00173 vs 0.004).

No production code is changed — this is a test-only stability fix.


- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.