### PR TITLE
Wait for PyDataset on_epoch_begin callback before starting workers

### DIFF
--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -349,9 +349,9 @@ class PyDatasetAdapter(DataAdapter):
                 "having been called."
             )
         self._within_epoch = True
+        self.py_dataset.on_epoch_begin()
         if self.enqueuer:
             self.enqueuer.start(self._epoch)
-        self.py_dataset.on_epoch_begin()
 
     def on_epoch_end(self):
         if self.enqueuer:


### PR DESCRIPTION
Fixes #23283

## Description
This PR simply moves the call to `on_epoch_begin` to happen before the worker pool is started. This ensures that the method will finish executing before any worker attempts to pull data. This mirrors what happen for `on_epoch_end`, which is called after the thread pool is stopped.

See [this notebook](https://colab.research.google.com/drive/1eMezIkGXxGf1VOup_3fdswizlIp9gjFz?usp=sharing) for a way to test both the bug and the proposed fix.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
