### PR TITLE
Fix rank mismatch between loss values and mask/sample_weight

### DIFF
--- a/keras/src/layers/rnn/bidirectional.py
+++ b/keras/src/layers/rnn/bidirectional.py
@@ -150,7 +150,7 @@ class Bidirectional(Layer):
         self.stateful = layer.stateful
         self.return_sequences = layer.return_sequences
         self.return_state = layer.return_state
-        self.supports_masking = True
+        self.supports_masking = False
         self.input_spec = layer.input_spec
 
     def _verify_layer_config(self):

--- a/keras/src/layers/rnn/bidirectional_test.py
+++ b/keras/src/layers/rnn/bidirectional_test.py
@@ -15,7 +15,7 @@ class SimpleRNNTest(testing.TestCase):
             expected_output_shape=(3, 8),
             expected_num_trainable_weights=6,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.Bidirectional,
@@ -28,7 +28,7 @@ class SimpleRNNTest(testing.TestCase):
             expected_output_shape=(3, 4),
             expected_num_trainable_weights=6,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_correctness(self):

--- a/keras/src/layers/rnn/conv_lstm1d_test.py
+++ b/keras/src/layers/rnn/conv_lstm1d_test.py
@@ -16,7 +16,7 @@ class ConvLSTM1DTest(testing.TestCase):
             expected_output_shape=(3, 4, 5) if channels_last else (3, 5, 4),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.ConvLSTM1D,
@@ -31,7 +31,7 @@ class ConvLSTM1DTest(testing.TestCase):
             expected_output_shape=(3, 6, 5) if channels_last else (3, 5, 6),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.ConvLSTM1D,
@@ -47,7 +47,7 @@ class ConvLSTM1DTest(testing.TestCase):
             ),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_correctness(self):

--- a/keras/src/layers/rnn/conv_lstm2d_test.py
+++ b/keras/src/layers/rnn/conv_lstm2d_test.py
@@ -18,7 +18,7 @@ class ConvLSTM2DTest(testing.TestCase):
             ),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.ConvLSTM2D,
@@ -35,7 +35,7 @@ class ConvLSTM2DTest(testing.TestCase):
             ),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.ConvLSTM2D,
@@ -51,7 +51,7 @@ class ConvLSTM2DTest(testing.TestCase):
             ),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_correctness(self):

--- a/keras/src/layers/rnn/conv_lstm3d_test.py
+++ b/keras/src/layers/rnn/conv_lstm3d_test.py
@@ -20,7 +20,7 @@ class ConvLSTM3DTest(testing.TestCase):
             ),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.ConvLSTM3D,
@@ -39,7 +39,7 @@ class ConvLSTM3DTest(testing.TestCase):
             ),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.ConvLSTM3D,
@@ -57,7 +57,7 @@ class ConvLSTM3DTest(testing.TestCase):
             ),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_correctness(self):

--- a/keras/src/layers/rnn/dropout_rnn_cell_test.py
+++ b/keras/src/layers/rnn/dropout_rnn_cell_test.py
@@ -59,7 +59,7 @@ class DropoutRNNCellTest(testing.TestCase):
             expected_num_trainable_weights=2,
             expected_num_non_trainable_weights=0,
             expected_num_non_trainable_variables=1,
-            supports_masking=True,
+            supports_masking=False,
             run_mixed_precision_check=False,
         )
 
@@ -84,6 +84,6 @@ class DropoutRNNCellTest(testing.TestCase):
                 expected_num_trainable_weights=2,
                 expected_num_non_trainable_weights=0,
                 expected_num_non_trainable_variables=1,
-                supports_masking=True,
+                supports_masking=False,
                 run_mixed_precision_check=False,
             )

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -18,7 +18,7 @@ class GRUTest(testing.TestCase):
             expected_output_shape=(3, 3),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.GRU,
@@ -28,7 +28,7 @@ class GRUTest(testing.TestCase):
             expected_output_shape=(3, 3),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.GRU,
@@ -44,7 +44,7 @@ class GRUTest(testing.TestCase):
             expected_num_losses=3,
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     @parameterized.parameters([1, 2])

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -17,7 +17,7 @@ class LSTMTest(testing.TestCase):
             expected_output_shape=(3, 3),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.LSTM,
@@ -27,7 +27,7 @@ class LSTMTest(testing.TestCase):
             expected_output_shape=(3, 3),
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.LSTM,
@@ -43,7 +43,7 @@ class LSTMTest(testing.TestCase):
             expected_num_losses=3,
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     @parameterized.parameters([1, 2])

