### PR TITLE
`get_file` also checks `os.altsep` on Windows.

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -321,7 +321,7 @@ def get_file(
                 "Please specify the `fname` argument."
             )
     else:
-        if os.sep in fname:
+        if os.sep in fname or (os.altsep and os.altsep in fname):
             raise ValueError(
                 "Paths are no longer accepted as the `fname` argument. "
                 "To specify the file's parent directory, use "


### PR DESCRIPTION
`get_file` doesn't allow full paths to be passed in in the `fname` argument. For completeness, `os.altsep` is also rejected on Windows in addition to `os.sep`.

Note that this is not tested as we don't run Windows tests.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
