### PR TITLE
Add matrix power operation to linalg API and backend implementations

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -40,6 +40,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_power as matrix_power
 from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import pinv as pinv

--- a/keras/api/_tf_keras/keras/ops/linalg/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/linalg/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_power as matrix_power
 from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import pinv as pinv

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -40,6 +40,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_power as matrix_power
 from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import pinv as pinv

--- a/keras/api/ops/linalg/__init__.py
+++ b/keras/api/ops/linalg/__init__.py
@@ -13,6 +13,7 @@ from keras.src.ops.linalg import inv as inv
 from keras.src.ops.linalg import jvp as jvp
 from keras.src.ops.linalg import lstsq as lstsq
 from keras.src.ops.linalg import lu_factor as lu_factor
+from keras.src.ops.linalg import matrix_power as matrix_power
 from keras.src.ops.linalg import matrix_rank as matrix_rank
 from keras.src.ops.linalg import norm as norm
 from keras.src.ops.linalg import pinv as pinv

--- a/keras/src/backend/jax/linalg.py
+++ b/keras/src/backend/jax/linalg.py
@@ -109,6 +109,11 @@ def matrix_rank(x, tol=None):
     return jnp.linalg.matrix_rank(x, tol=tol).astype("int32")
 
 
+def matrix_power(a, n):
+    a = convert_to_tensor(a)
+    return jnp.linalg.matrix_power(a, n)
+
+
 def pinv(x, rcond=None):
     x = convert_to_tensor(x)
     if x.ndim < 2:

--- a/keras/src/backend/numpy/linalg.py
+++ b/keras/src/backend/numpy/linalg.py
@@ -108,6 +108,11 @@ def matrix_rank(x, tol=None):
     return np.linalg.matrix_rank(x, tol=tol).astype("int32")
 
 
+def matrix_power(a, n):
+    a = convert_to_tensor(a)
+    return np.linalg.matrix_power(a, n)
+
+
 def pinv(x, rcond=None):
     x = convert_to_tensor(x)
     return np.linalg.pinv(x, rcond=rcond)

--- a/keras/src/backend/openvino/linalg.py
+++ b/keras/src/backend/openvino/linalg.py
@@ -1751,6 +1751,81 @@ def matrix_rank(x, tol=None):
     return OpenVINOKerasTensor(ov_opset.constant(rank_np).output(0))
 
 
+def matrix_power(a, n):
+    a = convert_to_tensor(a)
+    a_ov = get_ov_output(a)
+    rank = a_ov.get_partial_shape().rank.get_length()
+
+    if n == 0:
+        zero_s = ov_opset.constant(0, Type.i32).output(0)
+        a_shape = ov_opset.shape_of(a_ov, output_type="i32").output(0)
+        n_node = ov_opset.squeeze(
+            ov_opset.gather(
+                a_shape, ov_opset.constant([-1], Type.i32).output(0), zero_s
+            ).output(0),
+            zero_s,
+        ).output(0)
+
+        eye = ov_opset.eye(
+            n_node,
+            n_node,
+            zero_s,
+            a_ov.get_element_type(),
+        ).output(0)
+
+        if rank > 2:
+            num_batch_dims = rank - 2
+            batch_dims_shape = ov_opset.broadcast(
+                ov_opset.constant(1, Type.i32).output(0),
+                ov_opset.constant([num_batch_dims], Type.i32).output(0),
+            ).output(0)
+            eye_reshaped_shape = ov_opset.concat(
+                [
+                    batch_dims_shape,
+                    ov_opset.unsqueeze(n_node, zero_s).output(0),
+                    ov_opset.unsqueeze(n_node, zero_s).output(0),
+                ],
+                0,
+            ).output(0)
+            eye_reshaped = ov_opset.reshape(
+                eye, eye_reshaped_shape, False
+            ).output(0)
+            result = ov_opset.broadcast(eye_reshaped, a_shape).output(0)
+        else:
+            result = eye
+
+        return OpenVINOKerasTensor(result)
+
+    is_negative = n < 0
+    if is_negative:
+        n = abs(n)
+
+    if n == 1:
+        result_ov = a_ov
+    else:
+        result_ov = None
+        curr_a_ov = a_ov
+
+        while n > 0:
+            if n % 2 == 1:
+                if result_ov is None:
+                    result_ov = curr_a_ov
+                else:
+                    result_ov = ov_opset.matmul(
+                        result_ov, curr_a_ov, False, False
+                    ).output(0)
+            if n > 1:
+                curr_a_ov = ov_opset.matmul(
+                    curr_a_ov, curr_a_ov, False, False
+                ).output(0)
+            n //= 2
+
+    if is_negative:
+        result_ov = ov_opset.inverse(result_ov, adjoint=False).output(0)
+
+    return OpenVINOKerasTensor(result_ov)
+
+
 def pinv(x, rcond=None):
     raise NotImplementedError("`pinv` is not supported with openvino backend")
 

