### PR TITLE
Fix OrbaxCheckpoint restoration for Sequential models (#23251)

### DIFF
--- a/keras/src/callbacks/orbax_checkpoint_test.py
+++ b/keras/src/callbacks/orbax_checkpoint_test.py
@@ -5,6 +5,7 @@ import pytest
 from absl.testing import parameterized
 
 from keras.src import backend
+from keras.src import callbacks
 from keras.src import layers
 from keras.src import models
 from keras.src import saving
@@ -543,6 +544,68 @@ class OrbaxCheckpointTest(testing.TestCase, parameterized.TestCase):
         {"save_on_background": True},
     )
     @pytest.mark.requires_trainable_backend
+    def test_sequential_model_weight_roundtrip(self, save_on_background):
+        """Test model state restoration with exact weight matching for Sequential model."""
+        import numpy as np
+
+        utils.set_random_seed(123)
+
+        model = models.Sequential([
+            layers.Input((8,)),
+            layers.Dense(16, activation="relu"),
+            layers.Dense(1),
+        ])
+
+        model.compile(optimizer="adam", loss="mse")
+
+        x = np.random.randn(128, 8).astype("float32")
+        y = np.random.randn(128, 1).astype("float32")
+
+        class CaptureWeights(callbacks.Callback):
+            def on_epoch_end(self, epoch, logs=None):
+                self.saved_weights = [
+                    w.numpy().copy()
+                    for w in self.model.weights
+                ]
+
+        capture = CaptureWeights()
+
+        checkpoint_dir = os.path.join(
+            self.get_temp_dir(),
+            f"test_sequential_{save_on_background}_{id(self)}",
+        )
+
+        checkpoint = OrbaxCheckpoint(
+            directory=checkpoint_dir,
+            max_to_keep=2,
+            save_on_background=save_on_background,
+        )
+
+        model.fit(
+            x,
+            y,
+            epochs=1,
+            batch_size=16,
+            callbacks=[capture, checkpoint],
+            verbose=0,
+        )
+
+        restored = saving.load_model(checkpoint_dir)
+
+        self.assertEqual(len(capture.saved_weights), len(restored.weights))
+        for expected, actual in zip(capture.saved_weights, restored.weights):
+            self.assertAllClose(
+                expected,
+                actual,
+                atol=1e-6,
+                rtol=1e-6,
+                msg="Sequential weight mismatch on load_model",
+            )
+
+    @parameterized.parameters(
+        {"save_on_background": False},
+        {"save_on_background": True},
+    )
     def test_comprehensive_model_state_restoration(self, save_on_background):
         """Test comprehensive model state restoration with exact weight
         matching.

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -402,25 +402,45 @@ def _normalize_state_tree(loaded_state, model_state):
         normalized_flat = {}
         matched_loaded_paths = set()
         
+        # Pre-process loaded_flat for fast O(1) lookups
+        suffix_to_loaded = {}
+        opt_matches = {}
+        
+        for loaded_path in loaded_flat:
+            parts = loaded_path.split("/")
+            for i in range(1, len(parts)):
+                suffix = "/".join(parts[i:])
+                if suffix not in suffix_to_loaded:
+                    suffix_to_loaded[suffix] = loaded_path
+            
+            if len(parts) > 1:
+                dir_prefix = "/".join(parts[:-1])
+                var_name = parts[-1]
+                sub_parts = var_name.split("_")
+                for i in range(1, len(sub_parts)):
+                    sub_suffix = "_".join(sub_parts[i:])
+                    key_opt = (dir_prefix, sub_suffix)
+                    if key_opt not in opt_matches:
+                        opt_matches[key_opt] = loaded_path
+        
         for model_path in model_flat:
             if model_path in loaded_flat:
                 normalized_flat[model_path] = loaded_flat[model_path]
                 matched_loaded_paths.add(model_path)
+            elif model_path in suffix_to_loaded:
+                loaded_path = suffix_to_loaded[model_path]
+                normalized_flat[model_path] = loaded_flat[loaded_path]
+                matched_loaded_paths.add(loaded_path)
             else:
-                for loaded_path in loaded_flat:
-                    if loaded_path.endswith("/" + model_path):
+                model_parts = model_path.split("/")
+                if len(model_parts) > 1:
+                    dir_prefix = "/".join(model_parts[:-1])
+                    var_name = model_parts[-1]
+                    key_opt = (dir_prefix, var_name)
+                    if key_opt in opt_matches:
+                        loaded_path = opt_matches[key_opt]
                         normalized_flat[model_path] = loaded_flat[loaded_path]
                         matched_loaded_paths.add(loaded_path)
-                        break
-                    
-                    loaded_parts = loaded_path.split("/")
-                    model_parts = model_path.split("/")
-                    if len(loaded_parts) == len(model_parts):
-                        if loaded_parts[:-1] == model_parts[:-1]:
-                            if loaded_parts[-1].endswith("_" + model_parts[-1]):
-                                normalized_flat[model_path] = loaded_flat[loaded_path]
-                                matched_loaded_paths.add(loaded_path)
-                                break
         
         for loaded_path, value in loaded_flat.items():
             if loaded_path not in matched_loaded_paths:

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -354,7 +354,9 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
 
         loaded_state = loaded_checkpointables["pytree"]
 
-        # Set the model state directly from the loaded state
+        loaded_state = _normalize_state_tree(
+            loaded_state, model.get_state_tree()
+        )
         model.set_state_tree(loaded_state)
     else:
         raise ValueError(
@@ -363,6 +365,70 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
             "`.weights.h5` files, legacy H5 format files "
             "(`.h5` extension), or Orbax checkpoints."
         )
+
+
+def _normalize_state_tree(loaded_state, model_state):
+    """Normalizes the paths in the loaded state tree to match the model's.
+    """
+    normalized_state = {}
+    
+    def flatten(d, prefix=""):
+        res = {}
+        for k, v in d.items():
+            if isinstance(v, dict):
+                res.update(flatten(v, prefix + k + "/"))
+            else:
+                res[prefix + k] = v
+        return res
+        
+    def unflatten(d):
+        res = {}
+        for k, v in d.items():
+            parts = k.split("/")
+            curr = res
+            for p in parts[:-1]:
+                curr = curr.setdefault(p, {})
+            curr[parts[-1]] = v
+        return res
+
+    for key, loaded_val in loaded_state.items():
+        if key not in model_state:
+            normalized_state[key] = loaded_val
+            continue
+            
+        loaded_flat = flatten(loaded_val)
+        model_flat = flatten(model_state[key])
+        
+        normalized_flat = {}
+        matched_loaded_paths = set()
+        
+        for model_path in model_flat:
+            if model_path in loaded_flat:
+                normalized_flat[model_path] = loaded_flat[model_path]
+                matched_loaded_paths.add(model_path)
+            else:
+                for loaded_path in loaded_flat:
+                    if loaded_path.endswith("/" + model_path):
+                        normalized_flat[model_path] = loaded_flat[loaded_path]
+                        matched_loaded_paths.add(loaded_path)
+                        break
+                    
+                    loaded_parts = loaded_path.split("/")
+                    model_parts = model_path.split("/")
+                    if len(loaded_parts) == len(model_parts):
+                        if loaded_parts[:-1] == model_parts[:-1]:
+                            if loaded_parts[-1].endswith("_" + model_parts[-1]):
+                                normalized_flat[model_path] = loaded_flat[loaded_path]
+                                matched_loaded_paths.add(loaded_path)
+                                break
+        
+        for loaded_path, value in loaded_flat.items():
+            if loaded_path not in matched_loaded_paths:
+                normalized_flat[loaded_path] = value
+                
+        normalized_state[key] = unflatten(normalized_flat)
+        
+    return normalized_state
 
 
 def _load_model_from_orbax_checkpoint(
@@ -441,7 +507,7 @@ def _load_model_from_orbax_checkpoint(
         if key in composite_state
     }
 
-    # Apply the loaded state to the model
+    state_tree = _normalize_state_tree(state_tree, model.get_state_tree())
     model.set_state_tree(state_tree)
 
     # Load assets if present

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -378,3 +378,33 @@ class LoadWeightsTests(test_case.TestCase):
         dest_weights = dest_model.get_weights()
         for orig, loaded in zip(src_weights, dest_weights):
             self.assertAllClose(orig, loaded)
+
+    def test_normalize_state_tree_coverage(self):
+        from keras.src.saving.saving_api import _normalize_state_tree
+        
+        loaded_state = {
+            "extra_root_key": {"some_val": np.array([1])},
+            "layer": {
+                "sequential/dense/kernel": np.array([1]),
+                "unmatched_loaded_var": np.array([2]),
+                "adam/sequential_dense_kernel_m": np.array([3]),
+            }
+        }
+        
+        model_state = {
+            "layer": {
+                "dense/kernel": np.array([0]),
+                "adam/dense_kernel_m": np.array([0]),
+                "unmatched_model_var": np.array([0]),
+                "adam/unmatched_model_var": np.array([0]),
+            }
+        }
+        
+        normalized = _normalize_state_tree(loaded_state, model_state)
+        
+        self.assertIn("extra_root_key", normalized)
+        
+        layer_state = normalized["layer"]
+        self.assertEqual(layer_state["dense"]["kernel"].tolist(), [1])
+        self.assertEqual(layer_state["adam"]["dense_kernel_m"].tolist(), [3])
+        self.assertEqual(layer_state["unmatched_loaded_var"].tolist(), [2])


### PR DESCRIPTION
## Description
Fixes #23251.

When a `Sequential` model is rebuilt via `keras.saving.load_model()`, its variables are initialized without the `sequential/` prefix. Because `OrbaxCheckpoint` expects an exact path match when calling `set_state_tree()`, it silently skipped assigning these weights. 

This PR adds a `_normalize_state_tree` helper to `saving_api.py` that dynamically aligns the loaded Orbax paths with the rebuilt model's expected paths using a suffix match. It correctly restores both trainable variables and optimizer variables (which separate paths with `_`). An automated test `test_sequential_model_weight_roundtrip` has been added to prevent regressions.

**Disclosure:** I used an AI tool to help diagnose the bug, draft the patch, and write the test suite. However, I have comprehensively reviewed the code, manually tested it, and fully grasp the underlying mechanics of the fix (how Sequential model variables lose their name prefix during load_model() deserialization).

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
