### PR TITLE
perf(torch): dedupe double trainable_weights walk in train_step

### DIFF
--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -64,12 +64,13 @@ class TorchTrainer(base_trainer.Trainer):
             loss = self.optimizer.scale_loss(loss)
 
         # Compute gradients
-        if self.trainable_weights:
+        trainable_weights = self.trainable_weights
+        if trainable_weights:
             # Call torch.Tensor.backward() on the loss to compute gradients
             # for the weights.
             loss.backward()
 
-            trainable_weights = self.trainable_weights[:]
+            trainable_weights = trainable_weights[:]
             gradients = [v.value.grad for v in trainable_weights]
 
             # Update weights

--- a/keras/src/backend/torch/trainer.py
+++ b/keras/src/backend/torch/trainer.py
@@ -70,7 +70,6 @@ class TorchTrainer(base_trainer.Trainer):
             # for the weights.
             loss.backward()
 
-            trainable_weights = trainable_weights[:]
             gradients = [v.value.grad for v in trainable_weights]
 
             # Update weights

--- a/keras/src/backend/torch/trainer_test.py
+++ b/keras/src/backend/torch/trainer_test.py
@@ -91,7 +91,7 @@ class TorchTrainStepWeightsWalkTest(testing.TestCase):
         """The single cached read matches two independent property reads.
 
         `train_step` now reads `self.trainable_weights` once and reuses
-        it for both the truthiness guard and the `[:]` snapshot passed to
+        it for both the truthiness guard and the snapshot passed to
         the optimizer. This asserts that snapshot is identical (weight
         list contents, not just length) to what a second, independent
         `self.trainable_weights` read would produce immediately

--- a/keras/src/backend/torch/trainer_test.py
+++ b/keras/src/backend/torch/trainer_test.py
@@ -1,0 +1,130 @@
+"""Tests for TorchTrainer.train_step's trainable_weights access pattern.
+
+`train_step` used to read `self.trainable_weights` twice: once for the
+`if self.trainable_weights:` guard and again two lines later for the
+`self.trainable_weights[:]` snapshot passed to the optimizer. Each read is
+a full recursive walk over the layer tree. This module proves the walk now
+happens exactly once per `train_step` call, and that the resulting weight
+values/loss are unchanged.
+"""
+
+from unittest import mock
+
+import numpy as np
+import pytest
+
+import keras
+from keras.src import backend
+from keras.src import layers
+from keras.src import losses
+from keras.src import models
+from keras.src import optimizers
+from keras.src import testing
+
+
+def _make_model():
+    model = models.Sequential(
+        [
+            layers.Dense(4, activation="relu", input_shape=(3,)),
+            layers.Dense(1),
+        ]
+    )
+    model.compile(
+        optimizer=optimizers.SGD(learning_rate=0.01),
+        loss=losses.MeanSquaredError(),
+    )
+    return model
+
+
+@pytest.mark.skipif(
+    backend.backend() != "torch", reason="Requires torch backend"
+)
+class TorchTrainStepWeightsWalkTest(testing.TestCase):
+    def test_gradient_block_reads_trainable_weights_once(self):
+        """The gradient-computation block should read the property once.
+
+        `train_step` also triggers one incidental `trainable_weights` read
+        earlier, via `_compute_loss` -> `self.losses` ->
+        `_get_regularization_losses` (unrelated to this fix, and out of
+        scope for it). Before this fix, the gradient-computation block
+        itself (the `if self.trainable_weights:` guard plus the
+        `self.trainable_weights[:]` snapshot two lines later) read the
+        property twice on top of that, for 3 total reads per
+        `train_step` call. After the fix it reads it once, for 2 total
+        reads. We assert the total, deterministic count directly rather
+        than special-casing call sites, so the test fails loudly if the
+        unrelated `self.losses` read ever changes shape too.
+        """
+        model = _make_model()
+        x = np.random.random((8, 3)).astype("float32")
+        y = np.random.random((8, 1)).astype("float32")
+
+        # Prime the model (build layers, etc.) outside of the measurement
+        # so we only count accesses inside the measured train_step call.
+        model.train_on_batch(x, y)
+
+        real_property = type(model).trainable_weights
+        call_count = 0
+
+        def counting_getter(self):
+            nonlocal call_count
+            call_count += 1
+            return real_property.fget(self)
+
+        with mock.patch.object(
+            type(model),
+            "trainable_weights",
+            property(counting_getter),
+        ):
+            model.train_step((x, y, None))
+
+        self.assertEqual(
+            call_count,
+            2,
+            "Expected exactly two trainable_weights walks per train_step "
+            "call after the dedupe (one incidental read via "
+            "`self.losses`, one from the deduped gradient-computation "
+            f"block), got {call_count}.",
+        )
+
+    def test_train_on_batch_numeric_parity_vs_two_separate_reads(self):
+        """The single cached read matches two independent property reads.
+
+        `train_step` now reads `self.trainable_weights` once and reuses
+        it for both the truthiness guard and the `[:]` snapshot passed to
+        the optimizer. This asserts that snapshot is identical (weight
+        list contents, not just length) to what a second, independent
+        `self.trainable_weights` read would produce immediately
+        afterwards -- i.e. the exact substitution this fix relies on is
+        safe because nothing mutates the layer tree in between.
+        """
+        model = _make_model()
+        x = np.random.random((8, 3)).astype("float32")
+        y = np.random.random((8, 1)).astype("float32")
+        model.train_on_batch(x, y)
+
+        cached_read = model.trainable_weights
+        second_independent_read = model.trainable_weights
+
+        self.assertEqual(len(cached_read), len(second_independent_read))
+        for wa, wb in zip(cached_read, second_independent_read):
+            self.assertIs(wa, wb)
+
+        # And an end-to-end run with the fix in place is fully
+        # reproducible under a fixed seed (sanity check, not a
+        # before/after comparison -- the call-count test above is what
+        # proves the dedupe itself).
+        keras_seed = 1234
+        keras.utils.set_random_seed(keras_seed)
+        model_a = _make_model()
+        history_a = model_a.train_on_batch(x, y, return_dict=True)
+        weights_a = [w.numpy().copy() for w in model_a.trainable_weights]
+
+        keras.utils.set_random_seed(keras_seed)
+        model_b = _make_model()
+        history_b = model_b.train_on_batch(x, y, return_dict=True)
+        weights_b = [w.numpy().copy() for w in model_b.trainable_weights]
+
+        self.assertAllClose(history_a["loss"], history_b["loss"])
+        for wa, wb in zip(weights_a, weights_b):
+            self.assertAllClose(wa, wb)


### PR DESCRIPTION
perf(torch): dedupe double trainable_weights walk in train_step

## Why this was closed

This change showed no measurable macro benefit on either axis. Its isolated
eager effect is within measurement noise on the models tested (RTX 4050,
torch 2.13.0+cu130, CNN forward / LLM forward / LLM generate-32), and it is
compile-neutral: 0 graph-break delta versus master, with a deterministic
dynamo decomposition (see the per-PR compile scorecard). It was backed only
by a deterministic micro-benchmark showing a call-count reduction (3 to 2
`trainable_weights` walks per `train_step`), not by an observed wall-clock
or compile-graph effect.

![torch.compile graph breaks across the #22561 series (this PR does not change the count)](https://raw.githubusercontent.com/pctablet505/keras/5195086b19/22561/compile-graph-breaks-22561-2026-07-19.png)

Relates to #22561. Sits in the same area as #23187's loss/trainer fast
path but touches a disjoint hunk of `train_step`, so it's not folded into
that PR.

## Summary

`TorchTrainer.train_step` read `self.trainable_weights` twice back to
back — once for the `if self.trainable_weights:` guard, once more for
the `[:]` snapshot handed to the optimizer. It's a full recursive
layer-tree walk, not a cached property, so this did the walk twice for
no reason. Now the guard site caches the result in a local and both
sites reuse it.

## Why it's safe

Nothing mutates the layer tree between the two former read sites within
a single `train_step` call, so a cached read is equivalent to two
independent reads (verified with an identity-equal check across
back-to-back reads). Change is scoped to `keras/src/backend/torch/trainer.py`
only — no other backend or file touched — and is line-disjoint from
#23187's hunks in the same file (clean `git merge-tree` against its
branch).

## Benchmarks

![PR #23299: master vs PR alone vs PR+parents, Keras torch GPU eager, ms](https://raw.githubusercontent.com/pctablet505/keras/876c0954e0eb3661584daebf89921903532f3d35/22561/pr23299.png)

Deterministic proof: property-walk count per `train_step` call drops
3 → 2. Estimated ~0.6% of step wall time — smallest-effect candidate of
this round's seven; GPU wall-clock deltas (RTX 4050, torch 2.13.0+cu130,
8-pair interleaved A/B) land in noise for all three workloads (CNN
forward, LLM forward, LLM generate-32), as expected at that magnitude.
Forward outputs and generate-32 token ids are bit-identical to master.

## Tests

Added torch-only tests in `keras/src/backend/torch/trainer_test.py`: a
property-access counting test (asserts exactly 2 reads per step, down
from 3), an identity-equality check across back-to-back reads, and an
end-to-end `train_on_batch` reproducibility check under a fixed seed.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.