--- a/keras/src/backend/tensorflow/linalg.py
+++ b/keras/src/backend/tensorflow/linalg.py
@@ -251,6 +251,36 @@ def matrix_rank(x, tol=None):
     return tf.linalg.matrix_rank(x, tol=tol)
 
 
+def matrix_power(a, n):
+    a = convert_to_tensor(a)
+    if n == 0:
+        return tf.eye(
+            num_rows=tf.shape(a)[-1],
+            batch_shape=tf.shape(a)[:-2],
+            dtype=a.dtype,
+        )
+
+    if n < 0:
+        a = inv(a)
+        n = abs(n)
+
+    if n == 1:
+        return a
+
+    result = tf.eye(
+        num_rows=tf.shape(a)[-1],
+        batch_shape=tf.shape(a)[:-2],
+        dtype=a.dtype,
+    )
+    base = a
+    while n > 0:
+        if n % 2 == 1:
+            result = tf.matmul(result, base)
+        base = tf.matmul(base, base)
+        n //= 2
+    return result
+
+
 def pinv(x, rcond=None):
     x = convert_to_tensor(x)
     return tf.linalg.pinv(x, rcond=rcond)

--- a/keras/src/backend/torch/linalg.py
+++ b/keras/src/backend/torch/linalg.py
@@ -100,6 +100,11 @@ def matrix_rank(x, tol=None):
     return torch.linalg.matrix_rank(x, atol=tol).to(torch.int32)
 
 
+def matrix_power(a, n):
+    a = convert_to_tensor(a)
+    return torch.linalg.matrix_power(a, n)
+
+
 def pinv(x, rcond=None):
     x = convert_to_tensor(x)
     # `torch.linalg.pinv` expresses the threshold as `rtol` (relative

--- a/keras/src/ops/linalg.py
+++ b/keras/src/ops/linalg.py
@@ -732,6 +732,63 @@ def matrix_rank(x, tol=None):
     return backend.linalg.matrix_rank(x, tol=tol)
 
 
+class MatrixPower(Operation):
+    def __init__(self, n, *, name=None):
+        super().__init__(name=name)
+        if not isinstance(n, int):
+            raise TypeError(
+                f"n must be an integer. Received: n={n} of type {type(n)}"
+            )
+        self.n = n
+
+    def call(self, x):
+        return _matrix_power(x, self.n)
+
+    def compute_output_spec(self, x):
+        _assert_2d(x)
+        _assert_square(x)
+        return KerasTensor(x.shape, x.dtype)
+
+
+@keras_export(["keras.ops.matrix_power", "keras.ops.linalg.matrix_power"])
+def matrix_power(x, n):
+    """Raise a square matrix to the (integer) power `n`.
+
+    For positive integers `n`, the power is computed by repeated matrix
+    squarings and matrix multiplications. If `n == 0`, the identity matrix
+    of the same shape as `x` is returned. If `n < 0`, the inverse is
+    computed and then raised to the `abs(n)`.
+
+    Args:
+        x: Input tensor of shape `(..., M, M)`.
+        n: Exponent (integer).
+
+    Returns:
+        A tensor of shape `(..., M, M)` representing `x**n`.
+
+    Example:
+
+    >>> x = keras.ops.convert_to_tensor([[1., 2.], [3., 4.]])
+    >>> matrix_power(x, 3)
+    array([[ 37.,  54.],
+           [ 81., 118.]], dtype=float32)
+    """
+    if any_symbolic_tensors((x,)):
+        return MatrixPower(n).symbolic_call(x)
+    return _matrix_power(x, n)
+
+
+def _matrix_power(x, n):
+    if not isinstance(n, int):
+        raise TypeError(
+            f"n must be an integer. Received: n={n} of type {type(n)}"
+        )
+    x = backend.convert_to_tensor(x)
+    _assert_2d(x)
+    _assert_square(x)
+    return backend.linalg.matrix_power(x, n)
+
+
 class Pinv(Operation):
     def __init__(self, rcond=None, *, name=None):
         super().__init__(name=name)

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -98,6 +98,25 @@ class LinalgOpsDynamicShapeTest(testing.TestCase):
         with self.assertRaises(ValueError):
             linalg.matrix_rank(x)
 
