### PR TITLE
Implement Weight-Decomposed Low-Rank Adaptation (DoRA)

### DIFF
--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -902,6 +902,78 @@ class MultiHeadAttentionTest(testing.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
+    @pytest.mark.requires_trainable_backend
+    def test_dora(self):
+        layer = layers.MultiHeadAttention(
+            num_heads=3,
+            key_dim=8,
+            use_bias=False,
+            use_gate=True,
+        )
+        query = np.random.random((1, 2, 2))
+        key = np.random.random((1, 2, 2))
+        value = np.random.random((1, 2, 2))
+        layer(query, key, value)  # build
+
+        layer.query_dense.enable_dora(2)
+        layer.key_dense.enable_dora(2)
+        layer.value_dense.enable_dora(2)
+
+        # Try eager call
+        x = {
+            "query": query,
+            "key": key,
+            "value": value,
+        }
+        y = np.random.random((1, 2, 2))
+        _ = layer(**x)
+
+        # Try calling fit()
+        inputs = {
+            "query": layers.Input((2, 2)),
+            "key": layers.Input((2, 2)),
+            "value": layers.Input((2, 2)),
+        }
+        outputs = layer(inputs["query"], inputs["key"], inputs["value"])
+        model = models.Model(inputs, outputs)
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        inputs = {
+            "query": layers.Input((2, 2)),
+            "key": layers.Input((2, 2)),
+            "value": layers.Input((2, 2)),
+        }
+        outputs = layers.MultiHeadAttention(
+            num_heads=3,
+            key_dim=8,
+            use_bias=False,
+            use_gate=True,
+        )(inputs["query"], inputs["key"], inputs["value"])
+        new_model = models.Model(inputs, outputs)
+
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
     @parameterized.parameters([((1, 2, 3),), ((2, 3, 5),)])
     def test_symbolic_return_attention_scores(self, shape):
         mha = layers.MultiHeadAttention(num_heads=4, key_dim=2)

--- a/keras/src/layers/convolutional/base_conv.py
+++ b/keras/src/layers/convolutional/base_conv.py
@@ -85,6 +85,17 @@ class BaseConv(Layer):
             trainable matrices) during the forward pass. The delta is scaled by
             `lora_alpha / lora_rank`, allowing you to fine-tune the strength of
             the LoRA adjustment independently of `lora_rank`.
