### PR TITLE
Escape interpolated fields in make_layer_label

### DIFF
--- a/keras/src/utils/model_visualization.py
+++ b/keras/src/utils/model_visualization.py
@@ -1,5 +1,6 @@
 """Utilities related to model visualization."""
 
+import html
 import os
 import sys
 
@@ -82,14 +83,15 @@ def make_layer_label(layer, **kwargs):
         table += (
             f'<tr><td colspan="{colspan}" bgcolor="black">'
             '<font point-size="16" color="white">'
-            f"<b>{layer.name}</b> ({class_name})"
+            f"<b>{html.escape(str(layer.name))}</b> "
+            f"({html.escape(class_name)})"
             "</font></td></tr>"
         )
     else:
         table += (
             f'<tr><td colspan="{colspan}" bgcolor="black">'
             '<font point-size="16" color="white">'
-            f"<b>{class_name}</b>"
+            f"<b>{html.escape(class_name)}</b>"
             "</font></td></tr>"
         )
     if (
@@ -100,7 +102,8 @@ def make_layer_label(layer, **kwargs):
         table += (
             f'<tr><td bgcolor="white" colspan="{colspan}">'
             '<font point-size="14">'
-            f"Activation: <b>{get_layer_activation_name(layer)}</b>"
+            "Activation: "
+            f"<b>{html.escape(str(get_layer_activation_name(layer)))}</b>"
             "</font></td></tr>"
         )
 
@@ -125,7 +128,7 @@ def make_layer_label(layer, **kwargs):
                 shape_str = shape_str.replace("}", "").replace("{", "")
             else:
                 shape_str = "?"
-            return shape_str
+            return html.escape(shape_str)
 
         if class_name != "InputLayer":
             cols.append(
@@ -151,7 +154,7 @@ def make_layer_label(layer, **kwargs):
         cols.append(
             (
                 '<td bgcolor="white"><font point-size="14">'
-                f"Output dtype: <b>{dtype or '?'}</b>"
+                f"Output dtype: <b>{html.escape(str(dtype or '?'))}</b>"
                 "</font></td>"
             )
         )

--- a/keras/src/utils/model_visualization_test.py
+++ b/keras/src/utils/model_visualization_test.py
@@ -1,0 +1,23 @@
+from keras.src import layers
+from keras.src.testing import test_case
+from keras.src.utils import model_visualization
+
+
+class ModelVisualizationTest(test_case.TestCase):
+    def test_make_layer_label_escapes_html_metacharacters(self):
+        # Layer names only disallow "/", so "<", ">", "&" and '"' are valid and
+        # must be entity-escaped before being placed in the Graphviz HTML-like
+        # label. Otherwise a name can close the label and inject DOT attributes.
+        name = 'bad>, tooltip="x'
+        layer = layers.Dense(1, name=name)
+        label = model_visualization.make_layer_label(
+            layer,
+            show_layer_names=True,
+            show_layer_activations=False,
+            show_dtype=False,
+            show_shapes=False,
+            show_trainable=False,
+        )
+        self.assertNotIn(name, label)
+        self.assertNotIn('tooltip="x', label)
+        self.assertIn("bad&gt;, tooltip=&quot;x", label)


### PR DESCRIPTION
## Description

1. layer names only forbid "/", so <, >, & and " are allowed, and make_layer_label drops the name, class name, activation, shape and dtype straight into a graphviz HTML-like node label.
2. an unbalanced > ends the label early, so the trailing template text becomes part of the node's attribute list and a name taken from an untrusted config can inject dot attributes such as image or shapefile that graphviz resolves against local paths; a plain "&" on its own already produces invalid label markup.

html.escape each interpolated value before it enters the label. Added a make_layer_label test for the escaping.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ ] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
