### PR TITLE
Fix keras.ops.roll shift/axis handling to match numpy broadcasting

### DIFF
--- a/keras/src/backend/common/backend_utils.py
+++ b/keras/src/backend/common/backend_utils.py
@@ -435,6 +435,31 @@ def to_tuple_or_list(value):
     return value
 
 
+def _roll_arg_to_list(value):
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+        return value if isinstance(value, list) else [value]
+    return [value]
+
+
+def broadcast_shift_and_axis(shift, axis):
+    """Broadcast `shift` and `axis` arguments of `roll` to the same length.
+
+    Mirrors numpy's behavior of broadcasting a scalar (or length-1
+    sequence) `shift`/`axis` against the other argument. Accepts ints,
+    lists, tuples, and array-likes (e.g. numpy arrays) exposing `tolist()`.
+    """
+    shifts = _roll_arg_to_list(shift)
+    axes = _roll_arg_to_list(axis)
+    if len(shifts) == 1:
+        shifts = shifts * len(axes)
+    if len(axes) == 1:
+        axes = axes * len(shifts)
+    return shifts, axes
+
+
 ### Code for ops.vectorize() used for TF and torch backends.
 
 # See http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html

--- a/keras/src/backend/common/backend_utils.py
+++ b/keras/src/backend/common/backend_utils.py
@@ -425,6 +425,8 @@ def to_tuple_or_list(value):
     """Convert the non-`None` value to either a tuple or a list."""
     if value is None:
         return value
+    if hasattr(value, "tolist"):  # e.g. numpy array or scalar
+        value = value.tolist()
     if not isinstance(value, (int, tuple, list)):
         raise ValueError(
             "`value` must be an integer, tuple or list. "
@@ -435,28 +437,24 @@ def to_tuple_or_list(value):
     return value
 
 
-def _roll_arg_to_list(value):
-    if isinstance(value, (list, tuple)):
-        return list(value)
-    if hasattr(value, "tolist"):
-        value = value.tolist()
-        return value if isinstance(value, list) else [value]
-    return [value]
-
-
-def broadcast_shift_and_axis(shift, axis):
-    """Broadcast `shift` and `axis` arguments of `roll` to the same length.
+def normalize_shift_and_axis(shift, axis):
+    """Normalize `shift` and `axis` arguments of `roll` to the same length.
 
     Mirrors numpy's behavior of broadcasting a scalar (or length-1
     sequence) `shift`/`axis` against the other argument. Accepts ints,