+    def test_matrix_power(self):
+        x = KerasTensor([None, 20, 20])
+        out = linalg.matrix_power(x, 3)
+        self.assertEqual(out.shape, (None, 20, 20))
+
+        out = linalg.matrix_power(x, 0)
+        self.assertEqual(out.shape, (None, 20, 20))
+
+        out = linalg.matrix_power(x, -2)
+        self.assertEqual(out.shape, (None, 20, 20))
+
+        x = KerasTensor([None, None, 20])
+        with self.assertRaises(ValueError):
+            linalg.matrix_power(x, 3)
+
+        x = KerasTensor([None, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.matrix_power(x, 3)
+
     def test_norm(self):
         x = KerasTensor((None, 3))
         self.assertEqual(linalg.norm(x).shape, ())
@@ -295,6 +314,15 @@ class LinalgOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor([10])
         with self.assertRaises(ValueError):
             linalg.matrix_rank(x)
+
+    def test_matrix_power(self):
+        x = KerasTensor([4, 3, 3])
+        out = linalg.matrix_power(x, 3)
+        self.assertEqual(out.shape, (4, 3, 3))
+
+        x = KerasTensor([10, 20, 15])
+        with self.assertRaises(ValueError):
+            linalg.matrix_power(x, 3)
 
     def test_norm(self):
         x = KerasTensor((10, 3))
@@ -696,6 +724,54 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
         # Symbolic shape propagation.
         a_symb = backend.KerasTensor((4, 3, 5), dtype="float32")
         self.assertEqual(linalg.matrix_rank(a_symb).shape, (4,))
+
+    def test_matrix_power(self):
+        x = np.random.rand(4, 3, 3).astype("float32")
+        # Positive power
+        out = linalg.matrix_power(x, 3)
+        expected = np.linalg.matrix_power(x, 3)
+        self.assertAllClose(
+            out, expected, atol=1e-6, tpu_atol=1e-2, tpu_rtol=1e-2
+        )
+
+        # Zero power
+        out = linalg.matrix_power(x, 0)
+        expected = np.linalg.matrix_power(x, 0)
+        self.assertAllClose(
+            out, expected, atol=1e-6, tpu_atol=1e-2, tpu_rtol=1e-2
+        )
+
+        # Zero power (2D)
+        x_2d = np.random.rand(3, 3).astype("float32")
+        out = linalg.matrix_power(x_2d, 0)
+        expected = np.linalg.matrix_power(x_2d, 0)
+        self.assertAllClose(
+            out, expected, atol=1e-6, tpu_atol=1e-2, tpu_rtol=1e-2
+        )
+
+        # Negative power
+        x_inv_stable = (x + np.eye(3)).astype("float32")
+        out = linalg.matrix_power(x_inv_stable, -2)
+        expected = np.linalg.matrix_power(x_inv_stable, -2)
+        self.assertAllClose(
+            out, expected, atol=1e-6, tpu_atol=1e-2, tpu_rtol=1e-2
+        )
+
+        # Power 1
+        out = linalg.matrix_power(x, 1)
+        self.assertAllClose(out, x, atol=1e-6, tpu_atol=1e-2, tpu_rtol=1e-2)
+
+        # Error cases
+        with self.assertRaises(TypeError):
+            linalg.matrix_power(x, 3.5)
+
+        with self.assertRaises(ValueError):
+            # Non-square
+            linalg.matrix_power(np.random.rand(4, 3, 2), 2)
+
+        with self.assertRaises(ValueError):
+            # Rank < 2
+            linalg.matrix_power(np.random.rand(4), 2)
 
     @parameterized.named_parameters(
         ("tall_default_rcond", (7, 4), None),


### PR DESCRIPTION
## Description
This PR introduces the matrix_power operation to the keras.ops.linalg module, providing a unified API to raise square matrices to an integer power n across all supported backends.

`matrix_power` is a fundamental operation in linear algebra with several critical applications in machine learning, physics, and computer science. 

The keras.ops.linalg.matrix_power(x, n) operation raises a square matrix (or a batch of square matrices) to the integer power n.

   - If $n > 0$: The matrix is multiplied by itself $n$ times (calculated efficiently via binary exponentiation).
   - If $n = 0$: Returns the identity matrix of the same shape as x.
   - If $n < 0$: Computes the matrix inverse $x^{-1}$ and then raises it to the power $|n|$.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
