### PR TITLE
Reject decompression-bomb config/metadata in KerasFileEditor

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -82,10 +82,12 @@ class KerasFileEditor:
                 archive=zf,
                 mode="r",
             )
-            with zf.open(saving_lib._CONFIG_FILENAME, "r") as f:
-                config_json = f.read()
-            with zf.open(saving_lib._METADATA_FILENAME, "r") as f:
-                metadata_json = f.read()
+            config_json = saving_lib._safe_zip_read(
+                zf, saving_lib._CONFIG_FILENAME
+            )
+            metadata_json = saving_lib._safe_zip_read(
+                zf, saving_lib._METADATA_FILENAME
+            )
             self.config = json.loads(config_json)
             self.metadata = json.loads(metadata_json)
 

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -77,6 +77,9 @@ class KerasFileEditor:
 
         if filepath.endswith(".keras"):
             zf = zipfile.ZipFile(filepath, "r")
+            # Reject a decompression-bomb weights member up front, mirroring
+            # `saving_lib._load_model_from_fileobj`.
+            saving_lib._reject_zip_bomb(zf, f"{saving_lib._VARS_FNAME}.h5")
             weights_store = H5IOStore(
                 f"{saving_lib._VARS_FNAME}.h5",
                 archive=zf,

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -1,4 +1,6 @@
 import os
+import zipfile
+from unittest import mock
 
 import h5py
 import numpy as np
@@ -6,6 +8,7 @@ import pytest
 
 import keras
 from keras.src import testing
+from keras.src.saving import saving_lib
 from keras.src.saving.file_editor import KerasFileEditor
 
 
@@ -161,3 +164,33 @@ class SavingTest(testing.TestCase):
 
         with self.assertRaisesRegex(ValueError, "virtual"):
             KerasFileEditor(virtual_fpath)
+
+    def test_rejects_decompression_bomb_config(self):
+        # A `.keras` whose config.json decompresses to far more than it stores
+        # is a decompression bomb: opening the file reads that member fully
+        # into memory. Keep the weights/metadata members valid so only the
+        # config read is exercised.
+        model = keras.Sequential(
+            [keras.Input(shape=(3,)), keras.layers.Dense(5)]
+        )
+        good_fpath = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(good_fpath)
+        with zipfile.ZipFile(good_fpath) as zf:
+            metadata = zf.read("metadata.json")
+            weights = zf.read("model.weights.h5")
+
+        bomb_fpath = os.path.join(self.get_temp_dir(), "bomb.keras")
+        with zipfile.ZipFile(
+            bomb_fpath, "w", compression=zipfile.ZIP_DEFLATED
+        ) as zf:
+            zf.writestr("metadata.json", metadata)
+            zf.writestr("config.json", b'{"x":"' + b" " * 200_000 + b'"}')
+            info = zipfile.ZipInfo("model.weights.h5")
+            zf.writestr(info, weights)
+
+        with (
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_BOMB_FLOOR_BYTES", 64),
+            mock.patch.object(saving_lib, "_ZIP_MEMBER_MAX_EXPANSION", 10),
+        ):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                KerasFileEditor(bomb_fpath)


### PR DESCRIPTION
## Description

KerasFileEditor opens a `.keras` file so you can inspect or edit its contents, and in the constructor it reads the `config.json` and `metadata.json` members straight out of the zip with `zf.open(name).read()`. That pulls the whole decompressed member into memory, and the declared size comes from the archive with no bound. The main model loader reads those same two members through `saving_lib._safe_zip_read`, which refuses a member that declares far more than it stores on disk, so a crafted `.keras` of a few hundred KB can still declare a multi-gigabyte `config.json`. Opening such a file in the editor allocates that whole size, while `load_model` on the identical file rejects it. I noticed the gap while checking that the editor's other malicious-file guards (it already rejects h5 external/soft links and virtual datasets) lined up with the loader's. Routing both reads through `_safe_zip_read` applies the same decompression-bomb check the loader already uses, and I kept the change inside the constructor plus a regression test next to the existing ones.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ ] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.

