### PR TITLE
Fix ops.select output-shape/dtype inference under broadcasting

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9476,8 +9476,25 @@ class Select(Operation):
         return backend.numpy.select(condlist, choicelist, default)
 
     def compute_output_spec(self, condlist, choicelist, default=0):
-        first_element = choicelist[0]
-        return KerasTensor(first_element.shape, dtype=first_element.dtype)
+        # `select` broadcasts every array in `condlist` and `choicelist` (and
+        # `default`) to a common shape and promotes the dtype across all
+        # choices, like `where` above -- rather than assuming the first
+        # choice's shape/dtype, which is wrong when a condition or a later
+        # choice is broader than the first.
+        output_shape = ()
+        for condition in condlist:
+            output_shape = broadcast_shapes(
+                output_shape, getattr(condition, "shape", [])
+            )
+        dtypes_to_resolve = []
+        for choice in choicelist:
+            output_shape = broadcast_shapes(
+                output_shape, getattr(choice, "shape", [])
+            )
+            dtypes_to_resolve.append(getattr(choice, "dtype", type(choice)))
+        dtypes_to_resolve.append(getattr(default, "dtype", type(default)))
+        output_dtype = dtypes.result_type(*dtypes_to_resolve)
+        return KerasTensor(output_shape, dtype=output_dtype)
 
 
 @keras_export(["keras.ops.select", "keras.ops.numpy.select"])

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9479,19 +9479,16 @@ class Select(Operation):
         # `select` broadcasts every array in `condlist` and `choicelist` (and
         # `default`) to a common shape and promotes the dtype across all
         # choices, like `where` above -- rather than assuming the first
-        # choice's shape/dtype, which is wrong when a condition or a later
-        # choice is broader than the first.
+        # choice's shape/dtype, which is wrong when a condition, a later
+        # choice, or `default` is broader than the first choice.
         output_shape = ()
-        for condition in condlist:
+        for x in list(condlist) + list(choicelist) + [default]:
             output_shape = broadcast_shapes(
-                output_shape, getattr(condition, "shape", [])
+                output_shape, getattr(x, "shape", [])
             )
-        dtypes_to_resolve = []
-        for choice in choicelist:
-            output_shape = broadcast_shapes(
-                output_shape, getattr(choice, "shape", [])
-            )
-            dtypes_to_resolve.append(getattr(choice, "dtype", type(choice)))
+        dtypes_to_resolve = [
+            getattr(choice, "dtype", type(choice)) for choice in choicelist
+        ]
         dtypes_to_resolve.append(getattr(default, "dtype", type(default)))
         output_dtype = dtypes.result_type(*dtypes_to_resolve)
         return KerasTensor(output_shape, dtype=output_dtype)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7142,6 +7142,13 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         y = knp.select([x > 0], [row], 0)
         self.assertEqual(y.shape, (2, 3))
 
+        # `default` is broadcast too: a broader default widens the shape.
+        cond = backend.KerasTensor((1,))
+        choice = backend.KerasTensor((1,))
+        default_value = backend.KerasTensor((2, 3))
+        y = knp.select([cond > 0], [choice], default_value)
+        self.assertEqual(y.shape, (2, 3))
+
     def test_slogdet(self):
         x = np.ones((4, 4)) * 2.0
         out = knp.slogdet(x)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -7134,6 +7134,14 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         y = knp.select(condlist, choicelist, 42)
         self.assertEqual(y.shape, (6,))
 
+        # A broader condition or later choice widens the inferred shape (it is
+        # broadcast against every condition and choice, like `where`), not just
+        # the first choice's shape.
+        x = backend.KerasTensor((2, 3))
+        row = backend.KerasTensor((3,))
+        y = knp.select([x > 0], [row], 0)
+        self.assertEqual(y.shape, (2, 3))
+
     def test_slogdet(self):
         x = np.ones((4, 4)) * 2.0
         out = knp.slogdet(x)


### PR DESCRIPTION
Fixes #23264.

## Description

`keras.ops.select` broadcasts every array in `condlist` and `choicelist` (and `default`) to a common shape and promotes the dtype across all choices, but `Select.compute_output_spec` returned `choicelist[0]`'s shape and dtype:

```python
def compute_output_spec(self, condlist, choicelist, default=0):
    first_element = choicelist[0]
    return KerasTensor(first_element.shape, dtype=first_element.dtype)
```

So the inferred shape is wrong whenever a condition, a later choice, or `default` is broader than the first choice (`ops.select([x>0], [row], 0)` with `x=(None,3)`, `row=(None,1)` infers `(None,1)` but the real output is `(4,3)`), and only the first choice's dtype was considered.

**Fix:** mirror the sibling `Where.compute_output_spec` — broadcast the output shape over all conditions, choices, and `default`, and resolve the dtype with `dtypes.result_type` across all choices and `default`.

**Tests:** extended `test_select` with a broadcasting-condition case and a broadcasting-`default` case (each widens the inferred shape). They fail before this change and pass after; the existing equal-shape cases are unchanged. Verified on the numpy backend.

### AI assistance disclosure (per the AI-Assisted Contribution Policy)

This change was developed with the assistance of an AI coding tool. I have reviewed and understand the fix, verified it locally on the numpy backend, and take full responsibility for the contribution. I will respond to review comments myself.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
