### PR TITLE
perf(layers): skip _clear_losses recursion when no losses ever registered

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -67,6 +67,16 @@ else:
     )
 
 
+# Process-global, set-once flag. Stays `False` until the first `add_loss`
+# call anywhere in the process. While it is `False`, no layer's `_losses`
+# list or `_loss_ids` set can be non-empty (the only writer is `add_loss`,
+# which flips this flag before doing so), so the recursive
+# `_clear_losses()` walk in `_get_call_context` is provably a no-op and can
+# be skipped entirely. Once set, it is never unset, and behavior reverts to
+# exactly the prior (always-clear) semantics for the rest of the process.
+_LOSSES_REGISTERED = False
+
+
 @keras_export(["keras.Layer", "keras.layers.Layer"])
 class Layer(BackendLayer, Operation):
     """This is the class from which all layers inherit.
@@ -1275,6 +1285,8 @@ class Layer(BackendLayer, Operation):
                     "`add_loss()` can only be called from inside `build()` or "
                     f"`call()`, on a tensor input. Received invalid value: {x}"
                 )
+        global _LOSSES_REGISTERED
+        _LOSSES_REGISTERED = True
         if backend.in_stateless_scope():
             scope = backend.get_stateless_scope()
             if scope.collect_losses:
@@ -1690,7 +1702,8 @@ class Layer(BackendLayer, Operation):
             global_state.set_global_attribute(
                 "current_call_ctx", layer_call_ctx
             )
-            self._clear_losses()
+            if _LOSSES_REGISTERED:
+                self._clear_losses()
         return layer_call_ctx
 
     def _maybe_reset_call_context(self):

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -15,6 +15,7 @@ from keras.src import ops
 from keras.src import testing
 from keras.src.backend.common import global_state
 from keras.src.backend.common.remat import RematScope
+from keras.src.layers import layer as layer_module
 from keras.src.models import Model
 
 
@@ -636,6 +637,148 @@ class LayerTest(testing.TestCase):
         model(np.ones((1,)))
         self.assertLen(model.losses, 1)
         self.assertAllClose(model.losses[0], 1.0)
+
+    def test_clear_losses_walk_skipped_when_no_losses_ever_registered(self):
+        # `_get_call_context` should not walk the sublayer tree calling
+        # `_clear_losses()` on a model that has never registered a loss
+        # anywhere in the process. Once any layer anywhere calls
+        # `add_loss`, the module-level flag flips permanently and the walk
+        # always runs again (conservative over-clearing, never
+        # under-clearing).
+        original_flag = layer_module._LOSSES_REGISTERED
+        try:
+            layer_module._LOSSES_REGISTERED = False
+
+            class PlainLayer(layers.Layer):
+                def call(self, x):
+                    return x * 2
+
+            model = models.Sequential(
+                [PlainLayer() for _ in range(3)],
+            )
+            model.build((None, 4))
+            x = np.ones((2, 4))
+
+            with mock.patch.object(
+                layers.Layer, "_clear_losses", autospec=True
+            ) as mock_clear:
+                model(x)
+                mock_clear.assert_not_called()
+
+            self.assertFalse(layer_module._LOSSES_REGISTERED)
+
+            # Now register a loss anywhere; the flag flips permanently and
+            # the walk resumes on every subsequent outermost call.
+            class LossLayer(layers.Layer):
+                def call(self, x):
+                    self.add_loss(ops.sum(x))
+                    return x
+
+            loss_model = models.Sequential(
+                [LossLayer()] + [PlainLayer() for _ in range(3)],
+            )
+            loss_model.build((None, 4))
+            loss_model(x)
+            self.assertTrue(layer_module._LOSSES_REGISTERED)
+
+            with mock.patch.object(
+                layers.Layer, "_clear_losses", autospec=True
+            ) as mock_clear:
+                model(x)
+                mock_clear.assert_called()
+        finally:
+            layer_module._LOSSES_REGISTERED = original_flag
+
+    def test_add_loss_flag_makes_clear_losses_permanent(self):
+        # Regression: once the flag is set, unrelated loss-free models in
+        # the same process must still get their (empty) losses cleared
+        # every call, i.e. behavior is identical to pre-fix once any loss
+        # has ever been registered.
+        original_flag = layer_module._LOSSES_REGISTERED
+        try:
+            layer_module._LOSSES_REGISTERED = True
+
+            class PlainLayer(layers.Layer):
+                def call(self, x):
+                    return x * 2
+
+            layer = PlainLayer()
+            with mock.patch.object(
+                layers.Layer, "_clear_losses", autospec=True
+            ) as mock_clear:
+                layer(np.ones((1,)))
+                mock_clear.assert_called()
+        finally:
+            layer_module._LOSSES_REGISTERED = original_flag
+
+    def test_activity_regularizer_sets_losses_registered_flag(self):
+        # The activity-regularizer path routes through `add_loss`
+        # (layer.py, inside `Layer.__call__`), so it must also flip the
+        # module-level flag.
+        original_flag = layer_module._LOSSES_REGISTERED
+        try:
+            layer_module._LOSSES_REGISTERED = False
+
+            layer = layers.Dense(2, activity_regularizer="l2")
+            layer.build((None, 2))
+            layer(np.ones((1, 2)))
+
+            self.assertTrue(layer_module._LOSSES_REGISTERED)
+        finally:
+            layer_module._LOSSES_REGISTERED = original_flag
+
+    def test_activity_regularizer_losses_accumulate_correctly_per_call(self):
+        # Regression for the gated walk: an activity-regularized layer
+        # must still see exactly one loss per call (not accumulating
+        # across repeated calls), since once the flag is set the clear
+        # still runs on every outermost call.
+        layer = layers.Dense(2, activity_regularizer="l2")
+        layer.build((None, 2))
+
+        layer(np.ones((1, 2)))
+        self.assertLen(layer.losses, 1)
+
+        layer(np.ones((1, 2)))
+        self.assertLen(layer.losses, 1)
+
+        layer(np.ones((1, 2)))
+        self.assertLen(layer.losses, 1)
+
+    def test_stateless_scope_losses_still_cleared_when_flag_set(self):
+        # The gate only skips the walk when the flag is `False`. Once set,
+        # loss clearing under a stateless scope (used e.g. by the JAX
+        # backend) must behave exactly as before: each outermost call
+        # clears prior losses before the layer runs again.
+        original_flag = layer_module._LOSSES_REGISTERED
+        try:
+            layer_module._LOSSES_REGISTERED = True
+
+            class LossLayer(layers.Layer):
+                def call(self, x):
+                    self.add_loss(ops.sum(x))
+                    return x
+
+            layer = LossLayer()
+            layer.build((1,))
+            x = np.ones((1,))
+
+            state_mapping = [(v, v.value) for v in layer.variables]
+            with backend.StatelessScope(
+                state_mapping=state_mapping, collect_losses=True
+            ) as scope:
+                layer(x)
+            self.assertLen(scope.losses, 1)
+
+            # A second, independent stateless call must not accumulate
+            # losses from the first.
+            state_mapping = [(v, v.value) for v in layer.variables]
+            with backend.StatelessScope(
+                state_mapping=state_mapping, collect_losses=True
+            ) as scope2:
+                layer(x)
+            self.assertLen(scope2.losses, 1)
+        finally:
+            layer_module._LOSSES_REGISTERED = original_flag
 
     def test_training_arg_value_resolution(self):
         # Check that even if `training` is not passed


### PR DESCRIPTION
Closes #23292

## Why this was closed

This change showed no measurable macro benefit on either axis. Its isolated
eager effect is within measurement noise on the models tested, and it is
compile-neutral: 0 graph-break delta with deterministic dynamo decomposition
(see the per-PR compile scorecard). It was backed only by a deterministic
micro-benchmark (a 1 → 0 reduction in recursive-clear call count on models
that never register a loss), not by a measured macro speedup.

![torch.compile graph breaks across the #22561 series (this PR does not change the count)](https://raw.githubusercontent.com/pctablet505/keras/5195086b19/22561/compile-graph-breaks-22561-2026-07-19.png)

## Summary

`_get_call_context` unconditionally calls `self._clear_losses()` on every
outermost layer/model call, recursing into every sublayer's `_losses` /
`_loss_ids` even when the model never calls `add_loss`. This adds a
process-global flag, `_LOSSES_REGISTERED`, set by `add_loss` (the sole
writer of `_losses`/`_loss_ids`, including the `activity_regularizer`
path), and skips the recursive clear until it's set. On models that never
register a loss, this drops the walk from 1 call/forward-pass to 0.

## Why it's safe

The flag is one-way (`False -> True`, never reset) and flipped
synchronously at the top of `add_loss`, so there's no window where a loss
exists but the flag still reads `False` — skipping the clear while unset
cannot skip clearing anything real. Once any loss is registered anywhere
in the process, behavior is byte-identical to the old always-clear path.
Change is confined to `keras/src/layers/layer.py` above backend dispatch,
no `backend.backend()` guards, so it applies uniformly across backends.

![PR #23298: master vs PR alone vs PR+parents, Keras torch GPU eager, ms](https://raw.githubusercontent.com/pctablet505/keras/876c0954e0eb3661584daebf89921903532f3d35/22561/pr23298.png)

Isolated GPU wall-clock lands as noise (expected — one skipped Python-level
recursion on toy models where GPU kernel launch dominates); the
deterministic proof is the 1 → 0 call-count reduction. The "+ all 13 series
PRs" column shows composability with the rest of #22561 (1.25–1.38×) and
isn't attributable to this PR alone — it has no parent PRs and no
sequencing dependency with the rest of the series.

## Tests

`layer_test.py`: flag stays unset with no losses (no `_clear_losses` call),
flips permanently on first `add_loss` (direct and via
`activity_regularizer`), and loss collection/clearing across nested
sublayers still works once set. Full `layers/` suite clean on torch
(matches baseline pass/skip counts); `layer_test.py` clean on tensorflow
and jax.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.