### PR TITLE
Generalize in_top_k to support multi-dimensional inputs

### DIFF
--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -84,7 +84,7 @@ def top_k(x, k, sorted=True):
 
 
 def in_top_k(targets, predictions, k):
-    targets = targets[:, None]
+    targets = targets[..., None]
     topk_values = top_k(predictions, k)[0]
     targets_values = np.take_along_axis(predictions, targets, axis=-1)
     mask = targets_values >= topk_values

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -175,26 +175,28 @@ def top_k(x, k, sorted=True):
 def in_top_k(targets, predictions, k):
     from keras.src.backend.openvino.numpy import take_along_axis
 
-    one_constant = ov_opset.constant(1, Type.i32)
-    # Expand targets: (batch,) → (batch, 1) for use with take_along_axis
-    targets = ov_opset.unsqueeze(get_ov_output(targets), one_constant).output(0)
+    axis_constant = ov_opset.constant(-1, Type.i32)
+    # Expand targets: (...,) → (..., 1) for use with take_along_axis
+    targets = ov_opset.unsqueeze(get_ov_output(targets), axis_constant).output(
+        0
+    )
     predictions = get_ov_output(predictions)
 
-    # top_k returns (batch, k) sorted descending; last col is the k-th largest
+    # top_k returns (..., k) sorted descending; last col is the k-th largest
     topk_values = top_k(predictions, k)[0]
-    # Grab only the last column (index k-1): threshold value, shape (batch,)
+    # Grab only the last column (index k-1): threshold value, shape (...,)
     k_minus_1_idx = ov_opset.constant([k - 1], dtype=Type.i32).output(0)
-    topk_values_axis = ov_opset.constant(1, dtype=Type.i32).output(0)
+    topk_values_axis = ov_opset.constant(-1, dtype=Type.i32).output(0)
     topk_min = ov_opset.gather(
         topk_values, k_minus_1_idx, topk_values_axis
     ).output(0)
-    # Squeeze back (batch, 1) → (batch,)
-    topk_min = ov_opset.squeeze(topk_min, one_constant).output(0)
+    # Squeeze back (..., 1) → (...,)
+    topk_min = ov_opset.squeeze(topk_min, axis_constant).output(0)
 
-    # Gather the prediction score at each true class index → shape (batch, 1)
+    # Gather the prediction score at each true class index → shape (..., 1)
     targets_values = take_along_axis(predictions, targets, axis=-1)
-    # Squeeze back (batch, 1) → (batch,)
-    targets_values = ov_opset.squeeze(targets_values, one_constant).output(0)
+    # Squeeze back (..., 1) → (...,)
+    targets_values = ov_opset.squeeze(targets_values, axis_constant).output(0)
     # target score >= k-th largest score means it belongs in the top-k
     mask = ov_opset.greater_equal(targets_values, topk_min).output(0)
     return OpenVINOKerasTensor(mask)

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -71,6 +71,14 @@ def top_k(x, k, sorted=True):
 
 
 def in_top_k(targets, predictions, k):
+    if len(predictions.shape) > 2:
+        targets = convert_to_tensor(targets)
+        predictions = convert_to_tensor(predictions)
+        original_shape = tf.shape(targets)
+        predictions = tf.reshape(predictions, [-1, tf.shape(predictions)[-1]])
+        targets = tf.reshape(targets, [-1])
+        result = tf.math.in_top_k(targets, predictions, k)
+        return tf.reshape(result, original_shape)
     return tf.math.in_top_k(targets, predictions, k)
 
 

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -84,7 +84,7 @@ def top_k(x, k, sorted=True):
 
 def in_top_k(targets, predictions, k):
     targets = convert_to_tensor(targets).type(torch.int64)
-    targets = targets[:, None]
+    targets = targets.unsqueeze(-1)
     predictions = convert_to_tensor(predictions)
     topk_values = top_k(predictions, k).values
     targets_values = torch.take_along_dim(predictions, targets, dim=-1)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -739,6 +739,25 @@ class MathOpsCorrectnessTest(testing.TestCase):
             kmath.in_top_k(targets, predictions, k=3), [True, True, True]
         )
 
+        # Test multi-dimensional targets
+        targets = np.array([[1, 0]])
+        predictions = np.array([[[1.0, 0.0], [0.0, 1.0]]], dtype="float32")
+        self.assertAllEqual(
+            kmath.in_top_k(targets, predictions, k=1), [[False, False]]
+        )
+        targets = np.array([[1, 2], [0, 3]])
+        predictions = np.array(
+            [
+                [[0.1, 0.9, 0.8, 0.8], [0.05, 0.95, 0, 1]],
+                [[0.9, 0.1, 0.8, 0.8], [0.1, 0.8, 0.3, 1]],
+            ],
+            dtype="float32",
+        )
+        self.assertAllEqual(
+            kmath.in_top_k(targets, predictions, k=2),
+            [[True, False], [True, True]],
+        )
+
         # Test `nan` in predictions
         # https://github.com/keras-team/keras/issues/19995
         targets = np.array([1, 0])


### PR DESCRIPTION
## Description
This PR updates the in_top_k operation across all backends (Numpy, TensorFlow, Torch, OpenVINO) to support inputs with arbitrary dimensions beyond the standard (batch, classes).

Key changes:
   - Generalized Indexing: Replaced fixed indexing (e.g., [:, None]) with axis=-1 or ellipsis ... in Numpy, Torch, and OpenVINO to support arbitrary input ranks.
   - TensorFlow Backend Support: Implemented a flatten-and-reshape strategy for TensorFlow since tf.math.in_top_k natively only supports 2D predictions and 1D targets.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
