### PR TITLE
Support `data_format="channels_first"` in `keras.ops.image.reconstruct_patches`

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -952,10 +952,6 @@ class ReconstructPatches(Operation):
         self.strides = tuple(strides)
         self.padding = padding
         self.data_format = backend.standardize_data_format(data_format)
-        if self.data_format == "channels_first":
-            raise NotImplementedError(
-                "reconstruct_patches does not yet support channels_first."
-            )
 
     def call(self, patches):
         return _reconstruct_patches(
@@ -1008,8 +1004,13 @@ class ReconstructPatches(Operation):
                 f"prod(size) ({patch_volume})."
             )
 
-        grid_offset = 1 if original_ndim == expected_ndim_batched else 0
-        grid = patches_shape[grid_offset : grid_offset + len(self.size)]
+        if self.data_format == "channels_last":
+            grid_offset = 1 if original_ndim == expected_ndim_batched else 0
+            grid = patches_shape[grid_offset : grid_offset + len(self.size)]
+        else:
+            # channels_first: the grid dims are the trailing dims,
+            # (B, flat, *grid) batched or (flat, *grid) unbatched.
+            grid = patches_shape[-len(self.size) :]
         dim_names = ("depth", "height", "width")[-len(self.size) :]
         for g, p, o, dim_name in zip(
             grid, self.size, self.output_size, dim_names
@@ -1069,6 +1070,10 @@ def reconstruct_patches(
             4D `(N, gH, gW, pH*pW*C)`.
             For 3D patches: 4D `(gD, gH, gW, pD*pH*pW*C)` or
             5D `(N, gD, gH, gW, pD*pH*pW*C)`.
+            With `data_format="channels_first"` the flat patch dim comes
+            first instead: `(pH*pW*C, gH, gW)` / `(N, pH*pW*C, gH, gW)`
+            for 2D patches, `(pD*pH*pW*C, gD, gH, gW)` /
+            `(N, pD*pH*pW*C, gD, gH, gW)` for 3D patches.
         size: Patch size, matching the `size` used for extraction.
             Length 2 tuple for 2D, length 3 tuple for 3D, or int.
         output_size: Target spatial shape of the reconstruction. Length 2
@@ -1082,8 +1087,9 @@ def reconstruct_patches(
             to `size`.
         padding: `"same"` or `"valid"`, matching the extraction.
         data_format: A string specifying the data format of the input tensor.
-            Only `"channels_last"` is currently supported;
-            `"channels_first"` raises a `NotImplementedError`.
+            Either `"channels_last"` or `"channels_first"`. With
+            `"channels_first"` the reconstruction is returned in
+            `(C, H, W)` / `(N, C, H, W)` layout.
             If not specified, defaults to `keras.config.image_data_format`.
 
     Returns:
@@ -1218,9 +1224,23 @@ def _reconstruct_patches_2d(
     _validate_reconstruct_strides(size, strides, "reconstruct_patches")
     data_format = backend.standardize_data_format(data_format)
     if data_format == "channels_first":
-        raise NotImplementedError(
-            "reconstruct_patches does not yet support channels_first."
+        # Reconstruct in channels_last layout, then move channels back.
+        # Patches are (flat, gH, gW) unbatched or (B, flat, gH, gW) batched.
+        if len(patches.shape) == 3:
+            patches = backend.numpy.transpose(patches, axes=(1, 2, 0))
+        elif len(patches.shape) == 4:
+            patches = backend.numpy.transpose(patches, axes=(0, 2, 3, 1))
+        else:
+            raise ValueError(
+                "`patches` has unexpected rank for 2D channels_first "
+                f"reconstruction. Received shape: {patches.shape}"
+            )
+        result = _reconstruct_patches_2d(
+            patches, size, output_size, strides, padding, "channels_last"
         )
+        if len(result.shape) == 3:
+            return backend.numpy.transpose(result, axes=(2, 0, 1))
+        return backend.numpy.transpose(result, axes=(0, 3, 1, 2))
 
     pH, pW = size
     H, W = output_size
@@ -1313,10 +1333,23 @@ def _reconstruct_patches_3d(
     _validate_reconstruct_strides(size, strides, "reconstruct_patches")
     data_format = backend.standardize_data_format(data_format)
     if data_format == "channels_first":
-        raise NotImplementedError(
-            "reconstruct_patches does not yet support channels_first "
-            "for 3D patches."
+        # Reconstruct in channels_last layout, then move channels back.
+        # Patches are (flat, gD, gH, gW) unbatched or (B, flat, gD, gH, gW).
+        if len(patches.shape) == 4:
+            patches = backend.numpy.transpose(patches, axes=(1, 2, 3, 0))
+        elif len(patches.shape) == 5:
+            patches = backend.numpy.transpose(patches, axes=(0, 2, 3, 4, 1))
+        else:
+            raise ValueError(
+                "`patches` has unexpected rank for 3D channels_first "
+                f"reconstruction. Received shape: {patches.shape}"
+            )
+        result = _reconstruct_patches_3d(
+            patches, size, output_size, strides, padding, "channels_last"
         )
+        if len(result.shape) == 4:
+            return backend.numpy.transpose(result, axes=(3, 0, 1, 2))
+        return backend.numpy.transpose(result, axes=(0, 4, 1, 2, 3))
 
     pD, pH, pW = size
     D, H, W = output_size

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -1233,7 +1233,8 @@ def _reconstruct_patches_2d(
         else:
             raise ValueError(
                 "`patches` has unexpected rank for 2D channels_first "
-                f"reconstruction. Received shape: {patches.shape}"
+                "reconstruction. Expected 3 (unbatched) or 4 (batched). "
+                f"Received shape: {patches.shape}"
             )
         result = _reconstruct_patches_2d(
             patches, size, output_size, strides, padding, "channels_last"
@@ -1342,7 +1343,8 @@ def _reconstruct_patches_3d(
         else:
             raise ValueError(
                 "`patches` has unexpected rank for 3D channels_first "
-                f"reconstruction. Received shape: {patches.shape}"
+                "reconstruction. Expected 4 (unbatched) or 5 (batched). "
+                f"Received shape: {patches.shape}"
             )
         result = _reconstruct_patches_3d(
             patches, size, output_size, strides, padding, "channels_last"

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -722,30 +722,53 @@ class ImageOpsStaticShapeTest(testing.TestCase):
                 padding="same",
             )
 
-    def test_reconstruct_patches_channels_first_not_implemented(self):
-        # Op-level guard, eager and symbolic.
-        patches = np.zeros((1, 75, 4, 4), dtype="float32")
-        with self.assertRaisesRegex(NotImplementedError, "channels_first"):
+    def test_reconstruct_patches_channels_first(self):
+        # 2D channels_first batched: (B, pH*pW*C, gH, gW) -> (B, C, H, W)
+        patches = KerasTensor([2, 75, 4, 4])
+        out = kimage.reconstruct_patches(
+            patches,
+            size=(5, 5),
+            output_size=(20, 20),
+            padding="valid",
+            data_format="channels_first",
+        )
+        self.assertEqual(out.shape, (2, 3, 20, 20))
+        # 3D channels_first batched: (B, pD*pH*pW*C, gD, gH, gW)
+        patches_3d = KerasTensor([2, 375, 4, 4, 4])
+        out = kimage.reconstruct_patches(
+            patches_3d,
+            size=(5, 5, 5),
+            output_size=(20, 20, 20),
+            padding="valid",
+            data_format="channels_first",
+        )
+        self.assertEqual(out.shape, (2, 3, 20, 20, 20))
+        # The symbolic validation is data_format aware: the grid dims sit
+        # at the end in channels_first, and a mismatch still raises.
+        with self.assertRaisesRegex(ValueError, "size \\* grid"):
             kimage.reconstruct_patches(
-                patches,
+                KerasTensor([2, 75, 4, 4]),
                 size=(5, 5),
-                output_size=(20, 20),
+                output_size=(19, 20),
+                padding="valid",
                 data_format="channels_first",
             )
-        patches_3d = np.zeros((1, 375, 4, 4, 4), dtype="float32")
-        with self.assertRaisesRegex(NotImplementedError, "channels_first"):
+
+    def test_reconstruct_patches_channels_first_bad_rank(self):
+        with self.assertRaisesRegex(ValueError, "unexpected rank"):
             kimage.reconstruct_patches(
-                patches_3d,
+                np.zeros((75, 4), dtype="float32"),
+                size=(5, 5),
+                output_size=(20, 20),
+                padding="valid",
+                data_format="channels_first",
+            )
+        with self.assertRaisesRegex(ValueError, "unexpected rank"):
+            kimage.reconstruct_patches(
+                np.zeros((375, 4, 4), dtype="float32"),
                 size=(5, 5, 5),
                 output_size=(20, 20, 20),
-                data_format="channels_first",
-            )
-        patches_sym = KerasTensor([None, 75, 4, 4])
-        with self.assertRaisesRegex(NotImplementedError, "channels_first"):
-            kimage.reconstruct_patches(
-                patches_sym,
-                size=(5, 5),
-                output_size=(20, 20),
+                padding="valid",
                 data_format="channels_first",
             )
 
@@ -2658,6 +2681,78 @@ class ImageOpsCorrectnessTest(testing.TestCase):
             )
             self.assertEqual(tuple(out.shape), x.shape)
             self.assertAllClose(out, x, atol=1e-6)
+
+    def test_reconstruct_patches_channels_first(self):
+        # channels_first reconstruction equals the channels_last result
+        # after transposing. Patches are extracted in channels_last and
+        # transposed into channels_first layout, so the test runs on every
+        # backend regardless of NCHW conv support in extract_patches (the
+        # suite skips 2D channels_first extract_patches on tensorflow).
+        for h, w, c, size, padding in [
+            (20, 20, 3, (5, 5), "valid"),
+            (33, 41, 2, (5, 7), "same"),
+        ]:
+            x = _bf16_exact((2, h, w, c))
+            patches_cl = kimage.extract_patches(x, size=size, padding=padding)
+            patches_cf = knp.transpose(patches_cl, (0, 3, 1, 2))
+            recon_cf = kimage.reconstruct_patches(
+                patches_cf,
+                size=size,
+                output_size=(h, w),
+                padding=padding,
+                data_format="channels_first",
+            )
+            self.assertEqual(tuple(recon_cf.shape), (2, c, h, w))
+            self.assertAllClose(
+                recon_cf, np.transpose(x, (0, 3, 1, 2)), atol=1e-6
+            )
+
+        # Unbatched 2D exercises the rank-3 transpose branch.
+        x = _bf16_exact((8, 8, 2))
+        patches_cl = kimage.extract_patches(x, size=(4, 4), padding="valid")
+        patches_cf = knp.transpose(patches_cl, (2, 0, 1))
+        recon_cf = kimage.reconstruct_patches(
+            patches_cf,
+            size=(4, 4),
+            output_size=(8, 8),
+            data_format="channels_first",
+        )
+        self.assertEqual(tuple(recon_cf.shape), (2, 8, 8))
+        self.assertAllClose(recon_cf, np.transpose(x, (2, 0, 1)), atol=1e-6)
+
+    def test_reconstruct_patches_3d_channels_first(self):
+        # Batched 3D channels_first round-trip via transposed patches.
+        x = _bf16_exact((2, 6, 6, 6, 3))
+        patches_cl = kimage.extract_patches_3d(
+            x, size=(3, 3, 3), padding="valid"
+        )
+        patches_cf = knp.transpose(patches_cl, (0, 4, 1, 2, 3))
+        recon_cf = kimage.reconstruct_patches(
+            patches_cf,
+            size=(3, 3, 3),
+            output_size=(6, 6, 6),
+            padding="valid",
+            data_format="channels_first",
+        )
+        self.assertEqual(tuple(recon_cf.shape), (2, 3, 6, 6, 6))
+        self.assertAllClose(
+            recon_cf, np.transpose(x, (0, 4, 1, 2, 3)), atol=1e-6
+        )
+
+        # Unbatched 3D exercises the rank-4 transpose branch.
+        x = _bf16_exact((6, 6, 6, 2))
+        patches_cl = kimage.extract_patches_3d(
+            x, size=(3, 3, 3), padding="valid"
+        )
+        patches_cf = knp.transpose(patches_cl, (3, 0, 1, 2))
+        recon_cf = kimage.reconstruct_patches(
+            patches_cf,
+            size=(3, 3, 3),
+            output_size=(6, 6, 6),
+            data_format="channels_first",
+        )
+        self.assertEqual(tuple(recon_cf.shape), (2, 6, 6, 6))
+        self.assertAllClose(recon_cf, np.transpose(x, (3, 0, 1, 2)), atol=1e-6)
 
     def test_reconstruct_patches_int_dtype(self):
         # reconstruct_patches only reshapes/transposes/slices, so integer


### PR DESCRIPTION
Follow-up to #22984, part of #22951.

Adds `channels_first` support to `reconstruct_patches` (2D and 3D, batched and unbatched). The reconstruction runs in `channels_last` layout with the channels transposed back at the end, so the core reshape -> transpose -> slice path is unchanged. Symbolic shape inference and build-time validation are now data_format-aware (in `channels_first` the grid dims are the trailing axes), and the docstring documents the `channels_first` patch layouts.

Note on the tests: the correctness tests extract patches in `channels_last` and transpose them into `channels_first` layout rather than calling `extract_patches(data_format="channels_first")`, because 2D `channels_first` extraction routes through NCHW conv, which TensorFlow's CPU kernel only supports on oneDNN builds (the existing suite skips exactly that path on TF). This keeps the tests running on every backend. Inputs use bfloat16-exact values, same as the existing round-trip tests, so TPU stays green.

2 files changed; all tests pass on TF, JAX, NumPy, and PyTorch (including torch's `channels_first` CI config).

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.