### PR TITLE
Fix torch backend cross() using wrong default axis

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -677,10 +677,9 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     x1 = cast(x1, compute_dtype)
     x2 = cast(x2, compute_dtype)
     if axis is None:
-        # match numpy default (last axis); avoids torch's deprecated
-        # "first dimension of size 3" behavior when dim is unset
+        # match numpy default (last axis)
         axis = -1
-    return cast(torch.cross(x1, x2, dim=axis), result_dtype)
+    return cast(torch.linalg.cross(x1, x2, dim=axis), result_dtype)
 
 
 def cumprod(x, axis=None, dtype=None):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -676,6 +676,10 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
         compute_dtype = "float32"
     x1 = cast(x1, compute_dtype)
     x2 = cast(x2, compute_dtype)
+    if axis is None:
+        # match numpy default (last axis); avoids torch's deprecated
+        # "first dimension of size 3" behavior when dim is unset
+        axis = -1
     return cast(torch.cross(x1, x2, dim=axis), result_dtype)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3680,6 +3680,13 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
             knp.Cross(axis=-1)(x1, y1), np.cross(x1, y1, axis=-1)
         )
 
+        # Default axis is the last one, even when an earlier dimension also
+        # has length 3 (regression test for the torch backend).
+        x3 = np.arange(2 * 3 * 3).reshape([2, 3, 3]).astype("float32")
+        y4 = np.arange(2 * 3 * 3)[::-1].reshape([2, 3, 3]).astype("float32")
+        self.assertAllClose(knp.cross(x3, y4), np.cross(x3, y4))
+        self.assertAllClose(knp.Cross()(x3, y4), np.cross(x3, y4))
+
     def test_einsum(self):
         x = np.arange(24).reshape([2, 3, 4]).astype("float32")
         y = np.arange(24).reshape([2, 4, 3]).astype("float32")


### PR DESCRIPTION
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

---

on the torch backend ops.cross passed dim=axis directly to torch.cross. when axis is None (the default) torch.cross falls back to the first dimension of size 3, but numpy and the numpy/jax/tf backends use the last axis. so the torch result was wrong whenever an earlier axis was also length 3, and it printed a deprecation warning too.

small repro:

```python
import numpy as np, keras
a = np.arange(9.).reshape(3, 3); b = np.arange(9.)[::-1].reshape(3, 3)
keras.ops.cross(a, b)   # torch uses axis 0, doesnt match np.cross(a, b)
```

fix is to default axis to -1 before the call, same as the other backends. also switched to torch.linalg.cross so the deprecated one is gone.

added a (2,3,3) case to test_cross that fails on the old code. the old test used ones([2,1,4,3]) where only the last axis is size 3 and all ones cross to zero so it never caught this.
