### PR TITLE
Refactor _load_state to capture weight store and improve container state loading

### DIFF
--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -838,16 +838,17 @@ def _load_state(
     failure = False
 
     if hasattr(saveable, "load_own_variables") and weights_store:
+        store = weights_store.get(inner_path)
         if skip_mismatch or failed_saveables is not None:
             try:
-                saveable.load_own_variables(weights_store.get(inner_path))
+                saveable.load_own_variables(store)
             except Exception as e:
                 if failed_saveables is not None:
                     failed_saveables.add(id(saveable))
                 error_msgs[id(saveable)] = saveable, e
                 failure = True
         else:
-            saveable.load_own_variables(weights_store.get(inner_path))
+            saveable.load_own_variables(store)
 
     if hasattr(saveable, "load_assets") and assets_store:
         if skip_mismatch or failed_saveables is not None:
@@ -1031,10 +1032,8 @@ def _load_container_state(
                 #   - Containers that mirror already-loaded saveables (e.g.
                 #     a Functional model's `_operations_by_depth` whose
                 #     items are also in the `layers` collection).
-                tracked_failures = (
-                    failed_saveables if failed_saveables is not None else set()
-                )
-                failed_before = len(tracked_failures)
+                tracked_failures = set()
+                tracked_errors = {}
                 _load_container_state(
                     saveable,
                     weights_store,
@@ -1043,10 +1042,10 @@ def _load_container_state(
                     skip_mismatch=True,
                     visited_saveables=visited_saveables,
                     failed_saveables=tracked_failures,
-                    error_msgs=error_msgs,
+                    error_msgs=tracked_errors,
                     visited_containers=visited_containers,
                 )
-                if len(tracked_failures) > failed_before:
+                if tracked_failures:
                     # Legacy files saved before PR #22362 didn't write the
                     # `container*` groups for nested containers — silently
                     # skip so the model still loads (sublayers keep their


### PR DESCRIPTION
## Description
This PR refactors the model loading logic in `keras/src/saving/saving_lib.py` to improve efficiency and robustness.

**Refactored `_load_state`:** Captured the result of `weights_store.get(inner_path)` into a local variable `store` to avoid redundant calls. 

**Improved `_load_container_state`:** Enhanced the logic for detecting missing nested containers in legacy files. By using isolated failure tracking for recursive calls, the code now more accurately determines when a container's missing group should trigger a warning, ensuring backward compatibility without polluting the global failure state.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
