### PR TITLE
perf(functional): stop re-deriving static per-call state

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1666,10 +1666,11 @@ class Layer(BackendLayer, Operation):
             )
 
     def _assert_input_compatibility(self, arg_0):
-        if self.input_spec:
+        spec = self.input_spec
+        if spec:
             try:
                 input_spec.assert_input_compatibility(
-                    self.input_spec, arg_0, layer_name=self.name
+                    spec, arg_0, layer_name=self.name
                 )
             except SystemError:
                 if backend.backend() == "torch":

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -185,10 +185,10 @@ class Functional(Function, Model):
             # No call-context args to inject: `operation_fn(op, **{})`'s
             # injection loop is a provable no-op here (every candidate value
             # is `None`), so skip allocating a per-node wrapper closure and
-            # call each operation directly.
-            outputs = self._run_through_graph(
-                inputs, operation_fn=lambda op: op
-            )
+            # rely on `_run_through_graph`'s own `operation_fn=lambda op: op`
+            # default (evaluated once at def time) instead of re-passing an
+            # identical lambda here.
+            outputs = self._run_through_graph(inputs)
         else:
             outputs = self._run_through_graph(
                 inputs,
@@ -411,9 +411,8 @@ class Functional(Function, Model):
         # into a new `TrackedList` object on every assignment, which is
         # both unnecessary bookkeeping and would break identity-stability
         # of the cached value across reads.
-        cached = self.__dict__.get("_cached_input_spec")
-        if cached is not None:
-            return cached
+        if "_cached_input_spec" in self.__dict__:
+            return self.__dict__["_cached_input_spec"]
 
         def shape_with_no_batch_size(x):
             x = list(x)
@@ -457,7 +456,7 @@ class Functional(Function, Model):
     @input_spec.setter
     def input_spec(self, value):
         self._manual_input_spec = value
-        self.__dict__["_cached_input_spec"] = None
+        self.__dict__.pop("_cached_input_spec", None)
 
     def get_config(self):
         if not functional_like_constructor(self.__class__):

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -181,12 +181,21 @@ class Functional(Function, Model):
             for x, mask in zip(inputs, masks):
                 if mask is not None:
                     backend.set_keras_mask(x, mask)
-        outputs = self._run_through_graph(
-            inputs,
-            operation_fn=lambda op: operation_fn(
-                op, training=training, **kwargs
-            ),
-        )
+        if training is None and not kwargs:
+            # No call-context args to inject: `operation_fn(op, **{})`'s
+            # injection loop is a provable no-op here (every candidate value
+            # is `None`), so skip allocating a per-node wrapper closure and
+            # call each operation directly.
+            outputs = self._run_through_graph(
+                inputs, operation_fn=lambda op: op
+            )
+        else:
+            outputs = self._run_through_graph(
+                inputs,
+                operation_fn=lambda op: operation_fn(
+                    op, training=training, **kwargs
+                ),
+            )
         return unpack_singleton(outputs)
 
     def compute_output_spec(self, inputs, training=None, mask=None):
@@ -396,6 +405,16 @@ class Functional(Function, Model):
         if hasattr(self, "_manual_input_spec"):
             return self._manual_input_spec
 
+        # Bypass `Layer.__setattr__`/tracking for this cache: it holds a
+        # plain list of `InputSpec` objects, not sublayers/variables, and
+        # going through `self._tracker.track(...)` would rewrap the list
+        # into a new `TrackedList` object on every assignment, which is
+        # both unnecessary bookkeeping and would break identity-stability
+        # of the cached value across reads.
+        cached = self.__dict__.get("_cached_input_spec")
+        if cached is not None:
+            return cached
+
         def shape_with_no_batch_size(x):
             x = list(x)
             if x:
@@ -421,16 +440,24 @@ class Functional(Function, Model):
             ):
                 # Case where `_nested_inputs` is a plain dict of Inputs.
                 names = sorted(self._inputs_struct.keys())