+        dora_rank: Optional integer. If set, the layer's forward pass
+            will implement DoRA (Weight-Decomposed Low-Rank Adaptation)
+            with the provided rank. DoRA decomposes the layer's kernel
+            into magnitude and direction components and applies LoRA
+            to the direction component. This can improve the learning
+            capacity of LoRA. You can also enable DoRA on an existing
+            layer by calling `layer.enable_dora(rank)`.
+        dora_alpha: Optional integer. If set, this parameter scales the
+            low-rank adaptation delta during the forward pass. The delta
+            is scaled by `dora_alpha / dora_rank`, allowing you to fine-tune
+            the strength of the DoRA adjustment independently of `dora_rank`.
     """
 
     def __init__(
@@ -108,6 +119,8 @@ class BaseConv(Layer):
         bias_constraint=None,
         lora_rank=None,
         lora_alpha=None,
+        dora_rank=None,
+        dora_alpha=None,
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -131,8 +144,16 @@ class BaseConv(Layer):
         self.bias_constraint = constraints.get(bias_constraint)
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else lora_rank
+        self.dora_rank = dora_rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else dora_rank
+        if self.lora_rank and self.dora_rank:
+            raise ValueError(
+                "Only one of `lora_rank` or `dora_rank` can be set."
+            )
         self.lora_enabled = False
+        self.dora_enabled = False
         self.input_spec = InputSpec(min_ndim=self.rank + 2)
+
         self.data_format = self.data_format
 
         if self.filters is not None and self.filters <= 0:
@@ -223,6 +244,8 @@ class BaseConv(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank, lora_alpha=self.lora_alpha)
+        if self.dora_rank:
+            self.enable_dora(self.dora_rank, dora_alpha=self.dora_alpha)
 
     @property
     def kernel(self):
@@ -240,6 +263,19 @@ class BaseConv(Layer):
                 ),
                 dtype=self.compute_dtype,
             )
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(kernel, lora_delta)
+            # Normalize along all axes except the last one (filters)
+            axis = tuple(range(len(kernel.shape) - 1))
+            norm = ops.stop_gradient(
+                ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
+            )
+            kernel = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
+            kernel = ops.cast(kernel, dtype=self.compute_dtype)
+
         return kernel
 
     def convolution_op(self, inputs, kernel):
@@ -298,6 +334,8 @@ class BaseConv(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
+        if getattr(self, "dora_enabled", False):
+            raise ValueError("dora is already enabled. Cannot enable LoRA.")
         self._tracker.unlock()
 
         # LoRA weights should be float32 to avoid the risk of underflow or
@@ -324,6 +362,66 @@ class BaseConv(Layer):
         self.lora_rank = rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else rank
 
+    def enable_dora(
+        self,
+        rank,
+        dora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
+    ):
+        if self.kernel_constraint:
+            raise ValueError(
+                "DoRA is incompatible with kernel constraints. "
+                "In order to enable dora on this layer, remove the "
+                "`kernel_constraint` argument."
+            )
+        if not self.built:
+            raise ValueError(
+                "Cannot enable dora on a layer that isn't yet built."
+            )
+        if self.lora_enabled:
+            raise ValueError("LoRA is already enabled. Cannot enable DoRA.")
+        if self.dora_enabled:
+            raise ValueError(
+                "dora is already enabled. This can only be done once per layer."
+            )
+        self._tracker.unlock()
+
+        self.dora_kernel_a = self.add_weight(
+            name="dora_kernel_a",
+            shape=self._kernel.shape[:-1] + (rank,),
+            initializer=initializers.get(a_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+        self.dora_kernel_b = self.add_weight(
+            name="dora_kernel_b",
+            shape=(rank, self.filters),
+            initializer=initializers.get(b_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        # Initialize Magnitude Vector
+        # We reduce all axes except the last one (filters)
+        axis = tuple(range(len(self.kernel.shape) - 1))
+        initial_magnitude = ops.stop_gradient(
+            ops.sqrt(ops.sum(ops.square(self.kernel), axis=axis))
+        )
+        self.dora_magnitude = self.add_weight(
+            name="dora_magnitude",
+            shape=(self.filters,),
+            initializer=lambda *a, **kw: initial_magnitude,
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        self._kernel.trainable = False
+        self._tracker.lock()
+        self.dora_enabled = True
+        self.dora_rank = rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else rank
+
     def save_own_variables(self, store):
         # Do nothing if the layer isn't yet built
         if not self.built:
@@ -335,8 +433,9 @@ class BaseConv(Layer):
             store[str(i)] = variable
 
     def load_own_variables(self, store):
-        if not self.lora_enabled:
+        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
             self._check_load_own_variables(store)
+
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
@@ -348,6 +447,18 @@ class BaseConv(Layer):
         if self.lora_enabled:
             self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
             self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))
+        if self.dora_enabled:
+            self.dora_kernel_a.assign(ops.zeros(self.dora_kernel_a.shape))
+            self.dora_kernel_b.assign(ops.zeros(self.dora_kernel_b.shape))
+            # Temporarily disable to get base kernel
+            self.dora_enabled = False
+            base_kernel = self.kernel
+            self.dora_enabled = True
+
+            axis = tuple(range(len(base_kernel.shape) - 1))
+            self.dora_magnitude.assign(
+                ops.sqrt(ops.sum(ops.square(base_kernel), axis=axis))
+            )
 
     def get_config(self):
         config = super().get_config()
@@ -386,6 +497,9 @@ class BaseConv(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
             config["lora_alpha"] = self.lora_alpha
+        if self.dora_rank:
+            config["dora_rank"] = self.dora_rank
+            config["dora_alpha"] = self.dora_alpha
         return config
 
     def _check_load_own_variables(self, store):

--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -717,6 +717,190 @@ class ConvBasicTest(testing.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
+    @parameterized.named_parameters(
+        {
+            "testcase_name": "conv1d_kernel_size3_strides1",
+            "conv_cls": layers.Conv1D,
+            "filters": 6,
+            "kernel_size": 3,
+            "strides": 1,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 1,
+            "input_shape": (None, 5, 4),
+            "output_shape": (None, 3, 6),
+        },
+        {
+            "testcase_name": "conv1d_kernel_size2_strides2",
+            "conv_cls": layers.Conv1D,
+            "filters": 6,
+            "kernel_size": 2,
+            "strides": 2,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 2,
+            "input_shape": (None, 5, 4),
+            "output_shape": (None, 2, 6),
+        },
+        {
+            "testcase_name": "conv2d_kernel_size3_strides1",
+            "conv_cls": layers.Conv2D,
+            "filters": 6,
+            "kernel_size": 3,
+            "strides": 1,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 1,
+            "input_shape": (None, 5, 5, 4),
+            "output_shape": (None, 3, 3, 6),
+        },
+        {
+            "testcase_name": "conv2d_kernel_size2_strides2",
+            "conv_cls": layers.Conv2D,
+            "filters": 6,
+            "kernel_size": 2,
+            "strides": 2,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 2,
+            "input_shape": (None, 5, 5, 4),
+            "output_shape": (None, 2, 2, 6),
+        },
+        {
+            "testcase_name": "conv3d_kernel_size3_strides1",
+            "conv_cls": layers.Conv3D,
+            "filters": 6,
+            "kernel_size": 3,
+            "strides": 1,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 1,
+            "input_shape": (None, 5, 5, 5, 4),
+            "output_shape": (None, 3, 3, 3, 6),
+        },
+        {
+            "testcase_name": "conv3d_kernel_size2_strides2",
+            "conv_cls": layers.Conv3D,
+            "filters": 6,
+            "kernel_size": 2,
+            "strides": 2,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 2,
+            "input_shape": (None, 5, 5, 5, 4),
+            "output_shape": (None, 2, 2, 2, 6),
+        },
+    )
+    @pytest.mark.requires_trainable_backend
+    def test_enable_dora(
+        self,
+        conv_cls,
+        filters,
+        kernel_size,
+        strides,
+        padding,
+        data_format,
+        dilation_rate,
+        groups,
+        input_shape,
+        output_shape,
+    ):
+        if conv_cls not in (layers.Conv1D, layers.Conv2D, layers.Conv3D):
+            raise TypeError
+        layer = conv_cls(
+            filters=filters,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            dilation_rate=dilation_rate,
+            groups=groups,
+        )
+        layer.build(input_shape)
+        layer.enable_dora(2)
+        self.assertLen(layer.trainable_weights, 4)
+        self.assertLen(layer.non_trainable_weights, 1)
+        if backend.backend() == "torch":
+            self.assertLen(layer.torch_params, 5)
+        self.assertDType(layer.dora_kernel_a, "float32")
+        self.assertDType(layer.dora_kernel_b, "float32")
+        self.assertDType(layer.dora_magnitude, "float32")
+
+        # Try eager call
+        x = np.random.random((64,) + input_shape[1:])
+        y = np.random.random((64,) + output_shape[1:])
+        _ = layer(x[:2])
+
+        init_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        init_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        init_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        # Try calling fit()
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y)
+
+        final_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        final_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        final_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        diff_a = np.max(
+            np.abs(init_dora_a_kernel_value - final_dora_a_kernel_value)
+        )
+        diff_b = np.max(
+            np.abs(init_dora_b_kernel_value - final_dora_b_kernel_value)
+        )
+        diff_m = np.max(
+            np.abs(init_dora_magnitude_value - final_dora_magnitude_value)
+        )
+
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+        self.assertGreater(diff_m, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].dora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        new_model = models.Sequential(
+            [
+                conv_cls(
+                    filters=filters,
+                    kernel_size=kernel_size,
+                    strides=strides,
+                    padding=padding,
+                    data_format=data_format,
+                    dilation_rate=dilation_rate,
+                    groups=groups,
+                )
+            ]
+        )
+        new_model.build(input_shape)
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
     def test_lora_weight_name(self):
         class MyModel(models.Model):
             def __init__(self):
@@ -785,6 +969,49 @@ class ConvBasicTest(testing.TestCase):
             tpu_rtol=1e-3,
         )
 
+    def test_enable_dora_with_alpha(self):
+        layer = layers.Conv2D(filters=3, kernel_size=(2, 2), padding="valid")
+        input_shape = (1, 4, 4, 3)
+        layer.build(input_shape)
+
+        base_kernel = np.linspace(
+            0, 1, num=math.prod(layer.kernel.shape), dtype=np.float32
+        )
+        base_kernel = base_kernel.reshape(layer.kernel.shape)
+        layer._kernel.assign(base_kernel)
+
+        layer.enable_dora(rank=2, dora_alpha=3.0)
+        self.assertEqual(layer.dora_rank, 2)
+        self.assertEqual(layer.dora_alpha, 3.0)
+
+        dora_a_shape = layer.dora_kernel_a.shape
+        dora_b_shape = layer.dora_kernel_b.shape
+
+        dora_a = np.full(dora_a_shape, 0.1, dtype=np.float32)
+        dora_b = np.full(dora_b_shape, 0.2, dtype=np.float32)
+        layer.dora_kernel_a.assign(dora_a)
+        layer.dora_kernel_b.assign(dora_b)
+
+        scaling = 3.0 / 2
+        delta = np.matmul(dora_a.reshape(-1, 2), dora_b)
+        delta = delta.reshape(base_kernel.shape)
+        W_combined = base_kernel + scaling * delta
+
+        # Normalize along all axes except the last one
+        axis = tuple(range(len(W_combined.shape) - 1))
+        norm = np.sqrt(np.sum(np.square(W_combined), axis=axis))
+        expected_effective_kernel = ops.convert_to_numpy(
+            layer.dora_magnitude
+        ) * (W_combined / norm)
+
+        actual_effective_kernel = ops.convert_to_numpy(layer.kernel)
+        self.assertAllClose(
+            actual_effective_kernel,
+            expected_effective_kernel,
+            tpu_atol=1e-3,
+            tpu_rtol=1e-3,
+        )
+
     def test_lora_rank_argument(self):
         self.run_layer_test(
             layers.Conv2D,
@@ -802,6 +1029,26 @@ class ConvBasicTest(testing.TestCase):
             expected_num_non_trainable_weights=1,
             expected_num_seed_generators=0,
             expected_num_losses=2,  # we have 2 regularizers.
+            supports_masking=False,
+        )
+
+    def test_dora_rank_argument(self):
+        self.run_layer_test(
+            layers.Conv2D,
+            init_kwargs={
+                "filters": 5,
+                "kernel_size": 3,
+                "activation": "sigmoid",
+                "data_format": "channels_last",
+                "kernel_regularizer": "l2",
+                "dora_rank": 2,
+            },
+            input_shape=(2, 5, 5, 4),
+            expected_output_shape=(2, 3, 3, 5),
+            expected_num_trainable_weights=4,
+            expected_num_non_trainable_weights=1,
+            expected_num_seed_generators=0,
+            expected_num_losses=3,
             supports_masking=False,
         )
 

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -69,6 +69,17 @@ class Dense(Layer):
             trainable matrices) during the forward pass. The delta is scaled by
             `lora_alpha / lora_rank`, allowing you to fine-tune the strength of
             the LoRA adjustment independently of `lora_rank`.
+        dora_rank: Optional integer. If set, the layer's forward pass
+            will implement DoRA (Weight-Decomposed Low-Rank Adaptation)
+            with the provided rank. DoRA decomposes the layer's kernel
+            into magnitude and direction components and applies LoRA
+            to the direction component. This can improve the learning
+            capacity of LoRA. You can also enable DoRA on an existing
+            `Dense` layer by calling `layer.enable_dora(rank)`.
+        dora_alpha: Optional integer. If set, this parameter scales the
+            low-rank adaptation delta during the forward pass. The delta
+            is scaled by `dora_alpha / dora_rank`, allowing you to fine-tune
+            the strength of the DoRA adjustment independently of `dora_rank`.
 
     Input shape:
         N-D tensor with shape: `(batch_size, ..., input_dim)`.
@@ -95,6 +106,8 @@ class Dense(Layer):
         bias_constraint=None,
         lora_rank=None,
         lora_alpha=None,
+        dora_rank=None,
+        dora_alpha=None,
         quantization_config=None,
         **kwargs,
     ):
@@ -116,7 +129,15 @@ class Dense(Layer):
         self.bias_constraint = constraints.get(bias_constraint)
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else lora_rank
+        self.dora_rank = dora_rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else dora_rank
+        if self.lora_rank and self.dora_rank:
+            raise ValueError(
+                "Only one of `lora_rank` or `dora_rank` can be set."
+            )
         self.lora_enabled = False
+        self.dora_enabled = False
+
         self.quantization_config = quantization_config
         self.input_spec = InputSpec(min_ndim=2)
         self.supports_masking = True
@@ -154,6 +175,8 @@ class Dense(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
+        if self.dora_rank:
+            self.enable_dora(self.dora_rank, dora_alpha=self.dora_alpha)
 
     @property
     def kernel(self):
@@ -215,6 +238,17 @@ class Dense(Layer):
                 ),
                 dtype=self.compute_dtype,
             )
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(kernel, lora_delta)
+            # Normalize along input dimension (axis 0)
+            norm = ops.stop_gradient(
+                ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            )
+            kernel = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
+            kernel = ops.cast(kernel, dtype=self.compute_dtype)
 
         return kernel
 
@@ -252,6 +286,8 @@ class Dense(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
+        if self.dora_enabled:
+            raise ValueError("dora is already enabled. Cannot enable LoRA.")
         if self.quantization_mode == "gptq":
             raise NotImplementedError(
                 "lora is not currently supported with GPTQ quantization."
@@ -294,6 +330,74 @@ class Dense(Layer):
         self.lora_rank = rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else rank
 
+    def enable_dora(
+        self,
+        rank,
+        dora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
+    ):
+        if self.kernel_constraint:
+            raise ValueError(
+                "DoRA is incompatible with kernel constraints. "
+                "In order to enable dora on this layer, remove the "
+                "`kernel_constraint` argument."
+            )
+        if not self.built:
+            raise ValueError(
+                "Cannot enable dora on a layer that isn't yet built."
+            )
+        if self.lora_enabled:
+            raise ValueError("LoRA is already enabled. Cannot enable DoRA.")
+        if self.dora_enabled:
+            raise ValueError(
+                "dora is already enabled. This can only be done once per layer."
+            )
+        if self.quantization_mode == "gptq":
+            raise NotImplementedError(
+                "dora is not currently supported with GPTQ quantization."
+            )
+        self._tracker.unlock()
+        if self.quantization_mode == "int4" and hasattr(
+            self, "_orig_input_dim"
+        ):
+            input_dim_for_lora = self._orig_input_dim
+        else:
+            input_dim_for_lora = self.kernel.shape[0]
+
+        self.dora_kernel_a = self.add_weight(
+            name="dora_kernel_a",
+            shape=(input_dim_for_lora, rank),
+            initializer=initializers.get(a_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+        self.dora_kernel_b = self.add_weight(
+            name="dora_kernel_b",
+            shape=(rank, self.kernel.shape[1]),
+            initializer=initializers.get(b_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+        # Initialize Magnitude Vector to norm of frozen kernel
+        # We reduce all axes except the last one (units)
+        initial_magnitude = ops.stop_gradient(
+            ops.sqrt(ops.sum(ops.square(self.kernel), axis=0))
+        )
+        self.dora_magnitude = self.add_weight(
+            name="dora_magnitude",
+            shape=(self.units,),
+            initializer=lambda *a, **kw: initial_magnitude,
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        self._kernel.trainable = False
+        self._tracker.lock()
+        self.dora_enabled = True
+        self.dora_rank = rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else rank
+
     def save_own_variables(self, store):
         # Do nothing if the layer isn't yet built
         if not self.built:
@@ -332,8 +436,9 @@ class Dense(Layer):
             idx += 1
 
     def load_own_variables(self, store):
-        if not self.lora_enabled:
+        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
             self._check_load_own_variables(store)
+
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
@@ -363,6 +468,17 @@ class Dense(Layer):
         if self.lora_enabled:
             self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
             self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))
+        if self.dora_enabled:
+            self.dora_kernel_a.assign(ops.zeros(self.dora_kernel_a.shape))
+            self.dora_kernel_b.assign(ops.zeros(self.dora_kernel_b.shape))
+            # Temporarily disable to get base kernel
+            self.dora_enabled = False
+            base_kernel = self.kernel
+            self.dora_enabled = True
+
+            self.dora_magnitude.assign(
+                ops.sqrt(ops.sum(ops.square(base_kernel), axis=0))
+            )
 
     def get_config(self):
         base_config = super().get_config()
@@ -387,6 +503,9 @@ class Dense(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
             config["lora_alpha"] = self.lora_alpha
+        if self.dora_rank:
+            config["dora_rank"] = self.dora_rank
+            config["dora_alpha"] = self.dora_alpha
         return {**base_config, **config}
 
     @classmethod
@@ -1158,7 +1277,7 @@ class Dense(Layer):
         kernel_scale = self.kernel_scale
         kernel_zero = getattr(self, "kernel_zero", None)
 
-        if not self.lora_enabled:
+        if not self.lora_enabled and not self.dora_enabled:
             return kernel_value, kernel_scale, kernel_zero
 
         # Dequantize, Merge, and Re-quantize
@@ -1198,10 +1317,22 @@ class Dense(Layer):
             )
 
         # Step 2: Merge LoRA weights in float domain
-        lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
-            self.lora_kernel_a, self.lora_kernel_b
-        )
-        merged_float_kernel = ops.add(float_kernel, lora_delta)
+        if self.lora_enabled:
+            lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
+                self.lora_kernel_a, self.lora_kernel_b
+            )
+            merged_float_kernel = ops.add(float_kernel, lora_delta)
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(float_kernel, lora_delta)
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            merged_float_kernel = self.dora_magnitude * ops.divide_no_nan(
+                W_combined, norm
+            )
+        else:
+            merged_float_kernel = float_kernel
 
         # Step 3: Re-quantize the merged kernel
         if (

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -432,6 +432,158 @@ class DenseTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "lora is already enabled"):
             layer.enable_lora(rank=2)
 
+    @pytest.mark.requires_trainable_backend
+    def test_enable_dora(self):
+        layer = layers.Dense(units=16)
+        layer.build((None, 8))
+        layer.enable_dora(4)
+        self.assertLen(layer.trainable_weights, 4)
+        self.assertLen(layer.non_trainable_weights, 1)
+        if backend.backend() == "torch":
+            self.assertLen(layer.torch_params, 5)
+        self.assertDType(layer.dora_kernel_a, "float32")
+        self.assertDType(layer.dora_kernel_b, "float32")
+        self.assertDType(layer.dora_magnitude, "float32")
+
+        # Try eager call
+        x = np.random.random((64, 8))
+        y = np.random.random((64, 16))
+        _ = layer(x[:2])
+
+        init_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        init_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        init_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        # Try calling fit()
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y)
+
+        final_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        final_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        final_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        diff_a = np.max(
+            np.abs(init_dora_a_kernel_value - final_dora_a_kernel_value)
+        )
+        diff_b = np.max(
+            np.abs(init_dora_b_kernel_value - final_dora_b_kernel_value)
+        )
+        diff_m = np.max(
+            np.abs(init_dora_magnitude_value - final_dora_magnitude_value)
+        )
+
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+        self.assertGreater(diff_m, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].dora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        new_model = models.Sequential([layers.Dense(units=16)])
+        new_model.build((None, 8))
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    def test_enable_dora_with_alpha(self):
+        layer = layers.Dense(units=8)
+        layer.build((None, 4))
+
+        # Enable DoRA with `rank`=2 and `dora_alpha`=3.0.
+        layer.enable_dora(2, dora_alpha=3.0)
+        self.assertEqual(layer.dora_rank, 2)
+        self.assertEqual(layer.dora_alpha, 3.0)
+
+        # Manually compute the expected effective kernel
+        base_kernel = ops.convert_to_numpy(layer._kernel)
+        dora_update = np.matmul(
+            ops.convert_to_numpy(layer.dora_kernel_a),
+            ops.convert_to_numpy(layer.dora_kernel_b),
+        )
+        W_combined = base_kernel + (3.0 / 2) * dora_update
+        norm = np.sqrt(np.sum(np.square(W_combined), axis=0))
+        effective_kernel_expected = ops.convert_to_numpy(
+            layer.dora_magnitude
+        ) * (W_combined / norm)
+
+        # Verify that the effective kernel matches expectation.
+        self.assertAllClose(
+            ops.convert_to_numpy(layer.kernel), effective_kernel_expected
+        )
+
+    def test_dora_rank_argument(self):
+        self.run_layer_test(
+            layers.Dense,
+            init_kwargs={
+                "units": 5,
+                "activation": "sigmoid",
+                "kernel_regularizer": "l2",
+                "dora_rank": 2,
+            },
+            input_shape=(2, 3, 4),
+            expected_output_shape=(2, 3, 5),
+            expected_num_trainable_weights=4,
+            expected_num_non_trainable_weights=1,
+            expected_num_seed_generators=0,
+            expected_num_losses=3,
+            supports_masking=True,
+        )
+
+    def test_enable_dora_with_kernel_constraint(self):
+        layer = layers.Dense(units=2, kernel_constraint="max_norm")
+        with self.assertRaisesRegex(
+            ValueError, "DoRA is incompatible with kernel constraints"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_on_unbuilt_layer(self):
+        layer = layers.Dense(units=2)
+        with self.assertRaisesRegex(
+            ValueError, "Cannot enable dora on a layer that isn't yet built"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_when_already_enabled(self):
+        layer = layers.Dense(units=2)
+        layer.build((None, 2))
+        layer.enable_dora(rank=2)
+        with self.assertRaisesRegex(ValueError, "dora is already enabled"):
+            layer.enable_dora(rank=2)
+
+    def test_dora_lora_mutual_exclusivity(self):
+        layer = layers.Dense(units=2)
+        layer.build((None, 2))
+        layer.enable_lora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "LoRA is already enabled. Cannot enable DoRA."
+        ):
+            layer.enable_dora(rank=2)
+
+        layer2 = layers.Dense(units=2)
+        layer2.build((None, 2))
+        layer2.enable_dora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "dora is already enabled. Cannot enable LoRA."
+        ):
+            layer2.enable_lora(rank=2)
+
     # Test quantization-related methods.
 
     @parameterized.named_parameters(

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -70,6 +70,17 @@ class EinsumDense(Layer):
             trainable matrices) during the forward pass. The delta is scaled by
             `lora_alpha / lora_rank`, allowing you to fine-tune the strength of
             the LoRA adjustment independently of `lora_rank`.
+        dora_rank: Optional integer. If set, the layer's forward pass
+            will implement DoRA (Weight-Decomposed Low-Rank Adaptation)
+            with the provided rank. DoRA decomposes the layer's kernel
+            into magnitude and direction components and applies LoRA
+            to the direction component. This can improve the learning
+            capacity of LoRA. You can also enable DoRA on an existing
+            `EinsumDense` layer by calling `layer.enable_dora(rank)`.
+        dora_alpha: Optional integer. If set, this parameter scales the
+            low-rank adaptation delta during the forward pass. The delta
+            is scaled by `dora_alpha / dora_rank`, allowing you to fine-tune
+            the strength of the DoRA adjustment independently of `dora_rank`.
         **kwargs: Base layer keyword arguments, such as `name` and `dtype`.
 
     Examples:
@@ -138,6 +149,8 @@ class EinsumDense(Layer):
         bias_constraint=None,
         lora_rank=None,
         lora_alpha=None,
+        dora_rank=None,
+        dora_alpha=None,
         gptq_unpacked_column_size=None,
         quantization_config=None,
         **kwargs,
@@ -158,8 +171,16 @@ class EinsumDense(Layer):
         self.bias_constraint = constraints.get(bias_constraint)
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else lora_rank
+        self.dora_rank = dora_rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else dora_rank
+        if self.lora_rank and self.dora_rank:
+            raise ValueError(
+                "Only one of `lora_rank` or `dora_rank` can be set."
+            )
         self.lora_enabled = False
+        self.dora_enabled = False
         self.gptq_unpacked_column_size = gptq_unpacked_column_size
+
         self.quantization_config = quantization_config
 
     def _update_kernel_initializer(self, input_axes, output_axes):
@@ -233,6 +254,8 @@ class EinsumDense(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank, lora_alpha=self.lora_alpha)
+        if self.dora_rank:
+            self.enable_dora(self.dora_rank, dora_alpha=self.dora_alpha)
 
     @property
     def kernel(self):
@@ -297,6 +320,18 @@ class EinsumDense(Layer):
                 ),
                 dtype=self.compute_dtype,
             )
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(kernel, lora_delta)
+            # Normalize along all axes except the last one
+            axis = tuple(range(len(kernel.shape) - 1))
+            norm = ops.stop_gradient(
+                ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
+            )
+            kernel = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
+            kernel = ops.cast(kernel, dtype=self.compute_dtype)
 
         return kernel
 
@@ -338,6 +373,8 @@ class EinsumDense(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
+        if getattr(self, "dora_enabled", False):
+            raise ValueError("dora is already enabled. Cannot enable LoRA.")
         if self.quantization_mode == "gptq":
             raise NotImplementedError(
                 "lora is not currently supported with GPTQ quantization."
@@ -377,6 +414,74 @@ class EinsumDense(Layer):
         self.lora_rank = rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else rank
 
+    def enable_dora(
+        self,
+        rank,
+        dora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
+    ):
+        if self.kernel_constraint:
+            raise ValueError(
+                "DoRA is incompatible with kernel constraints. "
+                "In order to enable dora on this layer, remove the "
+                "`kernel_constraint` argument."
+            )
+        if not self.built:
+            raise ValueError(
+                "Cannot enable dora on a layer that isn't yet built."
+            )
+        if self.lora_enabled:
+            raise ValueError("LoRA is already enabled. Cannot enable DoRA.")
+        if self.dora_enabled:
+            raise ValueError(
+                "dora is already enabled. This can only be done once per layer."
+            )
+        if self.quantization_mode == "gptq":
+            raise NotImplementedError(
+                "dora is not currently supported with GPTQ quantization."
+            )
+        self._tracker.unlock()
+        if self.quantization_mode == "int4":
+            kernel_shape_for_lora = tuple(self.original_kernel_shape)
+        else:
+            kernel_shape_for_lora = self.kernel.shape
+
+        self.dora_kernel_a = self.add_weight(
+            name="dora_kernel_a",
+            shape=(kernel_shape_for_lora[:-1] + (rank,)),
+            initializer=initializers.get(a_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+        self.dora_kernel_b = self.add_weight(
+            name="dora_kernel_b",
+            shape=(rank, kernel_shape_for_lora[-1]),
+            initializer=initializers.get(b_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        # Initialize Magnitude Vector
+        # We reduce all axes except the last one
+        axis = tuple(range(len(self.kernel.shape) - 1))
+        initial_magnitude = ops.stop_gradient(
+            ops.sqrt(ops.sum(ops.square(self.kernel), axis=axis))
+        )
+        self.dora_magnitude = self.add_weight(
+            name="dora_magnitude",
+            shape=(kernel_shape_for_lora[-1],),
+            initializer=lambda *a, **kw: initial_magnitude,
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        self._kernel.trainable = False
+        self._tracker.lock()
+        self.dora_enabled = True
+        self.dora_rank = rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else rank
+
     def save_own_variables(self, store):
         # Do nothing if the layer isn't yet built
         if not self.built:
@@ -415,8 +520,9 @@ class EinsumDense(Layer):
             idx += 1
 
     def load_own_variables(self, store):
-        if not self.lora_enabled:
+        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
             self._check_load_own_variables(store)
+
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
@@ -446,6 +552,18 @@ class EinsumDense(Layer):
         if self.lora_enabled:
             self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
             self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))
+        if self.dora_enabled:
+            self.dora_kernel_a.assign(ops.zeros(self.dora_kernel_a.shape))
+            self.dora_kernel_b.assign(ops.zeros(self.dora_kernel_b.shape))
+            # Temporarily disable to get base kernel
+            self.dora_enabled = False
+            base_kernel = self.kernel
+            self.dora_enabled = True
+
+            axis = tuple(range(len(base_kernel.shape) - 1))
+            self.dora_magnitude.assign(
+                ops.sqrt(ops.sum(ops.square(base_kernel), axis=axis))
+            )
 
     def get_config(self):
         base_config = super().get_config()
@@ -474,6 +592,9 @@ class EinsumDense(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
             config["lora_alpha"] = self.lora_alpha
+        if self.dora_rank:
+            config["dora_rank"] = self.dora_rank
+            config["dora_alpha"] = self.dora_alpha
         if self.gptq_unpacked_column_size:
             config["gptq_unpacked_column_size"] = self.gptq_unpacked_column_size
         return {**base_config, **config}
@@ -1445,9 +1566,9 @@ class EinsumDense(Layer):
 
         kernel_zero = getattr(self, "kernel_zero", None)
 
-        # If quantized but LoRA is not enabled, return the original quantized
-        # kernel.
-        if not self.lora_enabled:
+        # If quantized but LoRA/DoRA is not enabled, return the original
+        # quantized kernel.
+        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
             return self._kernel, self.kernel_scale, kernel_zero
 
         # Dequantize, Merge, and Re-quantize
@@ -1486,11 +1607,24 @@ class EinsumDense(Layer):
                 f"Unsupported quantization mode: {self.quantization_mode}"
             )
 
-        # 2. Merge the LoRA update in the float domain
-        lora_update = (self.lora_alpha / self.lora_rank) * ops.matmul(
-            self.lora_kernel_a, self.lora_kernel_b
-        )
-        merged_kernel = ops.add(kernel_fp, lora_update)
+        # 2. Merge the LoRA/DoRA update in the float domain
+        if self.lora_enabled:
+            lora_update = (self.lora_alpha / self.lora_rank) * ops.matmul(
+                self.lora_kernel_a, self.lora_kernel_b
+            )
+            merged_kernel = ops.add(kernel_fp, lora_update)
+        elif self.dora_enabled:
+            lora_update = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(kernel_fp, lora_update)
+            axis = tuple(range(len(W_combined.shape) - 1))
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
+            merged_kernel = self.dora_magnitude * ops.divide_no_nan(
+                W_combined, norm
+            )
+        else:
+            merged_kernel = kernel_fp
 
         # 3. Re-quantize the merged float kernel back to the target format
         if self.quantization_mode == "int4":

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -550,6 +550,217 @@ class EinsumDenseTest(testing.TestCase):
             supports_masking=False,
         )
 
+    @pytest.mark.requires_trainable_backend
+    def test_enable_dora(self):
+        layer = layers.EinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes=None,
+        )
+        layer.build((None, 3))
+        layer.enable_dora(2)
+        self.assertLen(layer.trainable_weights, 3)
+        self.assertLen(layer.non_trainable_weights, 1)
+        if backend.backend() == "torch":
+            self.assertLen(layer.torch_params, 4)
+        self.assertDType(layer.dora_kernel_a, "float32")
+        self.assertDType(layer.dora_kernel_b, "float32")
+        self.assertDType(layer.dora_magnitude, "float32")
+
+        # Try eager call
+        x = np.random.random((64, 3))
+        y = np.random.random((64, 8, 32))
+        _ = layer(x[:2])
+
+        init_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        init_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        init_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        # Try calling fit()
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y, epochs=2)
+
+        final_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        final_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        final_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        diff_a = np.max(
+            np.abs(init_dora_a_kernel_value - final_dora_a_kernel_value)
+        )
+        diff_b = np.max(
+            np.abs(init_dora_b_kernel_value - final_dora_b_kernel_value)
+        )
+        diff_m = np.max(
+            np.abs(init_dora_magnitude_value - final_dora_magnitude_value)
+        )
+
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+        self.assertGreater(diff_m, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].dora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        new_model = models.Sequential(
+            [
+                layers.EinsumDense(
+                    equation="ab,bcd->acd",
+                    output_shape=(8, 32),
+                    bias_axes=None,
+                ),
+            ]
+        )
+        new_model.build((None, 3))
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    def test_enable_dora_with_alpha(self):
+        equation = "ab,bc->ac"
+        output_shape = 3
+        bias_axes = None
+
+        layer = layers.EinsumDense(
+            equation=equation, output_shape=output_shape, bias_axes=bias_axes
+        )
+        layer.build((None, 2))
+
+        base_kernel = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32
+        )
+        layer._kernel.assign(base_kernel)
+
+        layer.enable_dora(rank=2, dora_alpha=3.0)
+        self.assertEqual(layer.dora_rank, 2)
+        self.assertEqual(layer.dora_alpha, 3.0)
+
+        a_val = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+        b_val = np.array([[0.5, 0.6, 0.7], [0.8, 0.9, 1.0]], dtype=np.float32)
+        layer.dora_kernel_a.assign(a_val)
+        layer.dora_kernel_b.assign(b_val)
+
+        # Manually compute expected effective kernel.
+        expected_delta = 1.5 * np.matmul(a_val, b_val)
+        W_combined = base_kernel + expected_delta
+        norm = np.sqrt(np.sum(np.square(W_combined), axis=0))
+        expected_kernel = ops.convert_to_numpy(layer.dora_magnitude) * (
+            W_combined / norm
+        )
+
+        actual_kernel = ops.convert_to_numpy(layer.kernel)
+        self.assertAllClose(
+            actual_kernel, expected_kernel, tpu_atol=1e-3, tpu_rtol=1e-3
+        )
+
+    def test_dora_rank_argument(self):
+        self.run_layer_test(
+            layers.EinsumDense,
+            init_kwargs={
+                "equation": "ab,bcd->acd",
+                "output_shape": (8, 32),
+                "bias_axes": None,
+                "dora_rank": 2,
+            },
+            input_shape=(2, 3),
+            expected_output_shape=(2, 8, 32),
+            expected_num_trainable_weights=3,
+            expected_num_non_trainable_weights=1,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
+    def test_enable_dora_with_kernel_constraint(self):
+        layer = layers.EinsumDense(
+            "ab,bc->ac", output_shape=4, kernel_constraint="max_norm"
+        )
+        with self.assertRaisesRegex(
+            ValueError, "DoRA is incompatible with kernel constraints"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_on_unbuilt_layer(self):
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=4)
+        with self.assertRaisesRegex(
+            ValueError, "Cannot enable dora on a layer that isn't yet built"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_when_already_enabled(self):
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=4)
+        layer.build((None, 2))
+        layer.enable_dora(rank=2)
+        with self.assertRaisesRegex(ValueError, "dora is already enabled"):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_with_gptq_quantization(self):
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=4)
+        layer.build((None, 2))
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=2
+            ),
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "dora is not currently supported with GPTQ quantization",
+        ):
+            layer.enable_dora(rank=2)
+
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_enable_dora_int4_kernel_shape(self):
+        layer = layers.EinsumDense("ab,bcd->acd", output_shape=(2, 4))
+        layer.build((None, 3))
+        # original_kernel_shape should be (3, 2, 4)
+        layer.quantize("int4")
+        layer.enable_dora(rank=2)
+        self.assertEqual(layer.dora_kernel_a.shape, (3, 2, 2))
+
+    def test_dora_lora_mutual_exclusivity(self):
+        layer = layers.EinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes=None,
+        )
+        layer.build((None, 3))
+        layer.enable_lora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "LoRA is already enabled. Cannot enable DoRA."
+        ):
+            layer.enable_dora(rank=2)
+
+        layer2 = layers.EinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes=None,
+        )
+        layer2.build((None, 3))
+        layer2.enable_dora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "dora is already enabled. Cannot enable LoRA."
+        ):
+            layer2.enable_lora(rank=2)
+
     # Test quantization-related methods.
 
     @parameterized.named_parameters(

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -76,6 +76,17 @@ class Embedding(Layer):
             trainable matrices) during the forward pass. The delta is scaled by
             `lora_alpha / lora_rank`, allowing you to fine-tune the strength of
             the LoRA adjustment independently of `lora_rank`.
+        dora_rank: Optional integer. If set, the layer's forward pass
+            will implement DoRA (Weight-Decomposed Low-Rank Adaptation)
+            with the provided rank. DoRA decomposes the layer's embeddings
+            into magnitude and direction components and applies LoRA
+            to the direction component. This can improve the learning
+            capacity of LoRA. You can also enable DoRA on an existing
+            `Embedding` layer by calling `layer.enable_dora(rank)`.
+        dora_alpha: Optional integer. If set, this parameter scales the
+            low-rank adaptation delta during the forward pass. The delta
+            is scaled by `dora_alpha / dora_rank`, allowing you to fine-tune
+            the strength of the DoRA adjustment independently of `dora_rank`.
 
     Input shape:
         2D tensor with shape: `(batch_size, input_length)`.
@@ -95,6 +106,8 @@ class Embedding(Layer):
         weights=None,
         lora_rank=None,
         lora_alpha=None,
+        dora_rank=None,
+        dora_alpha=None,
         quantization_config=None,
         **kwargs,
     ):
@@ -134,7 +147,15 @@ class Embedding(Layer):
         self.autocast = False
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else lora_rank
+        self.dora_rank = dora_rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else dora_rank
+        if self.lora_rank and self.dora_rank:
+            raise ValueError(
+                "Only one of `lora_rank` or `dora_rank` can be set."
+            )
         self.lora_enabled = False
+        self.dora_enabled = False
+
         self.quantization_config = quantization_config
 
         if weights is not None:
@@ -165,6 +186,8 @@ class Embedding(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
+        if self.dora_rank:
+            self.enable_dora(self.dora_rank, dora_alpha=self.dora_alpha)
 
     @property
     def embeddings(self):
@@ -188,6 +211,20 @@ class Embedding(Layer):
                 ),
                 dtype=self.compute_dtype,
             )
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_embeddings_a, self.dora_embeddings_b
+            )
+            W_combined = ops.add(embeddings, lora_delta)
+            # Normalize along input dimension (axis 0)
+            norm = ops.stop_gradient(
+                ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            )
+            embeddings = self.dora_magnitude * ops.divide_no_nan(
+                W_combined, norm
+            )
+            embeddings = ops.cast(embeddings, dtype=self.compute_dtype)
+
         return embeddings
 
     def call(self, inputs):
@@ -232,6 +269,8 @@ class Embedding(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
+        if getattr(self, "dora_enabled", False):
+            raise ValueError("dora is already enabled. Cannot enable LoRA.")
         self._tracker.unlock()
 
         # LoRA weights should be float32 to avoid the risk of underflow or
@@ -257,6 +296,64 @@ class Embedding(Layer):
         self.lora_enabled = True
         self.lora_rank = rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else rank
+
+    def enable_dora(
+        self,
+        rank,
+        dora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
+    ):
+        if self.embeddings_constraint:
+            raise ValueError(
+                "DoRA is incompatible with embedding constraints. "
+                "In order to enable dora on this layer, remove the "
+                "`embeddings_constraint` argument."
+            )
+        if not self.built:
+            raise ValueError(
+                "Cannot enable dora on a layer that isn't yet built."
+            )
+        if self.lora_enabled:
+            raise ValueError("LoRA is already enabled. Cannot enable DoRA.")
+        if self.dora_enabled:
+            raise ValueError(
+                "dora is already enabled. This can only be done once per layer."
+            )
+        self._tracker.unlock()
+
+        self.dora_embeddings_a = self.add_weight(
+            name="dora_embeddings_a",
+            shape=(self.input_dim, rank),
+            initializer=initializers.get(a_initializer),
+            dtype="float32",
+            regularizer=self.embeddings_regularizer,
+        )
+        self.dora_embeddings_b = self.add_weight(
+            name="dora_embeddings_b",
+            shape=(rank, self.output_dim),
+            initializer=initializers.get(b_initializer),
+            dtype="float32",
+            regularizer=self.embeddings_regularizer,
+        )
+
+        # Initialize Magnitude Vector
+        # We reduce all axes except the last one (output_dim)
+        initial_magnitude = ops.stop_gradient(
+            ops.sqrt(ops.sum(ops.square(self.embeddings), axis=0))
+        )
+        self.dora_magnitude = self.add_weight(
+            name="dora_magnitude",
+            shape=(self.output_dim,),
+            initializer=lambda *a, **kw: initial_magnitude,
+            dtype="float32",
+        )
+
+        self._embeddings.trainable = False
+        self._tracker.lock()
+        self.dora_enabled = True
+        self.dora_rank = rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else rank
 
     def save_own_variables(self, store):
         # Do nothing if the layer isn't yet built
@@ -301,8 +398,9 @@ class Embedding(Layer):
             idx += 1
 
     def load_own_variables(self, store):
-        if not self.lora_enabled:
+        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
             self._check_load_own_variables(store)
+
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
@@ -338,6 +436,21 @@ class Embedding(Layer):
             self.lora_embeddings_b.assign(
                 ops.zeros(self.lora_embeddings_b.shape)
             )
+        if self.dora_enabled:
+            self.dora_embeddings_a.assign(
+                ops.zeros(self.dora_embeddings_a.shape)
+            )
+            self.dora_embeddings_b.assign(
+                ops.zeros(self.dora_embeddings_b.shape)
+            )
+            # Temporarily disable to get base kernel
+            self.dora_enabled = False
+            base_embeddings = self.embeddings
+            self.dora_enabled = True
+
+            self.dora_magnitude.assign(
+                ops.sqrt(ops.sum(ops.square(base_embeddings), axis=0))
+            )
 
     def get_config(self):
         base_config = super().get_config()
@@ -364,6 +477,9 @@ class Embedding(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
             config["lora_alpha"] = self.lora_alpha
+        if self.dora_rank:
+            config["dora_rank"] = self.dora_rank
+            config["dora_alpha"] = self.dora_alpha
         return {**base_config, **config}
 
     @classmethod
@@ -732,10 +848,22 @@ class Embedding(Layer):
             )
 
         # Merge LoRA weights in float domain.
-        lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
-            self.lora_embeddings_a, self.lora_embeddings_b
-        )
-        merged_float_embeddings = ops.add(float_embeddings, lora_delta)
+        if self.lora_enabled:
+            lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
+                self.lora_embeddings_a, self.lora_embeddings_b
+            )
+            merged_float_embeddings = ops.add(float_embeddings, lora_delta)
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_embeddings_a, self.dora_embeddings_b
+            )
+            W_combined = ops.add(float_embeddings, lora_delta)
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            merged_float_embeddings = self.dora_magnitude * ops.divide_no_nan(
+                W_combined, norm
+            )
+        else:
+            merged_float_embeddings = float_embeddings
 
         # Requantize.
         if self.quantization_mode == "int4":

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -341,6 +341,167 @@ class EmbeddingTest(test_case.TestCase):
         with self.assertRaisesRegex(ValueError, "lora is already enabled"):
             layer.enable_lora(rank=2)
 
+    @pytest.mark.requires_trainable_backend
+    def test_enable_dora(self):
+        layer = layers.Embedding(10, 16)
+        layer.build()
+        layer.enable_dora(4)
+        self.assertLen(layer.trainable_weights, 3)
+        self.assertLen(layer.non_trainable_weights, 1)
+        if backend.backend() == "torch":
+            self.assertLen(layer.torch_params, 4)
+        self.assertDType(layer.dora_embeddings_a, "float32")
+        self.assertDType(layer.dora_embeddings_b, "float32")
+        self.assertDType(layer.dora_magnitude, "float32")
+
+        # Try eager call
+        x = np.random.randint(0, 9, size=(64, 3))
+        y = np.random.random((64, 3, 16))
+        _ = layer(x[:2])
+
+        init_dora_a_embeddings_value = layer.dora_embeddings_a.numpy()
+        init_dora_b_embeddings_value = layer.dora_embeddings_b.numpy()
+        init_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        # Try calling fit()
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y)
+
+        final_dora_a_embeddings_value = layer.dora_embeddings_a.numpy()
+        final_dora_b_embeddings_value = layer.dora_embeddings_b.numpy()
+        final_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        diff_a = np.max(
+            np.abs(init_dora_a_embeddings_value - final_dora_a_embeddings_value)
+        )
+        diff_b = np.max(
+            np.abs(init_dora_b_embeddings_value - final_dora_b_embeddings_value)
+        )
+        diff_m = np.max(
+            np.abs(init_dora_magnitude_value - final_dora_magnitude_value)
+        )
+
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+        self.assertGreater(diff_m, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].dora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        new_model = models.Sequential(
+            [
+                layers.Input((3,), dtype="int32"),
+                layers.Embedding(10, 16),
+            ]
+        )
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    def test_enable_dora_with_alpha(self):
+        layer = layers.Embedding(input_dim=3, output_dim=2)
+        layer.build((None,))
+
+        base_emb = np.array(
+            [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float32
+        )
+        layer._embeddings.assign(base_emb)
+
+        layer.enable_dora(2, dora_alpha=3.0)
+        self.assertEqual(layer.dora_rank, 2)
+        self.assertEqual(layer.dora_alpha, 3.0)
+
+        a_val = np.array([[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]], dtype=np.float32)
+        b_val = np.array([[0.5, 0.5], [0.6, 0.6]], dtype=np.float32)
+        layer.dora_embeddings_a.assign(a_val)
+        layer.dora_embeddings_b.assign(b_val)
+
+        # Manually compute expected effective embeddings.
+        expected_delta = 1.5 * np.matmul(a_val, b_val)
+        W_combined = base_emb + expected_delta
+        norm = np.sqrt(np.sum(np.square(W_combined), axis=0))
+        expected_embeddings = ops.convert_to_numpy(layer.dora_magnitude) * (
+            W_combined / norm
+        )
+
+        actual_embeddings = ops.convert_to_numpy(layer.embeddings)
+        self.assertAllClose(
+            actual_embeddings, expected_embeddings, tpu_atol=1e-3, tpu_rtol=1e-3
+        )
+
+    def test_dora_rank_argument(self):
+        self.run_layer_test(
+            layers.Embedding,
+            init_kwargs={"input_dim": 5, "output_dim": 4, "dora_rank": 2},
+            input_shape=(2, 3),
+            input_dtype="int32",
+            expected_output_shape=(2, 3, 4),
+            expected_num_trainable_weights=3,
+            expected_num_non_trainable_weights=1,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
+    def test_dora_lora_mutual_exclusivity(self):
+        layer = layers.Embedding(input_dim=10, output_dim=16)
+        layer.build()
+        layer.enable_lora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "LoRA is already enabled. Cannot enable DoRA."
+        ):
+            layer.enable_dora(rank=2)
+
+        layer2 = layers.Embedding(input_dim=10, output_dim=16)
+        layer2.build()
+        layer2.enable_dora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "dora is already enabled. Cannot enable LoRA."
+        ):
+            layer2.enable_lora(rank=2)
+
+    def test_enable_dora_with_embeddings_constraint(self):
+        layer = layers.Embedding(
+            input_dim=10, output_dim=16, embeddings_constraint="max_norm"
+        )
+        with self.assertRaisesRegex(
+            ValueError, "DoRA is incompatible with embedding constraints"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_on_unbuilt_layer(self):
+        layer = layers.Embedding(input_dim=10, output_dim=16)
+        with self.assertRaisesRegex(
+            ValueError, "Cannot enable dora on a layer that isn't yet built."
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_when_already_enabled(self):
+        layer = layers.Embedding(input_dim=10, output_dim=16)
+        layer.build()
+        layer.enable_dora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "dora is already enabled. This can only be done once"
+        ):
+            layer.enable_dora(rank=2)
+
     # Test quantization-related methods.
 
     @parameterized.named_parameters(
@@ -779,6 +940,27 @@ class EmbeddingTest(test_case.TestCase):
         config = Int4QuantizationConfig(block_size=block_size)
         layer.quantize("int4", config=config)
         layer.enable_lora(rank=4)
+
+        x = np.random.randint(0, input_dim, size=(4, 8))
+
+        # Should run without error
+        y = layer(x)
+        self.assertEqual(y.shape, (4, 8, output_dim))
+
+    @parameterized.named_parameters(
+        ("grouped_block_64", 64),
+        ("per_channel", None),
+    )
+    @pytest.mark.requires_trainable_backend
+    def test_int4_block_size_with_dora(self, block_size):
+        """Test int4 quantization with DoRA and different block_size."""
+        input_dim, output_dim = 50, 128
+        layer = layers.Embedding(input_dim=input_dim, output_dim=output_dim)
+        layer.build()
+
+        config = Int4QuantizationConfig(block_size=block_size)
+        layer.quantize("int4", config=config)
+        layer.enable_dora(rank=4)
 
         x = np.random.randint(0, input_dim, size=(4, 8))
 

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1497,6 +1497,43 @@ class SavingH5IOStoreTest(testing.TestCase):
         revived_layer.lora_kernel_b.assign(lora_kernel_b)
         self.assertAllClose(revived_layer(ref_input), ref_output, atol=1e-6)
 
+    def test_h5_io_store_dora(self):
+        # For `keras_hub.models.backbone.save_dora_weights` and
+        # `keras_hub.models.backbone.load_dora_weights`
+        temp_filepath = Path(os.path.join(self.get_temp_dir(), "layer.dora.h5"))
+        layer = keras.layers.Dense(units=16)
+        layer.build((None, 8))
+        layer.enable_dora(4)
+
+        ref_input = np.random.random((1, 8)).astype("float32")
+        ref_output = layer(ref_input)
+
+        # Save the DoRA weights.
+        store = saving_lib.H5IOStore(temp_filepath, mode="w")
+        dora_store = store.make("dora")
+        dora_store["rank"] = layer.dora_rank
+        inner_store = store.make("dora/0")
+        inner_store["dora_kernel_a"] = layer.dora_kernel_a
+        inner_store["dora_kernel_b"] = layer.dora_kernel_b
+        inner_store["dora_magnitude"] = layer.dora_magnitude
+        store.close()
+
+        # Load the DoRA weights.
+        revived_layer = keras.layers.Dense(units=16)
+        revived_layer.build((None, 8))
+        store = saving_lib.H5IOStore(temp_filepath, mode="r")
+        dora_store = store.get("dora")
+        revived_layer.enable_dora(int(dora_store["rank"][()]))
+        dora_kernel_a = store.get("dora/0")["dora_kernel_a"]
+        dora_kernel_b = store.get("dora/0")["dora_kernel_b"]
+        dora_magnitude = store.get("dora/0")["dora_magnitude"]
+        revived_layer._kernel.assign(layer._kernel)
+        revived_layer.bias.assign(layer.bias)
+        revived_layer.dora_kernel_a.assign(dora_kernel_a)
+        revived_layer.dora_kernel_b.assign(dora_kernel_b)
+        revived_layer.dora_magnitude.assign(dora_magnitude)
+        self.assertAllClose(revived_layer(ref_input), ref_output, atol=1e-6)
+
     def test_h5_io_store_exception_raised(self):
         temp_filepath = Path(os.path.join(self.get_temp_dir(), "store.h5"))
 


### PR DESCRIPTION
## Description
This PR implements Weight-Decomposed Low-Rank Adaptation (DoRA) for Keras, based on the paper DoRA: Weight-Decomposed Low-Rank Adaptation (Lu et al., 2024) (https://arxiv.org/abs/2402.09353).

Design Doc: https://docs.google.com/document/d/13iJl_vVot4tMs9LMLrwHvlD-9TBZAD8bTNDk7yJsJM4/edit?usp=sharing
Benchmarking: https://colab.research.google.com/drive/1WWBou-NH7najBu676yS2_UHk7LJCc5rk?resourcekey=0-b1mdPX0RsifeT2bo4J3a5A&usp=sharing
### Overview
DoRA improves upon traditional LoRA by decoupling the magnitude and direction of weight updates. By applying low-rank adaptations exclusively to the directional component while treating magnitude as an independent trainable vector, DoRA enables training trajectories that more closely resemble full fine-tuning (FT) while maintaining the parameter efficiency of LoRA.

### Mathematical Implementation
The effective weight matrix $W'$ is computed as:
$$W' = m \cdot \frac{W_{frozen} + \Delta V}{\|W_{frozen} + \Delta V\|_c}$$
Where:
   - $m$ is a trainable magnitude vector.
   - $\Delta V$ is the low-rank adaptation ($\frac{\alpha}{rank} AB$).
   - $\|\cdot\|_c$ denotes the column-wise norm.

In accordance with Section 4.3 of the original paper, this implementation utilizes gradient detachment for the normalization factor (ops.stop_gradient(norm)) to significantly reduce training memory overhead without sacrificing accuracy.

### Key Features
   - Layer Support: Implemented for core parameter-heavy layers: Dense, EinsumDense, Embedding, and BaseConv (Convolutional layers).
   - Quantization Compatibility: Fully supports int4 and int8 quantization. The implementation handles dimension-tracking (_orig_input_dim,  _orig_output_dim) to ensure adapters and unpacking logic remain correct even with packed bit-widths.
   - Serialization: Updates get_config/from_config to ensure DoRA parameters are persisted. load_own_variables is updated to correctly reinstate DoRA topology and initialize magnitude vectors from checkpoints.
   - Dynamic Enablement: Users can enable DoRA on existing layers via layer.enable_dora(rank).

### Usage
```
   # During instantiation
   dense = keras.layers.Dense(units=64, dora_rank=4, dora_alpha=8)
  
   # Or dynamically on a built layer
   dense = keras.layers.Dense(units=64)
   dense.build(input_shape=(None, 32))
   dense.enable_dora(rank=4)
```

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
