### PR TITLE
Fix CosineSimilarity metric dropping axis in get_config

### DIFF
--- a/keras/src/metrics/regression_metrics.py
+++ b/keras/src/metrics/regression_metrics.py
@@ -295,11 +295,12 @@ class CosineSimilarity(reduction_metrics.MeanMetricWrapper):
 
     def __init__(self, name="cosine_similarity", dtype=None, axis=-1):
         super().__init__(cosine_similarity, name, dtype=dtype, axis=axis)
+        self.axis = axis
         # Metric should be maximized during optimization.
         self._direction = "up"
 
     def get_config(self):
-        return {"name": self.name, "dtype": self.dtype}
+        return {"name": self.name, "dtype": self.dtype, "axis": self.axis}
 
 
 @keras_export("keras.metrics.LogCoshError")

--- a/keras/src/metrics/regression_metrics_test.py
+++ b/keras/src/metrics/regression_metrics_test.py
@@ -61,12 +61,30 @@ class CosineSimilarityTest(testing.TestCase):
         self.assertEqual(cosine_obj.name, "my_cos")
         self.assertEqual(cosine_obj.dtype, "int32")
 
+        self.assertEqual(cosine_obj.axis, 2)
+
         # Check save and restore config
         cosine_obj2 = metrics.CosineSimilarity.from_config(
             cosine_obj.get_config()
         )
         self.assertEqual(cosine_obj2.name, "my_cos")
         self.assertEqual(cosine_obj2._dtype, "int32")
+        self.assertEqual(cosine_obj2.axis, 2)
+
+    def test_config_preserves_axis_result(self):
+        # A metric restored from config must compute the same result as the
+        # original when a non-default `axis` is used.
+        self.setup(axis=0)
+        cosine_obj = metrics.CosineSimilarity(axis=0)
+        cosine_obj2 = metrics.CosineSimilarity.from_config(
+            cosine_obj.get_config()
+        )
+        loss = cosine_obj(self.y_true, self.y_pred)
+        loss2 = cosine_obj2(self.y_true, self.y_pred)
+        expected_loss = np.mean(self.expected_loss)
+        self.assertAlmostEqual(loss, expected_loss, 3)
+        self.assertAlmostEqual(loss2, expected_loss, 3)
+        self.assertAlmostEqual(loss, loss2, 6)
 
     def test_unweighted(self):
         self.setup()


### PR DESCRIPTION
## Description

`keras.metrics.CosineSimilarity` accepts an `axis` argument (documented, and used in the class docstring examples), but its `get_config` returned a hard-coded `{"name": ..., "dtype": ...}` and dropped `axis`. After a `serialize`/`deserialize` round trip — e.g. saving and reloading a model compiled with this metric — `from_config(**config)` fell back to the default `axis=-1`, and the restored metric silently computed different numbers.

Repro on master:

```python
from keras import metrics

m = metrics.CosineSimilarity(axis=0)
m2 = metrics.deserialize(metrics.serialize(m))

m.update_state([[0., 1.], [1., 1.]], [[1., 0.], [1., 1.]])
m2.update_state([[0., 1.], [1., 1.]], [[1., 0.], [1., 1.]])
print(float(m.result()))   # 0.7071067690849304
print(float(m2.result()))  # 0.4999999701976776  (axis silently reset to -1)
```

**Root cause:** `CosineSimilarity` subclasses `MeanMetricWrapper` and overrides `get_config` (to avoid serializing the wrapped `fn`), but the override only kept `name`/`dtype` and omitted `axis`.

**Fix:** store `self.axis` in `__init__` and include it in `get_config`, matching the pattern already used by the sibling `MeanMetricWrapper` subclasses `PearsonCorrelation` and `ConcordanceCorrelation` in `correlation_metrics.py`.

**Testing:** extended `CosineSimilarityTest::test_config` to assert `axis` survives `from_config(get_config())`, and added `test_config_preserves_axis_result`, which asserts a restored metric with a non-default `axis` produces the same result as the original. Both new assertions fail on master and pass with this change. Full run: `pytest keras/src/metrics/regression_metrics_test.py keras/src/metrics/reduction_metrics_test.py keras/src/metrics/metric_test.py` → 66 passed (TensorFlow backend).

**AI disclosure (per the AI-Assisted Contribution Policy):** I used a general-purpose AI coding assistant while preparing this change. I have reviewed and tested the code and take full responsibility for it.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