-                return [
+                spec = [
                     make_spec_for_tensor(self._inputs_struct[name], name=name)
                     for name in names
                 ]
-            return None  # Deeply nested dict: skip checks.
-        return [make_spec_for_tensor(x) for x in self.inputs]
+            else:
+                spec = None  # Deeply nested dict: skip checks.
+        else:
+            spec = [make_spec_for_tensor(x) for x in self.inputs]
+        # `_inputs_struct` (and therefore the derived spec) is fixed once
+        # the Functional graph is built, so it is safe to cache. The setter
+        # below invalidates the cache if a manual spec is later assigned.
+        self.__dict__["_cached_input_spec"] = spec
+        return spec
 
     @input_spec.setter
     def input_spec(self, value):
         self._manual_input_spec = value
+        self.__dict__["_cached_input_spec"] = None
 
     def get_config(self):
         if not functional_like_constructor(self.__class__):

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -18,6 +18,7 @@ from keras.src.layers.input_spec import InputSpec
 from keras.src.models import Functional
 from keras.src.models import Model
 from keras.src.models import Sequential
+from keras.src.models import functional as functional_module
 from keras.src.models.model import model_from_json
 
 
@@ -495,6 +496,81 @@ class FunctionalTest(testing.TestCase):
             model(np.zeros((2, 3, 3)))
         model(np.zeros((2, 4, 3)))
 
+    def test_input_spec_is_cached(self):
+        # Single input.
+        inputs = Input(shape=(4,))
+        outputs = layers.Dense(2)(inputs)
+        model = Functional(inputs, outputs)
+
+        spec_1 = model.input_spec
+        spec_2 = model.input_spec
+        self.assertIs(spec_1, spec_2)
+
+        # Multi-input (list) case.
+        input_a = Input(shape=(4,), name="a")
+        input_b = Input(shape=(4,), name="b")
+        x = input_a + input_b
+        outputs = layers.Dense(2)(x)
+        model = Functional([input_a, input_b], outputs)
+        spec_1 = model.input_spec
+        spec_2 = model.input_spec
+        self.assertIs(spec_1, spec_2)
+
+        # Dict-input case (exercises the sorted-names branch).
+        model = Functional({"a": input_a, "b": input_b}, outputs)
+        spec_1 = model.input_spec
+        spec_2 = model.input_spec
+        self.assertIs(spec_1, spec_2)
+        self.assertEqual([s.name for s in spec_1], ["a", "b"])
+
+    def test_input_spec_cache_invalidated_by_manual_setter(self):
+        inputs = Input(shape=(None, 3))
+        outputs = layers.Dense(2)(inputs)
+        model = Functional(inputs, outputs)
+
+        # Populate the cache with the auto-derived spec first.
+        auto_spec = model.input_spec
+        self.assertIsNot(auto_spec, None)
+
+        # Manually overriding must take effect immediately, not return the
+        # stale cached auto-derived spec.
+        manual_spec = InputSpec(shape=(None, 4, 3))
+        model.input_spec = manual_spec
+        self.assertIs(model.input_spec, manual_spec)
+        with self.assertRaisesRegex(
+            ValueError,
+            r"expected shape=\(None, 4, 3\), found shape=\(2, 3, 3\)",
+        ):
+            model(np.zeros((2, 3, 3)))
+        model(np.zeros((2, 4, 3)))
+
+    def test_input_spec_matches_uncached_computation(self):
+        # Parity check: the cached property value must be identical (by
+        # value, since InputSpec objects aren't `__eq__`-comparable in a
+        # useful way here) to what the uncached code path would compute,
+        # for every branch of the property (single/list/dict/nested-dict).
+        def spec_shapes_and_names(spec):
+            if spec is None:
+                return None
+            return [(s.shape, s.name, s.optional) for s in spec]
+
+        # Single input.
+        inputs = Input(shape=(4,))
+        outputs = layers.Dense(2)(inputs)
+        model = Functional(inputs, outputs)
+        cached = spec_shapes_and_names(model.input_spec)
+        del model._cached_input_spec
+        recomputed = spec_shapes_and_names(model.input_spec)
+        self.assertEqual(cached, recomputed)
+
+        # Deeply nested dict input: `input_spec` should be None both times.
+        inputs = Input(shape=(4,), name="x")
+        outputs = layers.Dense(2)(inputs)
+        model = Functional({"nested": {"x": inputs}}, outputs)
+        self.assertIsNone(model.input_spec)
+        del model._cached_input_spec
+        self.assertIsNone(model.input_spec)
+
     def test_functional_slicing(self):
         inputs = Input(shape=(None, 2), name="input")
         x1 = layers.Dense(3, name="dense1")(inputs)
@@ -959,3 +1035,106 @@ class FunctionalTest(testing.TestCase):
         }
         with self.assertRaisesRegex(ValueError, "Missing node: node_b"):
             Functional.from_config(config)