-    lists, tuples, and array-likes (e.g. numpy arrays) exposing `tolist()`.
+    lists, tuples, and array-likes (e.g. numpy arrays).
     """
-    shifts = _roll_arg_to_list(shift)
-    axes = _roll_arg_to_list(axis)
+    shifts = list(to_tuple_or_list(shift))
+    axes = list(to_tuple_or_list(axis))
     if len(shifts) == 1:
         shifts = shifts * len(axes)
     if len(axes) == 1:
         axes = axes * len(shifts)
+    if len(shifts) != len(axes):
+        raise ValueError(
+            "`shift` and `axis` must be broadcastable to the same length. "
+            f"Received: shift={shift}, axis={axis}"
+        )
     return shifts, axes
 
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -8,8 +8,8 @@ from openvino import Type
 from keras.src.backend import config
 from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import dtypes
-from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axis
+from keras.src.backend.common.backend_utils import normalize_shift_and_axis
 from keras.src.backend.common.variables import standardize_dtype
 from keras.src.backend.openvino.core import DTYPES_MAX
 from keras.src.backend.openvino.core import DTYPES_MIN
@@ -4145,7 +4145,7 @@ def roll(x, shift, axis=None):
     if axis is not None:
         # The Roll operation requires `shift` and `axis` to have the same
         # length, while numpy broadcasts them against each other.
-        shifts, axes = broadcast_shift_and_axis(shift, axis)
+        shifts, axes = normalize_shift_and_axis(shift, axis)
         result = ov_opset.roll(x, shifts, axes).output(0)
     else:
         output_shape = ov_opset.shape_of(x).output(0)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -4142,7 +4142,15 @@ def reshape(x, newshape):
 def roll(x, shift, axis=None):
     x = get_ov_output(x)
     if axis is not None:
-        result = ov_opset.roll(x, shift, axis).output(0)
+        # The Roll operation requires `shift` and `axis` to have the same
+        # length, while numpy broadcasts them against each other.
+        shifts = list(shift) if isinstance(shift, (list, tuple)) else [shift]
+        axes = list(axis) if isinstance(axis, (list, tuple)) else [axis]
+        if len(shifts) == 1:
+            shifts = shifts * len(axes)
+        if len(axes) == 1:
+            axes = axes * len(shifts)
+        result = ov_opset.roll(x, shifts, axes).output(0)
     else:
         output_shape = ov_opset.shape_of(x).output(0)
         flattened = ov_opset.reshape(

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -8,6 +8,7 @@ from openvino import Type
 from keras.src.backend import config
 from keras.src.backend.common import KerasVariable
 from keras.src.backend.common import dtypes
+from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.variables import standardize_dtype
 from keras.src.backend.openvino.core import DTYPES_MAX
@@ -4144,12 +4145,7 @@ def roll(x, shift, axis=None):
     if axis is not None:
         # The Roll operation requires `shift` and `axis` to have the same
         # length, while numpy broadcasts them against each other.
-        shifts = list(shift) if isinstance(shift, (list, tuple)) else [shift]
-        axes = list(axis) if isinstance(axis, (list, tuple)) else [axis]
-        if len(shifts) == 1:
-            shifts = shifts * len(axes)
-        if len(axes) == 1:
-            axes = axes * len(shifts)
+        shifts, axes = broadcast_shift_and_axis(shift, axis)
         result = ov_opset.roll(x, shifts, axes).output(0)
     else:
         output_shape = ov_opset.shape_of(x).output(0)

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -14,8 +14,8 @@ from keras.src import tree
 from keras.src.backend import config
 from keras.src.backend import standardize_dtype
 from keras.src.backend.common import dtypes
-from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axis
+from keras.src.backend.common.backend_utils import normalize_shift_and_axis
 from keras.src.backend.common.backend_utils import to_tuple_or_list
 from keras.src.backend.common.backend_utils import vectorize_impl
 from keras.src.backend.tensorflow import sparse
@@ -2869,7 +2869,7 @@ def roll(x, shift, axis=None):
     if axis is not None:
         # `tf.roll` requires `shift` and `axis` to have the same length,
         # while numpy broadcasts them against each other.
-        shifts, axes = broadcast_shift_and_axis(shift, axis)
+        shifts, axes = normalize_shift_and_axis(shift, axis)
         return tf.roll(x, shift=shifts, axis=axes)
 
     # If axis is None, the roll happens as a 1-d tensor.

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -14,6 +14,7 @@ from keras.src import tree
 from keras.src.backend import config
 from keras.src.backend import standardize_dtype
 from keras.src.backend.common import dtypes
+from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import to_tuple_or_list
 from keras.src.backend.common.backend_utils import vectorize_impl
@@ -2868,12 +2869,7 @@ def roll(x, shift, axis=None):
     if axis is not None:
         # `tf.roll` requires `shift` and `axis` to have the same length,
         # while numpy broadcasts them against each other.
-        shifts = list(shift) if isinstance(shift, (list, tuple)) else [shift]
-        axes = list(axis) if isinstance(axis, (list, tuple)) else [axis]
-        if len(shifts) == 1:
-            shifts = shifts * len(axes)
-        if len(axes) == 1:
-            axes = axes * len(shifts)
+        shifts, axes = broadcast_shift_and_axis(shift, axis)
         return tf.roll(x, shift=shifts, axis=axes)
 
     # If axis is None, the roll happens as a 1-d tensor.

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2866,7 +2866,15 @@ def reshape(x, newshape):
 def roll(x, shift, axis=None):
     x = convert_to_tensor(x)
     if axis is not None:
-        return tf.roll(x, shift=shift, axis=axis)
+        # `tf.roll` requires `shift` and `axis` to have the same length,
+        # while numpy broadcasts them against each other.
+        shifts = list(shift) if isinstance(shift, (list, tuple)) else [shift]
+        axes = list(axis) if isinstance(axis, (list, tuple)) else [axis]
+        if len(shifts) == 1:
+            shifts = shifts * len(axes)
+        if len(axes) == 1:
+            axes = axes * len(shifts)
+        return tf.roll(x, shift=shifts, axis=axes)
 
     # If axis is None, the roll happens as a 1-d tensor.
     original_shape = tf.shape(x)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1823,7 +1823,17 @@ def reshape(x, newshape):
 
 def roll(x, shift, axis=None):
     x = convert_to_tensor(x)
-    return torch.roll(x, shift, dims=axis)
+    if axis is not None:
+        # `torch.roll` requires `shifts` and `dims` to have the same length,
+        # while numpy broadcasts them against each other.
+        shifts = list(shift) if isinstance(shift, (list, tuple)) else [shift]
+        axes = list(axis) if isinstance(axis, (list, tuple)) else [axis]
+        if len(shifts) == 1:
+            shifts = shifts * len(axes)
+        if len(axes) == 1:
+            axes = axes * len(shifts)
+        return torch.roll(x, tuple(shifts), dims=tuple(axes))
+    return torch.roll(x, shift)
 
 
 def searchsorted(sorted_sequence, values, side="left"):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -7,8 +7,8 @@ import torch
 from keras.src.backend import KerasTensor
 from keras.src.backend import config
 from keras.src.backend.common import dtypes
-from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axis
+from keras.src.backend.common.backend_utils import normalize_shift_and_axis
 from keras.src.backend.common.backend_utils import to_tuple_or_list
 from keras.src.backend.common.backend_utils import vectorize_impl
 from keras.src.backend.common.variables import standardize_dtype
@@ -1827,7 +1827,7 @@ def roll(x, shift, axis=None):
     if axis is not None:
         # `torch.roll` requires `shifts` and `dims` to have the same length,
         # while numpy broadcasts them against each other.
-        shifts, axes = broadcast_shift_and_axis(shift, axis)
+        shifts, axes = normalize_shift_and_axis(shift, axis)
         return torch.roll(x, tuple(shifts), dims=tuple(axes))
     return torch.roll(x, shift)
 

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -7,6 +7,7 @@ import torch
 from keras.src.backend import KerasTensor
 from keras.src.backend import config
 from keras.src.backend.common import dtypes
+from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import to_tuple_or_list
 from keras.src.backend.common.backend_utils import vectorize_impl
@@ -1826,12 +1827,7 @@ def roll(x, shift, axis=None):
     if axis is not None:
         # `torch.roll` requires `shifts` and `dims` to have the same length,
         # while numpy broadcasts them against each other.
-        shifts = list(shift) if isinstance(shift, (list, tuple)) else [shift]
-        axes = list(axis) if isinstance(axis, (list, tuple)) else [axis]
-        if len(shifts) == 1:
-            shifts = shifts * len(axes)
-        if len(axes) == 1:
-            axes = axes * len(shifts)
+        shifts, axes = broadcast_shift_and_axis(shift, axis)
         return torch.roll(x, tuple(shifts), dims=tuple(axes))
     return torch.roll(x, shift)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7361,6 +7361,17 @@ class Roll(Operation):
     def compute_output_spec(self, x):
         if self.axis is not None:
             canonicalize_axes(self.axis, len(x.shape))
+        if (
+            isinstance(self.shift, (list, tuple))
+            and isinstance(self.axis, (list, tuple))
+            and len(self.shift) != 1
+            and len(self.axis) != 1
+            and len(self.shift) != len(self.axis)
+        ):
+            raise ValueError(
+                "`shift` and `axis` must be broadcastable to the same "
+                f"length. Received: shift={self.shift}, axis={self.axis}"
+            )
         return KerasTensor(x.shape, dtype=x.dtype)
 
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9,9 +9,9 @@ from keras.src.api_export import keras_export
 from keras.src.backend import KerasTensor
 from keras.src.backend import any_symbolic_tensors
 from keras.src.backend.common import dtypes
-from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axes
 from keras.src.backend.common.backend_utils import canonicalize_axis
+from keras.src.backend.common.backend_utils import normalize_shift_and_axis
 from keras.src.backend.common.backend_utils import to_tuple_or_list
 from keras.src.ops import operation_utils
 from keras.src.ops.operation import Operation
@@ -7361,14 +7361,8 @@ class Roll(Operation):
 
     def compute_output_spec(self, x):
         if self.axis is not None:
-            shifts, axes = broadcast_shift_and_axis(self.shift, self.axis)
+            _, axes = normalize_shift_and_axis(self.shift, self.axis)
             canonicalize_axes(axes, len(x.shape))
-            if len(shifts) != len(axes):
-                raise ValueError(
-                    "`shift` and `axis` must be broadcastable to the same "
-                    f"length. Received: shift={self.shift}, "
-                    f"axis={self.axis}"
-                )
         return KerasTensor(x.shape, dtype=x.dtype)
 
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9,6 +9,7 @@ from keras.src.api_export import keras_export
 from keras.src.backend import KerasTensor
 from keras.src.backend import any_symbolic_tensors
 from keras.src.backend.common import dtypes
+from keras.src.backend.common.backend_utils import broadcast_shift_and_axis
 from keras.src.backend.common.backend_utils import canonicalize_axes
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import to_tuple_or_list
@@ -7360,18 +7361,14 @@ class Roll(Operation):
 
     def compute_output_spec(self, x):
         if self.axis is not None:
-            canonicalize_axes(self.axis, len(x.shape))
-        if (
-            isinstance(self.shift, (list, tuple))
-            and isinstance(self.axis, (list, tuple))
-            and len(self.shift) != 1
-            and len(self.axis) != 1
-            and len(self.shift) != len(self.axis)
-        ):
-            raise ValueError(
-                "`shift` and `axis` must be broadcastable to the same "
-                f"length. Received: shift={self.shift}, axis={self.axis}"
-            )
+            shifts, axes = broadcast_shift_and_axis(self.shift, self.axis)
+            canonicalize_axes(axes, len(x.shape))
+            if len(shifts) != len(axes):
+                raise ValueError(
+                    "`shift` and `axis` must be broadcastable to the same "
+                    f"length. Received: shift={self.shift}, "
+                    f"axis={self.axis}"
+                )
         return KerasTensor(x.shape, dtype=x.dtype)
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -2257,10 +2257,16 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.roll(x, 1, axis=[0, 1]).shape, (None, 3))
         self.assertEqual(knp.roll(x, [1, 2], axis=[0, 1]).shape, (None, 3))
         self.assertEqual(knp.roll(x, [1, 2], axis=[0]).shape, (None, 3))
+        self.assertEqual(
+            knp.roll(x, np.array([1, 2]), axis=np.array([0, 1])).shape,
+            (None, 3),
+        )
         with self.assertRaises(ValueError):
             knp.roll(x, 1, axis=2)
         with self.assertRaises(ValueError):
             knp.roll(x, [1, 2, 3], axis=[0, 1])
+        with self.assertRaises(ValueError):
+            knp.roll(x, np.array([1, 2, 3]), axis=np.array([0, 1]))
 
     def test_round(self):
         x = KerasTensor((None, 3))
@@ -6501,6 +6507,10 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         )
         self.assertAllClose(
             knp.roll(x, (1, 2), axis=(1,)), np.roll(x, (1, 2), axis=(1,))
+        )
+        self.assertAllClose(
+            knp.roll(x, np.array([1, 2]), axis=np.array([0, 1])),
+            np.roll(x, [1, 2], axis=[0, 1]),
         )
         self.assertAllClose(knp.Roll(1)(x), np.roll(x, 1))
         self.assertAllClose(knp.Roll(1, axis=1)(x), np.roll(x, 1, axis=1))

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -2255,8 +2255,12 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.roll(x, 1, axis=1).shape, (None, 3))
         self.assertEqual(knp.roll(x, 1, axis=0).shape, (None, 3))
         self.assertEqual(knp.roll(x, 1, axis=[0, 1]).shape, (None, 3))
+        self.assertEqual(knp.roll(x, [1, 2], axis=[0, 1]).shape, (None, 3))
+        self.assertEqual(knp.roll(x, [1, 2], axis=[0]).shape, (None, 3))
         with self.assertRaises(ValueError):
             knp.roll(x, 1, axis=2)
+        with self.assertRaises(ValueError):
+            knp.roll(x, [1, 2, 3], axis=[0, 1])
 
     def test_round(self):
         x = KerasTensor((None, 3))
@@ -3072,6 +3076,9 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(knp.roll(x, 1).shape, (2, 3))
         self.assertEqual(knp.roll(x, 1, axis=1).shape, (2, 3))
         self.assertEqual(knp.roll(x, 1, axis=0).shape, (2, 3))
+        self.assertEqual(knp.roll(x, 1, axis=[0, 1]).shape, (2, 3))
+        with self.assertRaises(ValueError):
+            knp.roll(x, [1, 2, 3], axis=[0, 1])
 
     def test_round(self):
         x = KerasTensor((2, 3))
@@ -6486,9 +6493,21 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.roll(x, 1), np.roll(x, 1))
         self.assertAllClose(knp.roll(x, 1, axis=1), np.roll(x, 1, axis=1))
         self.assertAllClose(knp.roll(x, -1, axis=0), np.roll(x, -1, axis=0))
+        self.assertAllClose(
+            knp.roll(x, 1, axis=(0, 1)), np.roll(x, 1, axis=(0, 1))
+        )
+        self.assertAllClose(
+            knp.roll(x, (1, 2), axis=(0, 1)), np.roll(x, (1, 2), axis=(0, 1))
+        )
+        self.assertAllClose(
+            knp.roll(x, (1, 2), axis=(1,)), np.roll(x, (1, 2), axis=(1,))
+        )
         self.assertAllClose(knp.Roll(1)(x), np.roll(x, 1))
         self.assertAllClose(knp.Roll(1, axis=1)(x), np.roll(x, 1, axis=1))
         self.assertAllClose(knp.Roll(-1, axis=0)(x), np.roll(x, -1, axis=0))
+        self.assertAllClose(
+            knp.Roll(1, axis=(0, 1))(x), np.roll(x, 1, axis=(0, 1))
+        )
 
     def test_round(self):
         x = np.array([[1.1, 2.5, 3.9], [3.2, 2.3, 1.8]])


### PR DESCRIPTION
## Description

Fix `keras.ops.roll` shift/axis handling to match NumPy broadcasting behavior.

### Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.