### PR TITLE
Fix Functional model dict inputs ignoring extra keys (#23258)

### DIFF
--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -364,10 +364,27 @@ class Functional(Function, Model):
         elif isinstance(inputs, dict) and isinstance(
             self._inputs_struct, dict
         ):
-            expected_keys = set(self._inputs_struct.keys())
-            runtime_keys = set(inputs.keys())
-            if expected_keys.issubset(runtime_keys) and expected_keys != runtime_keys:
-                inputs = {k: inputs[k] for k in self._inputs_struct}
+            def prune_extra_keys(expected, runtime):
+                if isinstance(expected, dict) and isinstance(runtime, dict):
+                    return {
+                        k: prune_extra_keys(expected[k], runtime[k])
+                        for k in expected
+                        if k in runtime
+                    }
+                elif isinstance(expected, (list, tuple)) and isinstance(
+                    runtime, (list, tuple)
+                ):
+                    min_len = min(len(expected), len(runtime))
+                    res = [
+                        prune_extra_keys(expected[i], runtime[i])
+                        for i in range(min_len)
+                    ]
+                    if len(runtime) > min_len:
+                        res.extend(runtime[min_len:])
+                    return type(runtime)(res)
+                return runtime
+
+            inputs = prune_extra_keys(self._inputs_struct, inputs)
         if (
             isinstance(self._inputs_struct, dict)
             and not isinstance(inputs, dict)

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -361,6 +361,13 @@ class Functional(Function, Model):
                     raise_exception = True
             else:
                 raise_exception = True
+        elif isinstance(inputs, dict) and isinstance(
+            self._inputs_struct, dict
+        ):
+            expected_keys = set(self._inputs_struct.keys())
+            runtime_keys = set(inputs.keys())
+            if expected_keys.issubset(runtime_keys) and expected_keys != runtime_keys:
+                inputs = {k: inputs[k] for k in self._inputs_struct}
         if (
             isinstance(self._inputs_struct, dict)
             and not isinstance(inputs, dict)

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -241,6 +241,22 @@ class FunctionalTest(testing.TestCase):
         out_val = model(in_val)
         self.assertEqual(out_val.shape, (2, 3))
 
+        i1, i2 = Input((1,)), Input((2,))
+        nested_model = Functional(
+            {"1": i1, "others": {"2": i2}},
+            i1,
+        )
+        nested_in_val = {
+            "1": np.ones((2, 1)),
+            "others": {
+                "2": np.ones((2, 2)),
+                "0_extra": np.ones((2, 1)),
+            },
+            "top_extra": np.ones((2, 1)),
+        }
+        nested_out_val = nested_model(nested_in_val)
+        self.assertEqual(nested_out_val.shape, (2, 1))
+
     @parameterized.named_parameters(
         ("list", list),
         ("tuple", tuple),

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -221,26 +221,25 @@ class FunctionalTest(testing.TestCase):
 
         model = Functional({"a": input_a}, outputs)
 
-        with pytest.warns() as record:
-            # Eager call
-            in_val = {
-                "a": np.random.random((2, 3)),
-                "b": np.random.random((2, 1)),
-            }
-            out_val = model(in_val)
-            self.assertEqual(out_val.shape, (2, 3))
+        in_val = {
+            "a": np.random.random((2, 3)),
+            "b": np.random.random((2, 1)),
+        }
+        out_val = model(in_val)
+        self.assertEqual(out_val.shape, (2, 3))
 
-            # Symbolic call
-            input_a_2 = Input(shape=(3,), batch_size=2)
-            input_b_2 = Input(shape=(1,), batch_size=2)
-            in_val = {"a": input_a_2, "b": input_b_2}
-            out_val = model(in_val)
-            self.assertEqual(out_val.shape, (2, 3))
-        self.assertLen(record, 1)
-        self.assertStartsWith(
-            str(record[0].message),
-            r"The structure of `inputs` doesn't match the expected structure",
-        )
+        input_a_2 = Input(shape=(3,), batch_size=2)
+        input_b_2 = Input(shape=(1,), batch_size=2)
+        in_val = {"a": input_a_2, "b": input_b_2}
+        out_val = model(in_val)
+        self.assertEqual(out_val.shape, (2, 3))
+
+        in_val = {
+            "0_extra": np.random.random((2, 1)),
+            "a": np.random.random((2, 3)),
+        }
+        out_val = model(in_val)
+        self.assertEqual(out_val.shape, (2, 3))
 
     @parameterized.named_parameters(
         ("list", list),

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -257,6 +257,19 @@ class FunctionalTest(testing.TestCase):
         nested_out_val = nested_model(nested_in_val)
         self.assertEqual(nested_out_val.shape, (2, 1))
 
+        i3 = Input((3,))
+        list_nested_model = Functional(
+            {"1": i1, "others_list": [i2, i3]},
+            i1,
+        )
+        list_nested_in_val = {
+            "1": np.ones((2, 1)),
+            "others_list": [np.ones((2, 2)), np.ones((2, 3)), np.ones((2, 4))],
+            "top_extra": np.ones((2, 1)),
+        }
+        list_nested_out_val = list_nested_model(list_nested_in_val)
+        self.assertEqual(list_nested_out_val.shape, (2, 1))
+
     @parameterized.named_parameters(
         ("list", list),
         ("tuple", tuple),


### PR DESCRIPTION
## Description
Fixes #23258.

When both the model and runtime inputs are dicts, `_standardize_inputs` skips name-based key selection. Extra runtime keys are flattened alphabetically by `tree.flatten()`, pairing the wrong tensor with the declared input. This adds a dict-to-dict reconciliation branch that filters extra keys by name, consistent with the existing list/tensor input path.

**Disclosure:** I used an AI tool to help diagnose the bug and draft the patch. I have manually reviewed, tested, and take full responsibility for the code.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