+
+    def test_call_without_training_or_kwargs_skips_operation_fn_wrapper(self):
+        """When `training is None` and there are no extra kwargs, `call()`
+        must pass operations straight through to `_run_through_graph`
+        (identity `operation_fn`) instead of building a per-node closure via
+        `functional.operation_fn`."""
+        inputs = Input(shape=(4,))
+        outputs = layers.Dense(2)(inputs)
+        model = Functional(inputs, outputs)
+        x = np.random.random((2, 4)).astype("float32")
+
+        seen_ops = []
+        real_run_through_graph = model._run_through_graph
+
+        def spying_run_through_graph(inputs, operation_fn=lambda op: op, **kw):
+            # Record whether the identity function was passed unchanged.
+            seen_ops.append(operation_fn)
+            return real_run_through_graph(
+                inputs, operation_fn=operation_fn, **kw
+            )
+
+        model._run_through_graph = spying_run_through_graph
+        try:
+            model(x)  # training=None, no kwargs.
+        finally:
+            model._run_through_graph = real_run_through_graph
+
+        self.assertEqual(len(seen_ops), 1)
+        # The fast path passes the literal `lambda op: op` (identity),
+        # not a call into `functional.operation_fn`.
+        dense_layer = model.layers[-1]
+        self.assertIs(seen_ops[0](dense_layer), dense_layer)
+
+    def test_call_with_training_still_uses_operation_fn_wrapper(self):
+        """The `training=...`/kwargs path must keep injecting call-context
+        args via `functional.operation_fn`, unchanged from before: the
+        wrapper (not the bare op) must be what reaches `_run_through_graph`,
+        and the injected value must actually change layer behavior."""
+        inputs = Input(shape=(4,))
+        outputs = layers.Dense(2)(inputs)
+        model = Functional(inputs, outputs)
+        x = np.random.random((2, 4)).astype("float32")
+
+        seen_ops = []
+        real_run_through_graph = model._run_through_graph
+
+        def spying_run_through_graph(inputs, operation_fn=lambda op: op, **kw):
+            seen_ops.append(operation_fn)
+            return real_run_through_graph(
+                inputs, operation_fn=operation_fn, **kw
+            )
+
+        model._run_through_graph = spying_run_through_graph
+        try:
+            model(x, training=True)
+        finally:
+            model._run_through_graph = real_run_through_graph
+
+        self.assertEqual(len(seen_ops), 1)
+        # Unlike the fast path, this must NOT be the bare identity function:
+        # it has to be a `functional.operation_fn`-produced wrapper closure.
+        dense_layer = model.layers[-1]
+        self.assertIsNot(seen_ops[0](dense_layer), dense_layer)
+
+        # Numeric parity: explicit training=False must differ from
+        # training=True for a layer with a registered `training`
+        # call-context arg (BatchNormalization), proving the `training`
+        # kwarg is genuinely propagated through the wrapper path rather
+        # than silently dropped.
+        bn_inputs = Input(shape=(4,))
+        bn_outputs = layers.BatchNormalization()(bn_inputs)
+        bn_model = Functional(bn_inputs, bn_outputs)
+        bn_model(x, training=True)  # Warm up moving stats.
+        y_train = ops.convert_to_numpy(bn_model(x, training=True))
+        y_infer = ops.convert_to_numpy(bn_model(x, training=False))
+        self.assertNotAllClose(y_train, y_infer)
+
+        # And training=False (explicit wrapper path) matches training=None
+        # (fast identity path) at inference, since BN's own default is
+        # equivalent to `training=False`.
+        y_default = ops.convert_to_numpy(bn_model(x))
+        self.assertAllClose(y_infer, y_default)
+
+    def test_functional_call_fast_and_slow_paths_numerically_match(self):
+        """The identity-operation_fn fast path (training=None, no kwargs)
+        must produce bit-for-bit-equivalent output to explicitly routing
+        through the `functional.operation_fn` wrapper with all-None args."""
+        inputs = Input(shape=(4,))
+        outputs = layers.Dense(3)(layers.Dense(5)(inputs))
+        model = Functional(inputs, outputs)
+        x = np.random.random((2, 4)).astype("float32")
+
+        fast_path_result = ops.convert_to_numpy(model(x))
+
+        standardized = model._standardize_inputs(x)
+        wrapped_outputs = model._run_through_graph(
+            standardized,
+            operation_fn=lambda op: functional_module.operation_fn(
+                op, training=None
+            ),
+        )
+        wrapped_result = ops.convert_to_numpy(wrapped_outputs)
+        self.assertAllClose(fast_path_result, wrapped_result)

