### PR TITLE
Fix Huber, CosineSimilarity and SparseCategoricalCrossentropy losing delta/axis on serialization

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -293,11 +293,10 @@ class CosineSimilarity(LossFunctionWrapper):
             dtype=dtype,
             axis=axis,
         )
-        self.axis = axis
 
     def get_config(self):
-        config = Loss.get_config(self)
-        config.update({"axis": self.axis})
+        config = super().get_config()
+        config.pop("fn")
         return config
 
 
@@ -351,11 +350,10 @@ class Huber(LossFunctionWrapper):
             dtype=dtype,
             delta=delta,
         )
-        self.delta = delta
 
     def get_config(self):
-        config = Loss.get_config(self)
-        config.update({"delta": self.delta})
+        config = super().get_config()
+        config.pop("fn")
         return config
 
 
@@ -1263,19 +1261,10 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
             ignore_class=ignore_class,
             axis=axis,
         )
-        self.from_logits = from_logits
-        self.ignore_class = ignore_class
-        self.axis = axis
 
     def get_config(self):
-        config = Loss.get_config(self)
-        config.update(
-            {
-                "from_logits": self.from_logits,
-                "ignore_class": self.ignore_class,
-                "axis": self.axis,
-            }
-        )
+        config = super().get_config()
+        config.pop("fn")
         return config
 
 

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -293,9 +293,12 @@ class CosineSimilarity(LossFunctionWrapper):
             dtype=dtype,
             axis=axis,
         )
+        self.axis = axis
 
     def get_config(self):
-        return Loss.get_config(self)
+        config = Loss.get_config(self)
+        config.update({"axis": self.axis})
+        return config
 
 
 @keras_export("keras.losses.Huber")
@@ -348,9 +351,12 @@ class Huber(LossFunctionWrapper):
             dtype=dtype,
             delta=delta,
         )
+        self.delta = delta
 
     def get_config(self):
-        return Loss.get_config(self)
+        config = Loss.get_config(self)
+        config.update({"delta": self.delta})
+        return config
 
 
 @keras_export("keras.losses.LogCosh")
@@ -1259,6 +1265,7 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
         )
         self.from_logits = from_logits
         self.ignore_class = ignore_class
+        self.axis = axis
 
     def get_config(self):
         config = Loss.get_config(self)
@@ -1266,6 +1273,7 @@ class SparseCategoricalCrossentropy(LossFunctionWrapper):
             {
                 "from_logits": self.from_logits,
                 "ignore_class": self.ignore_class,
+                "axis": self.axis,
             }
         )
         return config

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -534,7 +534,10 @@ class CosineSimilarityTest(testing.TestCase):
         self.assertEqual(cosine_obj.name, "cosine_loss")
         self.assertEqual(cosine_obj.reduction, "sum")
         config = cosine_obj.get_config()
-        self.assertEqual(config, {"name": "cosine_loss", "reduction": "sum"})
+        self.assertEqual(
+            config, {"name": "cosine_loss", "reduction": "sum", "axis": 2}
+        )
+        self.run_class_serialization_test(cosine_obj)
 
     def test_unweighted(self):
         self.setup()
@@ -622,11 +625,14 @@ class HuberLossTest(testing.TestCase):
         self.y_true = self.np_y_true
 
     def test_config(self):
-        h_obj = losses.Huber(reduction="sum", name="huber")
+        h_obj = losses.Huber(delta=2.0, reduction="sum", name="huber")
         self.assertEqual(h_obj.name, "huber")
         self.assertEqual(h_obj.reduction, "sum")
         config = h_obj.get_config()
-        self.assertEqual(config, {"name": "huber", "reduction": "sum"})
+        self.assertEqual(
+            config, {"name": "huber", "reduction": "sum", "delta": 2.0}
+        )
+        self.run_class_serialization_test(h_obj)
 
     def test_all_correct(self):
         self.setup()
@@ -1233,6 +1239,14 @@ class SparseCategoricalCrossentropyTest(testing.TestCase):
         self.run_class_serialization_test(
             losses.SparseCategoricalCrossentropy(name="scce")
         )
+        scce_obj = losses.SparseCategoricalCrossentropy(
+            from_logits=True, ignore_class=3, axis=0, name="scce"
+        )
+        config = scce_obj.get_config()
+        self.assertEqual(config["from_logits"], True)
+        self.assertEqual(config["ignore_class"], 3)
+        self.assertEqual(config["axis"], 0)
+        self.run_class_serialization_test(scce_obj)
 
     def test_all_correct_unweighted(self):
         y_true = np.array([[0], [1], [2]], dtype="int64")


### PR DESCRIPTION
## Description

Several loss classes drop their numeric hyperparameters from `get_config`, so saving and reloading a compiled model silently changes the loss being computed:

- `Huber(delta=2.0)` serializes to `{'name': 'huber_loss', 'reduction': 'sum_over_batch_size'}` and deserializes with `delta=1.0`
- `CosineSimilarity(axis=1)` deserializes with `axis=-1`
- `SparseCategoricalCrossentropy(axis=0)` keeps `from_logits`/`ignore_class` but loses `axis` (`axis` was added in #21104 without updating `get_config`)

Repro on master:

```python
import numpy as np
from keras import losses

h = losses.Huber(delta=2.0)
h2 = losses.deserialize(losses.serialize(h))
print(h2.get_config())  # {'name': 'huber_loss', 'reduction': 'sum_over_batch_size'} — delta gone

y_true = np.array([[0.0], [0.0]])
y_pred = np.array([[4.0], [4.0]])
print(float(h(y_true, y_pred)))   # 6.0
print(float(h2(y_true, y_pred)))  # 3.5  (delta silently reset to 1.0)
```

The same happens end to end: saving a model compiled with `Huber(delta=2.0)` to `.keras` and reloading it produces different `evaluate()` results (6.0 vs 3.5 on the data above), with no warning. This is also a regression vs `tf.keras`, where `Huber.get_config` included `delta`.

**Root cause:** these `LossFunctionWrapper` subclasses override `get_config` with `return Loss.get_config(self)` to avoid serializing the wrapped `fn`, but that base config only contains `name`/`reduction`/`dtype` — the per-class kwargs (`delta`, `axis`) live only in `self._fn_kwargs` and are discarded. `from_config` then rebuilds with `cls(**config)`, so the dropped kwargs revert to their defaults.

**Fix:** store the hyperparameters as attributes (`self.delta`, `self.axis`) and include them in `get_config`, matching the pattern already used by `CategoricalCrossentropy` and `CategoricalFocalCrossentropy`. These three classes were the only losses with a bare `Loss.get_config(self)` override plus extra constructor arguments.

**Testing:** updated the `test_config` assertions for `Huber` and `CosineSimilarity` (they previously codified the truncated config) and added serialization round-trip coverage with non-default `delta`/`axis` via `run_class_serialization_test`, including a `SparseCategoricalCrossentropy(from_logits=True, ignore_class=3, axis=0)` case. All three updated tests fail on master and pass with this change. Full run: `pytest keras/src/losses/` → 180 passed, 1 skipped (TensorFlow backend).

**AI disclosure (per the AI-Assisted Contribution Policy):** I used a general-purpose AI coding assistant while preparing this change. I have reviewed and tested the code and take full responsibility for it.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
