### PR TITLE
Add grain support to `audio_dataset_from_directory`.

### DIFF
--- a/keras/src/utils/audio_dataset_utils.py
+++ b/keras/src/utils/audio_dataset_utils.py
@@ -674,15 +674,6 @@ def _read_and_decode_audio_grain(
     if len(audio.shape) == 1:
         audio = np.expand_dims(audio, axis=-1)
 
-    # Decode_wav's desired_samples is applied before resampling in TF
-    if output_sequence_length is not None:
-        diff = output_sequence_length - len(audio)
-        if diff > 0:
-            padding = np.zeros((diff, audio.shape[1]), dtype=audio.dtype)
-            audio = np.concatenate([audio, padding], axis=0)
-        elif diff < 0:
-            audio = audio[:output_sequence_length]
-
     # Resample if needed
     if sampling_rate is not None and default_audio_rate != sampling_rate:
         if len(audio) > 0:
@@ -692,6 +683,15 @@ def _read_and_decode_audio_grain(
             num_samples = max(1, num_samples)
             audio = signal.resample(audio, num_samples, axis=0)
             audio = audio.astype("float32")
+
+    # Trim/pad to output_sequence_length
+    if output_sequence_length is not None:
+        diff = output_sequence_length - len(audio)
+        if diff > 0:
+            padding = np.zeros((diff, audio.shape[1]), dtype=audio.dtype)
+            audio = np.concatenate([audio, padding], axis=0)
+        elif diff < 0:
+            audio = audio[:output_sequence_length]
 
     with backend.device_scope("cpu"):
         audio = ops.convert_to_tensor(audio, dtype="float32")

--- a/keras/src/utils/audio_dataset_utils.py
+++ b/keras/src/utils/audio_dataset_utils.py
@@ -1,9 +1,20 @@
+import pathlib
+
 import numpy as np
 
 from keras.src.api_export import keras_export
 from keras.src.utils import dataset_utils
+from keras.src.utils.grain_utils import make_batch
+from keras.src.utils.module_utils import grain
 from keras.src.utils.module_utils import tensorflow as tf
 from keras.src.utils.module_utils import tensorflow_io as tfio
+
+try:
+    from scipy import signal
+    from scipy.io import wavfile
+except ImportError:
+    signal = None
+    wavfile = None
 
 ALLOWED_FORMATS = (".wav",)
 
@@ -23,9 +34,10 @@ def audio_dataset_from_directory(
     validation_split=None,
     subset=None,
     follow_links=False,
+    format="tf",
     verbose=True,
 ):
-    """Generates a `tf.data.Dataset` from audio files in a directory.
+    """Generates a dataset from audio files in a directory.
 
     If your directory structure is:
 
@@ -41,11 +53,15 @@ def audio_dataset_from_directory(
 
     Then calling `audio_dataset_from_directory(main_directory,
     labels='inferred')`
-    will return a `tf.data.Dataset` that yields batches of audio files from
+    will return a dataset that yields batches of audio files from
     the subdirectories `class_a` and `class_b`, together with labels
     0 and 1 (0 corresponding to `class_a` and 1 corresponding to `class_b`).
 
     Only `.wav` files are supported at this time.
+
+    By default, this function will return a `tf.data.Dataset` object. You can
+    set `format="grain"` to return a `grain.IterDataset` object instead, which
+    removes the TensorFlow dependency.
 
     Args:
         directory: Directory where the data is located.
@@ -93,12 +109,19 @@ def audio_dataset_from_directory(
             `"validation"` or `"both"`. Only used if `validation_split` is set.
         follow_links: Whether to visits subdirectories pointed to by symlinks.
             Defaults to `False`.
+        format: The format of the return object. Defaults to `"tf"`. Available
+            options are:
+            - `"tf"`: returns a `tf.data.Dataset` object. Requires
+                TensorFlow to be installed.
+            - `"grain"`: returns a `grain.IterDataset` object. Requires
+                Grain to be installed.
         verbose: Whether to display number information on classes and
             number of files found. Defaults to `True`.
 
     Returns:
 
-    A `tf.data.Dataset` object.
+    A `tf.data.Dataset` (`format="tf"`) or `grain.IterDataset`
+    (`format="grain"`) object.
 
     - If `label_mode` is `None`, it yields `string` tensors of shape
       `(batch_size,)`, containing the contents of a batch of audio files.
@@ -146,6 +169,11 @@ def audio_dataset_from_directory(
             "Cannot set both `ragged` and `output_sequence_length`"
         )
 
+    if format == "grain" and ragged:
+        raise ValueError(
+            "Ragged datasets are not supported when `format='grain'`."
+        )
+
     if sampling_rate is not None:
         if not isinstance(sampling_rate, int):
             raise ValueError(
@@ -159,7 +187,7 @@ def audio_dataset_from_directory(
                 f"Received: sampling_rate={sampling_rate}"
             )
 
-        if not tfio.available:
+        if format == "tf" and not tfio.available:
             raise ImportError(
                 "To use the argument `sampling_rate`, you should install "
                 "tensorflow_io. You can install it via `pip install "
@@ -212,21 +240,36 @@ def audio_dataset_from_directory(
             shuffle=shuffle,
             shuffle_buffer_size=shuffle_buffer_size,
             seed=seed,
+            format=format,
         )
-        train_dataset = prepare_dataset(
-            dataset=train_dataset,
-            batch_size=batch_size,
-            class_names=class_names,
-            output_sequence_length=output_sequence_length,
-            ragged=ragged,
-        )
-        val_dataset = prepare_dataset(
-            dataset=val_dataset,
-            batch_size=batch_size,
-            class_names=class_names,
-            output_sequence_length=output_sequence_length,
-            ragged=ragged,
-        )
+        if format == "tf":
+            train_dataset = _prepare_dataset_tf(
+                dataset=train_dataset,
+                batch_size=batch_size,
+                class_names=class_names,
+                output_sequence_length=output_sequence_length,
+                ragged=ragged,
+            )
+            val_dataset = _prepare_dataset_tf(
+                dataset=val_dataset,
+                batch_size=batch_size,
+                class_names=class_names,
+                output_sequence_length=output_sequence_length,
+                ragged=ragged,
+            )
+        else:
+            train_dataset = _prepare_dataset_grain(
+                dataset=train_dataset,
+                batch_size=batch_size,
+                class_names=class_names,
+                output_sequence_length=output_sequence_length,
+            )
+            val_dataset = _prepare_dataset_grain(
+                dataset=val_dataset,
+                batch_size=batch_size,
+                class_names=class_names,
+                output_sequence_length=output_sequence_length,
+            )
         return train_dataset, val_dataset
 
     else:
@@ -244,18 +287,27 @@ def audio_dataset_from_directory(
             shuffle=shuffle,
             shuffle_buffer_size=shuffle_buffer_size,
             seed=seed,
+            format=format,
         )
-        dataset = prepare_dataset(
-            dataset=dataset,
-            batch_size=batch_size,
-            class_names=class_names,
-            output_sequence_length=output_sequence_length,
-            ragged=ragged,
-        )
+        if format == "tf":
+            dataset = _prepare_dataset_tf(
+                dataset=dataset,
+                batch_size=batch_size,
+                class_names=class_names,
+                output_sequence_length=output_sequence_length,
+                ragged=ragged,
+            )
+        else:
+            dataset = _prepare_dataset_grain(
+                dataset=dataset,
+                batch_size=batch_size,
+                class_names=class_names,
+                output_sequence_length=output_sequence_length,
+            )
         return dataset
 
 
-def prepare_dataset(
+def _prepare_dataset_tf(
     dataset,
     batch_size,
     class_names,
@@ -268,6 +320,26 @@ def prepare_dataset(
             dataset = dataset.padded_batch(batch_size)
         else:
             dataset = dataset.batch(batch_size)
+
+    # Users may need to reference `class_names`.
+    dataset.class_names = class_names
+    return dataset
+
+
+def _prepare_dataset_grain(
+    dataset,
+    batch_size,
+    class_names,
+    output_sequence_length,
+):
+    dataset = dataset.to_iter_dataset()
+    if batch_size is not None:
+        if output_sequence_length is None:
+            dataset = dataset.batch(
+                batch_size, batch_fn=_make_audio_padded_batch_grain
+            )
+        else:
+            dataset = dataset.batch(batch_size, batch_fn=make_batch)
 
     # Users may need to reference `class_names`.
     dataset.class_names = class_names
@@ -287,6 +359,7 @@ def get_training_and_validation_dataset(
     shuffle=False,
     shuffle_buffer_size=None,
     seed=None,
+    format="tf",
 ):
     (
         file_paths_train,
@@ -320,6 +393,7 @@ def get_training_and_validation_dataset(
         shuffle=shuffle,
         shuffle_buffer_size=shuffle_buffer_size,
         seed=seed,
+        format=format,
     )
 
     val_dataset = paths_and_labels_to_dataset(
@@ -331,6 +405,7 @@ def get_training_and_validation_dataset(
         output_sequence_length=output_sequence_length,
         ragged=ragged,
         shuffle=False,
+        format=format,
     )
 
     return train_dataset, val_dataset
@@ -350,6 +425,7 @@ def get_dataset(
     shuffle=False,
     shuffle_buffer_size=None,
     seed=None,
+    format="tf",
 ):
     file_paths, labels = dataset_utils.get_training_or_validation_split(
         file_paths, labels, validation_split, subset
@@ -371,10 +447,114 @@ def get_dataset(
         shuffle=shuffle,
         shuffle_buffer_size=shuffle_buffer_size,
         seed=seed,
+        format=format,
     )
 
 
-def read_and_decode_audio(
+def paths_and_labels_to_dataset(
+    file_paths,
+    labels,
+    label_mode,
+    num_classes,
+    sampling_rate,
+    output_sequence_length,
+    ragged,
+    shuffle=False,
+    shuffle_buffer_size=None,
+    seed=None,
+    format="tf",
+):
+    """Constructs a fixed-size dataset of audio and labels."""
+    if format == "tf":
+        return _paths_and_labels_to_dataset_tf(
+            file_paths=file_paths,
+            labels=labels,
+            label_mode=label_mode,
+            num_classes=num_classes,
+            sampling_rate=sampling_rate,
+            output_sequence_length=output_sequence_length,
+            ragged=ragged,
+            shuffle=shuffle,
+            shuffle_buffer_size=shuffle_buffer_size,
+            seed=seed,
+        )
+    elif format == "grain":
+        return _paths_and_labels_to_dataset_grain(
+            file_paths=file_paths,
+            labels=labels,
+            label_mode=label_mode,
+            num_classes=num_classes,
+            sampling_rate=sampling_rate,
+            output_sequence_length=output_sequence_length,
+            shuffle=shuffle,
+            seed=seed,
+        )
+    else:
+        raise ValueError(
+            '`format` should be either "tf" or "grain". '
+            f"Received: format={format}"
+        )
+
+
+def _paths_and_labels_to_dataset_tf(
+    file_paths,
+    labels,
+    label_mode,
+    num_classes,
+    sampling_rate,
+    output_sequence_length,
+    ragged,
+    shuffle=False,
+    shuffle_buffer_size=None,
+    seed=None,
+):
+    path_ds = tf.data.Dataset.from_tensor_slices(file_paths)
+    if label_mode:
+        label_ds = dataset_utils.labels_to_dataset_tf(
+            labels, label_mode, num_classes
+        )
+        ds = tf.data.Dataset.zip((path_ds, label_ds))
+    else:
+        ds = path_ds
+
+    if shuffle:
+        ds = ds.shuffle(buffer_size=shuffle_buffer_size or 1024, seed=seed)
+
+    if label_mode:
+        ds = ds.map(
+            lambda x, y: (
+                _read_and_decode_audio_tf(
+                    x, sampling_rate, output_sequence_length
+                ),
+                y,
+            ),
+            num_parallel_calls=tf.data.AUTOTUNE,
+        )
+
+        if ragged:
+            ds = ds.map(
+                lambda x, y: (tf.RaggedTensor.from_tensor(x), y),
+                num_parallel_calls=tf.data.AUTOTUNE,
+            )
+
+    else:
+        ds = ds.map(
+            lambda x: _read_and_decode_audio_tf(
+                x, sampling_rate, output_sequence_length
+            ),
+            num_parallel_calls=tf.data.AUTOTUNE,
+        )
+
+        if ragged:
+            ds = ds.map(
+                lambda x: tf.RaggedTensor.from_tensor(x),
+                num_parallel_calls=tf.data.AUTOTUNE,
+            )
+
+    return ds
+
+
+def _read_and_decode_audio_tf(
     path, sampling_rate=None, output_sequence_length=None
 ):
     """Reads and decodes audio file."""
@@ -407,58 +587,123 @@ def _trim_and_pad_audio(audio, output_sequence_length):
     return audio
 
 
-def paths_and_labels_to_dataset(
+def _paths_and_labels_to_dataset_grain(
     file_paths,
     labels,
     label_mode,
     num_classes,
     sampling_rate,
     output_sequence_length,
-    ragged,
     shuffle=False,
-    shuffle_buffer_size=None,
     seed=None,
 ):
-    """Constructs a fixed-size dataset of audio and labels."""
-    path_ds = tf.data.Dataset.from_tensor_slices(file_paths)
+    """Constructs a dataset of audio and labels using grain."""
+    path_ds = grain.MapDataset.source(file_paths)
     if label_mode:
-        label_ds = dataset_utils.labels_to_dataset_tf(
+        label_ds = dataset_utils.labels_to_dataset_grain(
             labels, label_mode, num_classes
         )
-        ds = tf.data.Dataset.zip((path_ds, label_ds))
+        ds = grain.experimental.ZipMapDataset([path_ds, label_ds])
     else:
         ds = path_ds
 
     if shuffle:
-        ds = ds.shuffle(buffer_size=shuffle_buffer_size or 1024, seed=seed)
+        ds = ds.shuffle(seed=seed)
 
+    args = (sampling_rate, output_sequence_length)
     if label_mode:
         ds = ds.map(
-            lambda x, y: (
-                read_and_decode_audio(x, sampling_rate, output_sequence_length),
-                y,
-            ),
-            num_parallel_calls=tf.data.AUTOTUNE,
-        )
-
-        if ragged:
-            ds = ds.map(
-                lambda x, y: (tf.RaggedTensor.from_tensor(x), y),
-                num_parallel_calls=tf.data.AUTOTUNE,
+            lambda data: (
+                _read_and_decode_audio_grain(data[0], *args),
+                data[1],
             )
-
+        )
     else:
-        ds = ds.map(
-            lambda x: read_and_decode_audio(
-                x, sampling_rate, output_sequence_length
-            ),
-            num_parallel_calls=tf.data.AUTOTUNE,
-        )
-
-        if ragged:
-            ds = ds.map(
-                lambda x: tf.RaggedTensor.from_tensor(x),
-                num_parallel_calls=tf.data.AUTOTUNE,
-            )
+        ds = ds.map(lambda x: _read_and_decode_audio_grain(x, *args))
 
     return ds
+
+
+def _read_and_decode_audio_grain(
+    path, sampling_rate=None, output_sequence_length=None
+):
+    """Reads and decodes audio file using scipy."""
+    from keras.src import backend
+    from keras.src import ops
+
+    if wavfile is None or signal is None:
+        raise ImportError(
+            "To use the grain audio dataset, you should install scipy. "
+            "You can install it via `pip install scipy`."
+        )
+
+    if isinstance(path, bytes):
+        path = path.decode("utf-8")
+    elif isinstance(path, pathlib.Path):
+        path = str(path.resolve())
+
+    default_audio_rate, audio = wavfile.read(path)
+
+    # Ensure audio is float32 and normalized between -1.0 and 1.0
+    if audio.dtype == np.int16:
+        audio = audio.astype("float32") / 32768.0
+    elif audio.dtype == np.int32:
+        audio = audio.astype("float32") / 2147483648.0
+    elif audio.dtype == np.uint8:
+        audio = (audio.astype("float32") - 128.0) / 128.0
+    elif audio.dtype == np.float32:
+        audio = audio.astype("float32")
+    else:
+        audio = audio.astype("float32")
+
+    if len(audio.shape) == 1:
+        audio = np.expand_dims(audio, axis=-1)
+
+    # Decode_wav's desired_samples is applied before resampling in TF
+    if output_sequence_length is not None:
+        diff = output_sequence_length - len(audio)
+        if diff > 0:
+            padding = np.zeros((diff, audio.shape[1]), dtype=audio.dtype)
+            audio = np.concatenate([audio, padding], axis=0)
+        elif diff < 0:
+            audio = audio[:output_sequence_length]
+
+    # Resample if needed
+    if sampling_rate is not None and default_audio_rate != sampling_rate:
+        num_samples = int(
+            round(len(audio) * sampling_rate / default_audio_rate)
+        )
+        audio = signal.resample(audio, num_samples, axis=0)
+        audio = audio.astype("float32")
+
+    with backend.device_scope("cpu"):
+        audio = ops.convert_to_tensor(audio, dtype="float32")
+
+    return audio
+
+
+def _make_audio_padded_batch_grain(values):
+    from keras.src import backend
+    from keras.src import ops
+    from keras.src import tree
+
+    if not values:
+        raise ValueError("Cannot batch 0 values. Please file a bug.")
+
+    def pad_and_stack(*xs):
+        shapes = [x.shape for x in xs]
+        if len(shapes[0]) == 2:
+            max_len = max(shape[0] for shape in shapes)
+            padded_xs = []
+            for x in xs:
+                pad_len = max_len - x.shape[0]
+                if pad_len > 0:
+                    padded_xs.append(ops.pad(x, [[0, pad_len], [0, 0]]))
+                else:
+                    padded_xs.append(x)
+            return ops.stack(padded_xs)
+        else:
+            return ops.stack(xs)
+
+    with backend.device_scope("cpu"):
+        return tree.map_structure(pad_and_stack, *values)

--- a/keras/src/utils/audio_dataset_utils.py
+++ b/keras/src/utils/audio_dataset_utils.py
@@ -1,9 +1,8 @@
-import pathlib
-
 import numpy as np
 
 from keras.src.api_export import keras_export
 from keras.src.utils import dataset_utils
+from keras.src.utils import file_utils
 from keras.src.utils.grain_utils import make_batch
 from keras.src.utils.module_utils import grain
 from keras.src.utils.module_utils import tensorflow as tf
@@ -140,6 +139,27 @@ def audio_dataset_from_directory(
       of shape `(batch_size, num_classes)`, representing a one-hot
       encoding of the class index.
     """
+    if format not in ("tf", "grain"):
+        raise ValueError(
+            '`format` should be either "tf" or "grain". '
+            f"Received: format={format}"
+        )
+
+    if format == "grain":
+        if ragged:
+            raise ValueError(
+                "Ragged datasets are not supported when `format='grain'`."
+            )
+        if wavfile is None or signal is None:
+            raise ImportError(
+                "To use the grain audio dataset, you should install scipy. "
+                "You can install it via `pip install scipy`."
+            )
+        if file_utils.is_remote_path(directory):
+            raise ValueError(
+                "Remote directories are not supported when `format='grain'`."
+            )
+
     if labels not in ("inferred", None):
         if not isinstance(labels, (list, tuple)):
             raise ValueError(
@@ -167,11 +187,6 @@ def audio_dataset_from_directory(
     if ragged and output_sequence_length is not None:
         raise ValueError(
             "Cannot set both `ragged` and `output_sequence_length`"
-        )
-
-    if format == "grain" and ragged:
-        raise ValueError(
-            "Ragged datasets are not supported when `format='grain'`."
         )
 
     if sampling_rate is not None:
@@ -637,10 +652,10 @@ def _read_and_decode_audio_grain(
             "You can install it via `pip install scipy`."
         )
 
-    if isinstance(path, bytes):
+    if hasattr(path, "decode"):
         path = path.decode("utf-8")
-    elif isinstance(path, pathlib.Path):
-        path = str(path.resolve())
+    else:
+        path = str(path)
 
     default_audio_rate, audio = wavfile.read(path)
 
@@ -670,11 +685,13 @@ def _read_and_decode_audio_grain(
 
     # Resample if needed
     if sampling_rate is not None and default_audio_rate != sampling_rate:
-        num_samples = int(
-            round(len(audio) * sampling_rate / default_audio_rate)
-        )
-        audio = signal.resample(audio, num_samples, axis=0)
-        audio = audio.astype("float32")
+        if len(audio) > 0:
+            num_samples = int(
+                round(len(audio) * sampling_rate / default_audio_rate)
+            )
+            num_samples = max(1, num_samples)
+            audio = signal.resample(audio, num_samples, axis=0)
+            audio = audio.astype("float32")
 
     with backend.device_scope("cpu"):
         audio = ops.convert_to_tensor(audio, dtype="float32")

--- a/keras/src/utils/audio_dataset_utils_test.py
+++ b/keras/src/utils/audio_dataset_utils_test.py
@@ -593,6 +593,17 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             _ = audio_dataset_utils.audio_dataset_from_directory(
                 directory, validation_split=0.2, subset="training"
             )
+        with self.assertRaisesRegex(ValueError, "`format` should be either"):
+            _ = audio_dataset_utils.audio_dataset_from_directory(
+                directory, format="invalid"
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "Remote directories are not supported"
+        ):
+            _ = audio_dataset_utils.audio_dataset_from_directory(
+                "gs://bucket/remote/path", format="grain"
+            )
 
     @parameterized.named_parameters(
         ("tf", "tf"),

--- a/keras/src/utils/audio_dataset_utils_test.py
+++ b/keras/src/utils/audio_dataset_utils_test.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+from absl.testing import parameterized
 
 from keras.src import testing
 from keras.src.utils import audio_dataset_utils
@@ -65,7 +66,11 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             i += 1
         return temp_dir
 
-    def test_audio_dataset_from_directory_standalone(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_standalone(self, format):
         # Test retrieving audio samples without labels from a directory and its
         # subdirs.
         # Save a few extra audio in the parent directory.
@@ -76,12 +81,16 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
                 f.write(audio.numpy())
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=5, output_sequence_length=30, labels=None
+            directory,
+            batch_size=5,
+            output_sequence_length=30,
+            labels=None,
+            format=format,
         )
         batch = next(iter(dataset))
         # We return plain audio
-        self.assertEqual(batch.shape, (5, 30, 1))
-        self.assertEqual(batch.dtype.name, "float32")
+        self.assertEqual(tuple(batch.shape), (5, 30, 1))
+        self.assertDType(batch, "float32")
         # Count samples
         batch_count = 0
         sample_count = 0
@@ -91,43 +100,53 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
         self.assertEqual(batch_count, 2)
         self.assertEqual(sample_count, 10)
 
-    def test_audio_dataset_from_directory_binary(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_binary(self, format):
         directory = self._prepare_directory(num_classes=2)
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=8, output_sequence_length=30, label_mode="int"
+            directory,
+            batch_size=8,
+            output_sequence_length=30,
+            label_mode="int",
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape, (8, 30, 1))
-        self.assertEqual(batch[0].dtype.name, "float32")
-        self.assertEqual(batch[1].shape, (8,))
-        self.assertEqual(batch[1].dtype.name, "int32")
+        self.assertEqual(tuple(batch[0].shape), (8, 30, 1))
+        self.assertDType(batch[0], "float32")
+        self.assertEqual(tuple(batch[1].shape), (8,))
+        self.assertDType(batch[1], "int32")
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
             batch_size=8,
             output_sequence_length=30,
             label_mode="binary",
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape, (8, 30, 1))
-        self.assertEqual(batch[0].dtype.name, "float32")
-        self.assertEqual(batch[1].shape, (8, 1))
-        self.assertEqual(batch[1].dtype.name, "float32")
+        self.assertEqual(tuple(batch[0].shape), (8, 30, 1))
+        self.assertDType(batch[0], "float32")
+        self.assertEqual(tuple(batch[1].shape), (8, 1))
+        self.assertDType(batch[1], "float32")
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
             batch_size=8,
             output_sequence_length=30,
             label_mode="categorical",
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape, (8, 30, 1))
-        self.assertEqual(batch[0].dtype.name, "float32")
-        self.assertEqual(batch[1].shape, (8, 2))
-        self.assertEqual(batch[1].dtype.name, "float32")
+        self.assertEqual(tuple(batch[0].shape), (8, 30, 1))
+        self.assertDType(batch[0], "float32")
+        self.assertEqual(tuple(batch[1].shape), (8, 2))
+        self.assertDType(batch[1], "float32")
 
     def test_static_shape_in_graph(self):
         directory = self._prepare_directory(num_classes=2)
@@ -143,27 +162,47 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
 
         symbolic_fn(dataset)
 
-    def test_sample_count(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_sample_count(self, format):
         directory = self._prepare_directory(num_classes=4, count=15)
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=8, output_sequence_length=30, label_mode=None
+            directory,
+            batch_size=8,
+            output_sequence_length=30,
+            label_mode=None,
+            format=format,
         )
         sample_count = 0
         for batch in dataset:
             sample_count += batch.shape[0]
         self.assertEqual(sample_count, 15)
 
-    def test_audio_dataset_from_directory_multiclass(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_multiclass(self, format):
         directory = self._prepare_directory(num_classes=4, count=15)
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=8, output_sequence_length=30, label_mode=None
+            directory,
+            batch_size=8,
+            output_sequence_length=30,
+            label_mode=None,
+            format=format,
         )
         batch = next(iter(dataset))
-        self.assertEqual(batch.shape, (8, 30, 1))
+        self.assertEqual(tuple(batch.shape), (8, 30, 1))
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=8, output_sequence_length=30, label_mode=None
+            directory,
+            batch_size=8,
+            output_sequence_length=30,
+            label_mode=None,
+            format=format,
         )
         sample_count = 0
         iterator = iter(dataset)
@@ -172,29 +211,38 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
         self.assertEqual(sample_count, 15)
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=8, output_sequence_length=30, label_mode="int"
+            directory,
+            batch_size=8,
+            output_sequence_length=30,
+            label_mode="int",
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape, (8, 30, 1))
-        self.assertEqual(batch[0].dtype.name, "float32")
-        self.assertEqual(batch[1].shape, (8,))
-        self.assertEqual(batch[1].dtype.name, "int32")
+        self.assertEqual(tuple(batch[0].shape), (8, 30, 1))
+        self.assertDType(batch[0], "float32")
+        self.assertEqual(tuple(batch[1].shape), (8,))
+        self.assertDType(batch[1], "int32")
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
             batch_size=8,
             output_sequence_length=30,
             label_mode="categorical",
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape, (8, 30, 1))
-        self.assertEqual(batch[0].dtype.name, "float32")
-        self.assertEqual(batch[1].shape, (8, 4))
-        self.assertEqual(batch[1].dtype.name, "float32")
+        self.assertEqual(tuple(batch[0].shape), (8, 30, 1))
+        self.assertDType(batch[0], "float32")
+        self.assertEqual(tuple(batch[1].shape), (8, 4))
+        self.assertDType(batch[1], "float32")
 
-    def test_audio_dataset_from_directory_validation_split(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_validation_split(self, format):
         directory = self._prepare_directory(num_classes=2, count=10)
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
@@ -203,10 +251,11 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             validation_split=0.2,
             subset="training",
             seed=1337,
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape, (8, 30, 1))
+        self.assertEqual(tuple(batch[0].shape), (8, 30, 1))
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
             batch_size=10,
@@ -214,12 +263,17 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             validation_split=0.2,
             subset="validation",
             seed=1337,
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape, (2, 30, 1))
+        self.assertEqual(tuple(batch[0].shape), (2, 30, 1))
 
-    def test_audio_dataset_from_directory_manual_labels(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_manual_labels(self, format):
         directory = self._prepare_directory(num_classes=2, count=2)
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
@@ -227,12 +281,17 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             output_sequence_length=30,
             labels=[0, 1],
             shuffle=False,
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
         self.assertAllClose(batch[1], [0, 1])
 
-    def test_audio_dataset_from_directory_follow_links(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_follow_links(self, format):
         directory = self._prepare_directory(
             num_classes=2, count=25, nested_dirs=True
         )
@@ -242,6 +301,7 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             output_sequence_length=30,
             label_mode=None,
             follow_links=True,
+            format=format,
         )
         sample_count = 0
         for batch in dataset:
@@ -266,8 +326,12 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
 
         self.assertEqual(batch[0].shape.as_list(), [8, None, None])
 
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
     def test_audio_dataset_from_directory_no_output_sequence_length_no_ragged(
-        self,
+        self, format
     ):
         # This test case tests `audio_dataset_from_directory` when `ragged` and
         # `output_sequence_length` are not passed while the input sequence
@@ -283,13 +347,19 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             i for i in range(min_sequence_length, max_sequence_length + 1)
         ]
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=2
+            directory, batch_size=2, format=format
         )
         sequence_lengths = list(set([b.shape[1] for b, _ in dataset]))
         for seq_len in sequence_lengths:
             self.assertIn(seq_len, possible_sequence_lengths)
 
-    def test_audio_dataset_from_directory_variable_length_label_modes(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_variable_length_label_modes(
+        self, format
+    ):
         directory = self._prepare_directory(
             num_classes=2, count=16, different_sequence_lengths=True
         )
@@ -299,9 +369,10 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             batch_size=8,
             label_mode=None,
             shuffle=False,
+            format=format,
         )
         batch = next(iter(dataset))
-        self.assertEqual(batch.shape.rank, 3)
+        self.assertEqual(len(batch.shape), 3)
         self.assertEqual(batch.shape[0], 8)
         self.assertEqual(batch.shape[-1], 1)
 
@@ -310,31 +381,37 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             batch_size=8,
             label_mode="binary",
             shuffle=False,
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape.rank, 3)
+        self.assertEqual(len(batch[0].shape), 3)
         self.assertEqual(batch[0].shape[0], 8)
         self.assertEqual(batch[0].shape[-1], 1)
-        self.assertEqual(batch[1].shape, (8, 1))
-        self.assertEqual(batch[1].dtype.name, "float32")
+        self.assertEqual(tuple(batch[1].shape), (8, 1))
+        self.assertDType(batch[1], "float32")
 
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
             batch_size=8,
             label_mode="categorical",
             shuffle=False,
+            format=format,
         )
         batch = next(iter(dataset))
         self.assertLen(batch, 2)
-        self.assertEqual(batch[0].shape.rank, 3)
+        self.assertEqual(len(batch[0].shape), 3)
         self.assertEqual(batch[0].shape[0], 8)
         self.assertEqual(batch[0].shape[-1], 1)
-        self.assertEqual(batch[1].shape, (8, 2))
-        self.assertEqual(batch[1].dtype.name, "float32")
+        self.assertEqual(tuple(batch[1].shape), (8, 2))
+        self.assertDType(batch[1], "float32")
 
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
     def test_audio_dataset_from_directory_no_output_sequence_length_same_lengths(  # noqa: E501
-        self,
+        self, format
     ):
         # This test case tests `audio_dataset_from_directory` when `ragged` and
         # `output_sequence_length` are not passed while the input sequence
@@ -346,7 +423,7 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
         # should work fine and pad each sequence to the length of the longest
         # sequence in it's batch
         dataset = audio_dataset_utils.audio_dataset_from_directory(
-            directory, batch_size=2
+            directory, batch_size=2, format=format
         )
         sequence_lengths = list(set([batch[0].shape[1] for batch in dataset]))
         self.assertEqual(len(sequence_lengths), 1)
@@ -442,6 +519,14 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
                 directory, ragged=True, output_sequence_length=30
             )
 
+        with self.assertRaisesRegex(
+            ValueError,
+            "Ragged datasets are not supported when `format='grain'`.",
+        ):
+            _ = audio_dataset_utils.audio_dataset_from_directory(
+                directory, ragged=True, format="grain"
+            )
+
         with self.assertRaisesRegex(ValueError, "`labels` argument should be"):
             _ = audio_dataset_utils.audio_dataset_from_directory(
                 directory, labels="other"
@@ -509,7 +594,11 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
                 directory, validation_split=0.2, subset="training"
             )
 
-    def test_audio_dataset_from_directory_not_batched(self):
+    @parameterized.named_parameters(
+        ("tf", "tf"),
+        ("grain", "grain"),
+    )
+    def test_audio_dataset_from_directory_not_batched(self, format):
         directory = self._prepare_directory(num_classes=2, count=2)
         dataset = audio_dataset_utils.audio_dataset_from_directory(
             directory,
@@ -517,6 +606,7 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             output_sequence_length=30,
             label_mode=None,
             shuffle=False,
+            format=format,
         )
         sample = next(iter(dataset))
         self.assertEqual(len(sample.shape), 2)

--- a/keras/src/utils/audio_dataset_utils_test.py
+++ b/keras/src/utils/audio_dataset_utils_test.py
@@ -461,7 +461,7 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
 
             @tf.function
             def read_audio(path):
-                return audio_dataset_utils.read_and_decode_audio(
+                return audio_dataset_utils._read_and_decode_audio_tf(
                     path,
                     sampling_rate=target_sampling_rate,
                     output_sequence_length=output_sequence_length,
@@ -472,6 +472,27 @@ class AudioDatasetFromDirectoryTest(testing.TestCase):
             self.assertEqual(sample.shape, (output_sequence_length, 1))
         finally:
             audio_dataset_utils.tfio = original_tfio
+
+    def test_output_sequence_length_applied_after_resampling_grain(self):
+        source_sampling_rate = 48000
+        target_sampling_rate = 16000
+        output_sequence_length = 16000
+        directory = self.get_temp_dir()
+        filename = os.path.join(directory, "audio.wav")
+        audio = np.random.random((source_sampling_rate * 2, 1))
+        from scipy.io import wavfile
+
+        wavfile.write(
+            filename, source_sampling_rate, (audio * 32767).astype(np.int16)
+        )
+
+        sample = audio_dataset_utils._read_and_decode_audio_grain(
+            filename,
+            sampling_rate=target_sampling_rate,
+            output_sequence_length=output_sequence_length,
+        )
+
+        self.assertEqual(tuple(sample.shape), (output_sequence_length, 1))
 
     def test_audio_dataset_from_directory_errors(self):
         directory = self._prepare_directory(num_classes=3, count=5)


### PR DESCRIPTION
## Description

Add `format="grain"` support to `keras.utils.audio_dataset_from_directory` to align with other dataset utility functions.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