--- a/keras/src/ops/function.py
+++ b/keras/src/ops/function.py
@@ -82,6 +82,11 @@ class Function(Operation):
         self._nodes_by_depth = nodes_by_depth
         self._operations = operations
         self._operations_by_depth = operations_by_depth
+        # `nodes_by_depth` is fixed once the graph is built (immutable
+        # post-construction), so its sorted key order can be precomputed
+        # once here instead of being resorted on every `_run_through_graph`
+        # call.
+        self._depth_keys_sorted = sorted(nodes_by_depth.keys(), reverse=True)
 
         # Run through graph to check all outputs are connected to the inputs.
         def empty_op_outputs(op, *args, **kwargs):
@@ -186,8 +191,11 @@ class Function(Operation):
             tensor_dict[id(x)] = y
 
         nodes_by_depth = self._nodes_by_depth
-        depth_keys = list(nodes_by_depth.keys())
-        depth_keys.sort(reverse=True)
+        depth_keys = getattr(self, "_depth_keys_sorted", None)
+        if depth_keys is None:
+            # Fallback for instances that bypassed `Function.__init__`
+            # (e.g. old pickles/deserialized objects predating this cache).
+            depth_keys = sorted(nodes_by_depth.keys(), reverse=True)
 
         for depth in depth_keys:
             nodes = nodes_by_depth[depth]

--- a/keras/src/ops/function_test.py
+++ b/keras/src/ops/function_test.py
@@ -198,3 +198,38 @@ class FunctionTest(testing.TestCase):
 
         result = fn(np.ones((2, 3)) * 3)
         self.assertAllClose(result, np.ones((2, 3)) * 9)  # 3^2 = 9
+
+    def test_depth_keys_precomputed_at_init(self):
+        """`_depth_keys_sorted` is built once in `__init__`, not per-call."""
+        x1 = keras_tensor.KerasTensor((2, 3))
+        x2 = keras_tensor.KerasTensor((2, 3))
+        y = knp.add(x1, x2) * 3
+        fn = function.Function(inputs=[x1, x2], outputs=y)
+
+        self.assertTrue(hasattr(fn, "_depth_keys_sorted"))
+        expected = sorted(fn._nodes_by_depth.keys(), reverse=True)
+        self.assertEqual(fn._depth_keys_sorted, expected)
+
+        # Calling the function must not mutate/rebuild the cached list
+        # (compare identity, not just equality, to prove no reallocation).
+        cached_before = fn._depth_keys_sorted
+        fn([np.ones((2, 3)), np.ones((2, 3))])
+        self.assertIs(fn._depth_keys_sorted, cached_before)
+
+    def test_run_through_graph_uses_precomputed_depth_keys(self):
+        """`_run_through_graph` must fall back gracefully if the precomputed
+        attribute is absent (e.g. objects predating this cache), and must
+        produce identical results whether or not the cache is present."""
+        x1 = keras_tensor.KerasTensor((2, 3))
+        x2 = keras_tensor.KerasTensor((2, 3))
+        y = knp.add(x1, x2) * 3
+        fn = function.Function(inputs=[x1, x2], outputs=y)
+
+        inputs = [np.ones((2, 3)), np.ones((2, 3)) * 2]
+        result_with_cache = fn(inputs)
+
+        # Simulate a legacy instance without the precomputed attribute.
+        del fn._depth_keys_sorted
+        result_without_cache = fn(inputs)
+
+        self.assertAllClose(result_with_cache, result_without_cache)