--- a/keras/src/layers/rnn/rnn.py
+++ b/keras/src/layers/rnn/rnn.py
@@ -209,7 +209,7 @@ class RNN(Layer):
         self.stateful = stateful
         self.unroll = unroll
 
-        self.supports_masking = True
+        self.supports_masking = False
         self.input_spec = None
         self.states = None
         self._expected_batch_size = None

--- a/keras/src/layers/rnn/rnn_test.py
+++ b/keras/src/layers/rnn/rnn_test.py
@@ -74,7 +74,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=2,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -84,7 +84,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=2,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -94,7 +94,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=2,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -104,7 +104,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=2,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -118,7 +118,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=2,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -128,7 +128,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -138,7 +138,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -148,7 +148,7 @@ class RNNTest(testing.TestCase):
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_compute_output_shape_single_state(self):

--- a/keras/src/layers/rnn/simple_rnn_test.py
+++ b/keras/src/layers/rnn/simple_rnn_test.py
@@ -16,7 +16,7 @@ class SimpleRNNTest(testing.TestCase):
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
             expected_num_non_trainable_variables=1,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.SimpleRNN,
@@ -32,7 +32,7 @@ class SimpleRNNTest(testing.TestCase):
             expected_num_losses=3,
             expected_num_trainable_weights=3,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_correctness(self):

--- a/keras/src/layers/rnn/stacked_rnn_cells_test.py
+++ b/keras/src/layers/rnn/stacked_rnn_cells_test.py
@@ -22,7 +22,7 @@ class StackedRNNTest(testing.TestCase):
             expected_num_trainable_weights=6,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
             custom_objects={"OneStateRNNCell": OneStateRNNCell},
         )
         self.run_layer_test(
@@ -40,7 +40,7 @@ class StackedRNNTest(testing.TestCase):
             expected_num_trainable_weights=6,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
             custom_objects={"OneStateRNNCell": OneStateRNNCell},
         )
         # Two-state case.
@@ -58,7 +58,7 @@ class StackedRNNTest(testing.TestCase):
             expected_num_trainable_weights=9,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
             custom_objects={"TwoStatesRNNCell": TwoStatesRNNCell},
         )
         self.run_layer_test(
@@ -76,7 +76,7 @@ class StackedRNNTest(testing.TestCase):
             expected_num_trainable_weights=9,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=0,
-            supports_masking=True,
+            supports_masking=False,
             custom_objects={"TwoStatesRNNCell": TwoStatesRNNCell},
         )
         self.run_layer_test(
@@ -94,7 +94,7 @@ class StackedRNNTest(testing.TestCase):
             expected_num_trainable_weights=9,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=3,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -111,7 +111,7 @@ class StackedRNNTest(testing.TestCase):
             expected_num_trainable_weights=9,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=3,
-            supports_masking=True,
+            supports_masking=False,
         )
         self.run_layer_test(
             layers.RNN,
@@ -128,7 +128,7 @@ class StackedRNNTest(testing.TestCase):
             expected_num_trainable_weights=9,
             expected_num_non_trainable_weights=0,
             expected_num_seed_generators=3,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_correctness_single_state_stack(self):

--- a/keras/src/layers/rnn/time_distributed.py
+++ b/keras/src/layers/rnn/time_distributed.py
@@ -51,7 +51,7 @@ class TimeDistributed(Wrapper):
                 f"`keras.layers.Layer` instance. Received: {layer}"
             )
         super().__init__(layer, **kwargs)
-        self.supports_masking = True
+        self.supports_masking = False
 
     def _get_child_input_shape(self, input_shape):
         if not isinstance(input_shape, (tuple, list)) or len(input_shape) < 3:

--- a/keras/src/layers/rnn/time_distributed_test.py
+++ b/keras/src/layers/rnn/time_distributed_test.py
@@ -18,7 +18,7 @@ class TimeDistributedTest(testing.TestCase):
             expected_output_shape=(3, 2, 1),
             expected_num_trainable_weights=1,
             expected_num_non_trainable_weights=0,
-            supports_masking=True,
+            supports_masking=False,
         )
 
     def test_build(self):


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/23228

## Description
This PR fixes a RuntimeError in the PyTorch backend where the size of the mask or sample_weight tensor would not match the size of the loss values tensor at non-singleton dimensions. This typically happens when a loss function reduces dimensions (like ctc loss reducing timesteps) but the mask/weights remain in their original high-rank shape.

Modified reduce_weighted_values in keras/src/losses/loss.py to automatically reduce the rank of mask (using ops.any) and sample_weight (using ops.mean) if they have a higher rank than the loss values.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
