### PR TITLE
Fixed — normalized class_weight keys to integers and added a dict-like check. [Normalize and validate class_weight keys in class_weight_to_sample_weights]

### DIFF
--- a/api_gen.py
+++ b/api_gen.py
@@ -13,22 +13,28 @@ import shutil
 import namex
 import namex.generate
 
+import sys
+
 # Patch namex for Windows support
-orig_join = namex.generate.os.path.join
-orig_walk = namex.generate.os.walk
+if sys.platform == "win32":
+    orig_join = namex.generate.os.path.join
+    orig_walk = namex.generate.os.walk
 
+    def forward_slash_join(*args):
+        res = orig_join(*args)
+        if isinstance(res, bytes):
+            return res.replace(b"\\", b"/")
+        return res.replace("\\", "/")
 
-def forward_slash_join(*args):
-    return orig_join(*args).replace("\\", "/")
+    def forward_slash_walk(top, *args, **kwargs):
+        for root, dirs, files in orig_walk(top, *args, **kwargs):
+            if isinstance(root, bytes):
+                yield root.replace(b"\\", b"/"), dirs, files
+            else:
+                yield root.replace("\\", "/"), dirs, files
 
-
-def forward_slash_walk(top, *args, **kwargs):
-    for root, dirs, files in orig_walk(top, *args, **kwargs):
-        yield root.replace("\\", "/"), dirs, files
-
-
-namex.generate.os.path.join = forward_slash_join
-namex.generate.os.walk = forward_slash_walk
+    namex.generate.os.path.join = forward_slash_join
+    namex.generate.os.walk = forward_slash_walk
 
 PACKAGE = "keras"
 BUILD_DIR_NAME = "tmp_build_dir"

--- a/api_gen.py
+++ b/api_gen.py
@@ -11,6 +11,24 @@ import re
 import shutil
 
 import namex
+import namex.generate
+
+# Patch namex for Windows support
+orig_join = namex.generate.os.path.join
+orig_walk = namex.generate.os.walk
+
+
+def forward_slash_join(*args):
+    return orig_join(*args).replace("\\", "/")
+
+
+def forward_slash_walk(top, *args, **kwargs):
+    for root, dirs, files in orig_walk(top, *args, **kwargs):
+        yield root.replace("\\", "/"), dirs, files
+
+
+namex.generate.os.path.join = forward_slash_join
+namex.generate.os.walk = forward_slash_walk
 
 PACKAGE = "keras"
 BUILD_DIR_NAME = "tmp_build_dir"
@@ -180,6 +198,7 @@ def build():
         )
     finally:
         # Clean up: remove the build directory (no longer needed)
+        os.chdir(root_path)
         shutil.rmtree(build_dir)
 
 

--- a/api_gen.py
+++ b/api_gen.py
@@ -9,11 +9,10 @@ It generates API and formats user and generated APIs.
 import os
 import re
 import shutil
+import sys
 
 import namex
 import namex.generate
-
-import sys
 
 # Patch namex for Windows support
 if sys.platform == "win32":

--- a/api_gen.py
+++ b/api_gen.py
@@ -9,31 +9,8 @@ It generates API and formats user and generated APIs.
 import os
 import re
 import shutil
-import sys
 
 import namex
-import namex.generate
-
-# Patch namex for Windows support
-if sys.platform == "win32":
-    orig_join = namex.generate.os.path.join
-    orig_walk = namex.generate.os.walk
-
-    def forward_slash_join(*args):
-        res = orig_join(*args)
-        if isinstance(res, bytes):
-            return res.replace(b"\\", b"/")
-        return res.replace("\\", "/")
-
-    def forward_slash_walk(top, *args, **kwargs):
-        for root, dirs, files in orig_walk(top, *args, **kwargs):
-            if isinstance(root, bytes):
-                yield root.replace(b"\\", b"/"), dirs, files
-            else:
-                yield root.replace("\\", "/"), dirs, files
-
-    namex.generate.os.path.join = forward_slash_join
-    namex.generate.os.walk = forward_slash_walk
 
 PACKAGE = "keras"
 BUILD_DIR_NAME = "tmp_build_dir"
@@ -203,7 +180,6 @@ def build():
         )
     finally:
         # Clean up: remove the build directory (no longer needed)
-        os.chdir(root_path)
         shutil.rmtree(build_dir)
 
 

--- a/keras/src/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/src/trainers/data_adapters/data_adapter_utils.py
@@ -118,18 +118,28 @@ def check_data_cardinality(data):
 
 
 def class_weight_to_sample_weights(y, class_weight):
-    # Validate that class_weight keys are valid class indices before using
-    # them. Without this check, invalid keys are silently ignored and
-    # `sample_weight` defaults to 1.0 for every sample, hiding real bugs.
-    for key in class_weight.keys():
+    # Validate and normalize class_weight keys to integer class indices.
+    # Without this check, invalid keys are silently ignored, and string keys
+    # (e.g., "0") would fail to match integer lookups later, silently
+    # defaulting sample_weight to 1.0.
+    if not hasattr(class_weight, "items") or not hasattr(class_weight, "get"):
+        raise ValueError(
+            "`class_weight` must be a dict-like mapping of class indices "
+            f"to weights. Received: class_weight={class_weight} of type "
+            f"{type(class_weight)}."
+        )
+
+    cleaned_class_weight = {}
+    for key, val in class_weight.items():
         try:
-            int(key)
+            cleaned_class_weight[int(key)] = val
         except (TypeError, ValueError):
             raise ValueError(
                 "`class_weight` must be a dictionary with integer keys "
                 "representing class indices. Received an invalid key: "
                 f"{key!r} of type {type(key)}."
             )
+    class_weight = cleaned_class_weight
 
     # Convert to numpy to ensure consistent handling of operations
     # (e.g., np.round()) across frameworks like TensorFlow, JAX, and PyTorch
@@ -146,6 +156,7 @@ def class_weight_to_sample_weights(y, class_weight):
     for i in range(y_numpy.shape[0]):
         sample_weight[i] = class_weight.get(int(y_numpy[i]), 1.0)
     return sample_weight
+
 
 def get_keras_tensor_spec(batches):
     """Return the KerasTensor spec for a list of batches.

--- a/keras/src/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/src/trainers/data_adapters/data_adapter_utils.py
@@ -118,6 +118,19 @@ def check_data_cardinality(data):
 
 
 def class_weight_to_sample_weights(y, class_weight):
+    # Validate that class_weight keys are valid class indices before using
+    # them. Without this check, invalid keys are silently ignored and
+    # `sample_weight` defaults to 1.0 for every sample, hiding real bugs.
+    for key in class_weight.keys():
+        try:
+            int(key)
+        except (TypeError, ValueError):
+            raise ValueError(
+                "`class_weight` must be a dictionary with integer keys "
+                "representing class indices. Received an invalid key: "
+                f"{key!r} of type {type(key)}."
+            )
+
     # Convert to numpy to ensure consistent handling of operations
     # (e.g., np.round()) across frameworks like TensorFlow, JAX, and PyTorch
 
@@ -133,7 +146,6 @@ def class_weight_to_sample_weights(y, class_weight):
     for i in range(y_numpy.shape[0]):
         sample_weight[i] = class_weight.get(int(y_numpy[i]), 1.0)
     return sample_weight
-
 
 def get_keras_tensor_spec(batches):
     """Return the KerasTensor spec for a list of batches.

--- a/keras/src/trainers/data_adapters/data_adapter_utils_test.py
+++ b/keras/src/trainers/data_adapters/data_adapter_utils_test.py
@@ -129,12 +129,39 @@ class TestClassWeightToSampleWeights(testing.TestCase):
                 {},
                 np.array([1.0, 1.0, 1.0, 1.0]),
             ),
+            (
+                "string_number_keys",
+                np.array([0, 1, 0, 2]),
+                {"0": 1.0, "1": 2.0, "2": 3.0},
+                np.array([1.0, 2.0, 1.0, 3.0]),
+            ),
+            (
+                "float_number_keys",
+                np.array([0, 1, 0, 2]),
+                {0.0: 1.0, 1.0: 2.0, 2.0: 3.0},
+                np.array([1.0, 2.0, 1.0, 3.0]),
+            ),
         ]
     )
     def test_class_weight_to_sample_weights(self, y, class_weight, expected):
         self.assertAllClose(
             class_weight_to_sample_weights(y, class_weight), expected
         )
+
+    def test_class_weight_to_sample_weights_invalid_key(self):
+        y = np.array([0, 1, 0, 2])
+        with self.assertRaisesRegex(ValueError, "integer keys"):
+            class_weight_to_sample_weights(y, {"invalid": 0.5})
+
+    def test_class_weight_to_sample_weights_non_dict(self):
+        y = np.array([0, 1, 0, 2])
+        with self.assertRaisesRegex(ValueError, "dict-like mapping"):
+            class_weight_to_sample_weights(y, "not_a_dict")
+
+    def test_class_weight_to_sample_weights_none_key(self):
+        y = np.array([0, 1, 0, 2])
+        with self.assertRaisesRegex(ValueError, "integer keys"):
+            class_weight_to_sample_weights(y, {None: 0.5})
 
     @pytest.mark.skipif(backend.backend() != "torch", reason="torch only")
     def test_class_weight_to_sample_weights_torch_specific(self):


### PR DESCRIPTION
## Description
Previously, passing an invalid `class_weight` key (e.g. a string that doesn't match any class index) into `model.fit()` was silently ignored. Training would proceed as if `class_weight` was never provided, with `sample_weight` defaulting to `1.0` for every sample — hiding real bugs in user code.

**Change:** Added validation in `class_weight_to_sample_weights()` (in `keras/src/trainers/data_adapters/data_adapter_utils.py`) that checks every key in `class_weight` can be converted to an integer class index. If not, it now raises a clear `ValueError` instead of silently ignoring the invalid key.

**Testing:** Verified locally that valid `class_weight` dicts (e.g. `{0: 1.0, 1: 2.0}`) still work correctly, and invalid keys (e.g. `{"invalid": 0.5}`) now raise a descriptive `ValueError` instead of silently defaulting to 1.0.

Fixes #23220

This bug was originally reported at tensorflow/tensorflow#98283 and a fix was attempted at tensorflow/tensorflow#98429, but that PR was closed by the maintainer noting the fix belongs in the Keras repo rather than the legacy tf.keras path in TensorFlow core.

## Contributor Agreement
**Please review our AI-Assisted Contribution Policy and check all boxes below before submitting your PR for review:**
- [x] I am a human, and not a bot. --yes-homosepian-here!!
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.