### PR DESCRIPTION
Closes #23291

## Why this was closed

This change showed no measurable macro benefit on either axis. Its isolated eager effect is within measurement noise on the models tested (all NOISE in the canonical 8-pair paired runs), and it is compile-neutral: 0 graph-break delta, deterministic dynamo decomposition (see the per-PR compile scorecard). It was backed only by a deterministic micro-benchmark (call-count reduction), not a measured end-to-end win, so it does not clear the bar on its own.

![torch.compile graph breaks across the #22561 series (this PR does not change the count)](https://raw.githubusercontent.com/pctablet505/keras/5195086b19/22561/compile-graph-breaks-22561-2026-07-19.png)

Three pieces of construction-time-fixed state in the `Functional`/`Function` forward path were recomputed on every call: `Functional.input_spec` rebuilt its `InputSpec` list on each property read (and it's read twice per call), `_run_through_graph` re-sorted the static `_nodes_by_depth` keys, and `Functional.call` allocated a fresh per-node `operation_fn` closure even when it had nothing to inject. Each is now computed once at build time and read at call time.

## Why it's safe

- Everything cached is keyed off state that is fixed once the graph is built (`_inputs_struct`, `_nodes_by_depth`). The one mutation path — the manual `input_spec` setter — explicitly invalidates the cache, so a user-supplied spec always wins.
- The `input_spec` cache is written directly to `self.__dict__`, deliberately bypassing `Layer.__setattr__`: routing it through attribute tracking would rewrap the list in a `TrackedList` on every write and break identity stability of the cached object.
- The precomputed depth-key order is read via `getattr` with a re-sort fallback, so instances that never ran `Function.__init__` (old pickles, deserialization edge cases) stay correct — just uncached.
- The closure skip is gated on exactly `training is None and not kwargs`, the only call shape under which the skipped wrapper is provably a no-op (bare `model(x)` inference). Anything with `training` bound or extra kwargs — including `fit()` — takes the unchanged wrapper path.
- Bit-exact vs master: forward max|Δ| = 0.0 on CNN and LLM, `generate(32)` token ids identical.

## Benchmark (GPU, master vs this PR alone)

![PR #23302: master vs this PR alone, Keras torch GPU eager, ms](https://raw.githubusercontent.com/pctablet505/keras/876c0954e0eb3661584daebf89921903532f3d35/22561/pr23302.png)

| workload | master | this PR alone |
|---|--:|--:|
| CNN forward | 1.239 ms | 1.230 ms (~noise) |
| LLM forward | 3.520 ms | 3.498 ms (~noise) |
| LLM generate-32 | 113.310 ms | 112.753 ms (~noise) |

8 interleaved A/B process pairs, paired-ratio verdict against an A/A null calibration; torch 2.13.0+cu130, RTX 4050 Laptop GPU, master `a2f8eac8b2`. All three land in noise at the whole-model level — expected, since each removed cost is a tiny fraction of one forward pass. The evidence for this PR is the deterministic elimination of per-call work plus demonstrated no-regression, not a macro win. Note the closure skip only benefits the `model(x)` call shape; the other two items apply to every call.

## Tests

New unit tests in `functional_test.py` and `function_test.py` cover cache correctness and invalidation, closure-skip vs wrapper call shapes, precomputed depth-key use, and fast/slow-path numerical parity. Full `models/`, `ops/function_test.py`, and `layers/layer_test.py` pass on torch; cross-backend sanity runs pass on tensorflow and jax.

Part of the #22561 series.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.