### PR TITLE
Fix torch backend symmetric pad returning edge padding

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1614,6 +1614,22 @@ def pad(x, pad_width, mode="constant", constant_values=None):
             )
         kwargs["value"] = constant_values
     x = convert_to_tensor(x)
+    if mode == "symmetric":
+        # torch has no "symmetric" pad, so mirror manually (including the edge
+        # value). `replicate` only repeats the edge and is numpy's "edge" mode.
+        pw = list(pad_width)
+        if len(pw) == 1:
+            pw = pw * x.ndim
+        for axis, (left, right) in enumerate(pw):
+            if left == 0 and right == 0:
+                continue
+            size = x.shape[axis]
+            period = 2 * size
+            pos = torch.arange(-left, size + right, device=x.device)
+            m = torch.remainder(pos, period)
+            idx = torch.where(m < size, m, period - 1 - m)
+            x = torch.index_select(x, axis, idx)
+        return x
     pad_sum = []
     pad_width = list(pad_width)[::-1]  # torch uses reverse order
     pad_width_sum = 0
@@ -1624,8 +1640,6 @@ def pad(x, pad_width, mode="constant", constant_values=None):
         pad_width_sum -= pad[0] + pad[1]
         if pad_width_sum == 0:  # early break when no padding in higher order
             break
-    if mode == "symmetric":
-        mode = "replicate"
     if mode == "constant":
         return torch.nn.functional.pad(x, pad=pad_sum, mode=mode, **kwargs)
     # TODO: reflect and symmetric padding are implemented for padding the

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6283,9 +6283,9 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         )
     )
     def test_pad(self, dtype, mode, constant_values):
-        # 2D
-        x = np.ones([2, 3], dtype=dtype)
-        pad_width = ((1, 1), (1, 1))
+        # 2D (use varied values so symmetric != edge/reflect padding)
+        x = (np.arange(6).reshape([2, 3]) % 5).astype(dtype)
+        pad_width = ((1, 1), (2, 2))
 
         if mode != "constant":
             if constant_values is not None:


### PR DESCRIPTION
## Description

`keras.ops.pad(..., mode="symmetric")` on the torch backend was returning edge/replicate padding instead of symmetric padding. The torch backend aliased `mode="symmetric"` to torch's `"replicate"` mode, which just repeats the edge value. That is numpy's `"edge"` mode, not `"symmetric"`.

Example on the torch backend before this change:

```python
>>> keras.ops.pad([1,2,3,4,5], ((2,3),), mode="symmetric")
[1, 1, 1, 2, 3, 4, 5, 5, 5, 5]   # wrong (edge padding)
```

numpy (and the jax/tf backends) give:

```python
>>> np.pad([1,2,3,4,5], (2,3), mode="symmetric")
[2, 1, 1, 2, 3, 4, 5, 5, 4, 3]   # correct mirror
```

Fix mirrors the values manually per axis (torch has no native symmetric mode). The index math also handles pad widths larger than the axis size, matching numpy.

The existing test only padded an all-ones array, where symmetric and edge padding are identical, so it never caught this. Updated the 2D case to use varied values.

Verified against `numpy.pad` across 1D/2D/3D, per-dim and broadcast pad widths, larger-than-size pads, and int/float dtypes. `test_pad` passes on the torch backend and fails without the source fix.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
