### PR TITLE
[OpenVINO] Fix Equalization dynamic shape causing AugMix test failure

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -13,4 +13,3 @@ MathOpsCorrectnessTest::test_erfinv_operation_basic
 MathOpsCorrectnessTest::test_erfinv_operation_dtype
 NNOpsCorrectnessTest::test_ctc_decode
 NNOpsDtypeTest::test_ctc_decode
-aug_mix_test.py::AugMixTest::test_random_augment_randomness

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1088,16 +1088,22 @@ def bincount(x, weights=None, minlength=0, sparse=False):
     rank_x = ov_opset.reshape(rank_x, scalar_shape, False).output(0)
     const_minus_one = ov_opset.constant(-1, x_type).output(0)
     rank_minus_one = ov_opset.add(rank_x, const_minus_one).output(0)
-    minlength = get_ov_output(minlength)
-    minlength = ov_opset.convert(minlength, x_type).output(0)
     const_one = ov_opset.constant(1, x_type).output(0)
     const_zero = ov_opset.constant(0, x_type).output(0)
-    max_element = ov_opset.reduce_max(x, const_zero, keep_dims=False).output(0)
-    depth = ov_opset.add(max_element, const_one).output(0)
-    depth = ov_opset.maximum(depth, minlength).output(0)
-    depth_scalar = ov_opset.reduce_max(
-        depth, const_zero, keep_dims=False
-    ).output(0)
+    # Use a constant depth when possible to give one_hot a static output shape.
+    if isinstance(minlength, int) and minlength > 0:
+        depth_scalar = ov_opset.constant(minlength, Type.i64).output(0)
+    else:
+        minlength = get_ov_output(minlength)
+        minlength = ov_opset.convert(minlength, x_type).output(0)
+        max_element = ov_opset.reduce_max(
+            x, const_zero, keep_dims=False
+        ).output(0)
+        depth = ov_opset.add(max_element, const_one).output(0)
+        depth = ov_opset.maximum(depth, minlength).output(0)
+        depth_scalar = ov_opset.reduce_max(
+            depth, const_zero, keep_dims=False
+        ).output(0)
     one_hot = ov_opset.one_hot(
         x, depth_scalar, const_one, const_zero, axis=-1
     ).output(0)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1090,20 +1090,14 @@ def bincount(x, weights=None, minlength=0, sparse=False):
     rank_minus_one = ov_opset.add(rank_x, const_minus_one).output(0)
     const_one = ov_opset.constant(1, x_type).output(0)
     const_zero = ov_opset.constant(0, x_type).output(0)
-    # Use a constant depth when possible to give one_hot a static output shape.
-    if isinstance(minlength, int) and minlength > 0:
-        depth_scalar = ov_opset.constant(minlength, Type.i64).output(0)
-    else:
-        minlength = get_ov_output(minlength)
-        minlength = ov_opset.convert(minlength, x_type).output(0)
-        max_element = ov_opset.reduce_max(
-            x, const_zero, keep_dims=False
-        ).output(0)
-        depth = ov_opset.add(max_element, const_one).output(0)
-        depth = ov_opset.maximum(depth, minlength).output(0)
-        depth_scalar = ov_opset.reduce_max(
-            depth, const_zero, keep_dims=False
-        ).output(0)
+    minlength = get_ov_output(minlength)
+    minlength = ov_opset.convert(minlength, x_type).output(0)
+    max_element = ov_opset.reduce_max(x, const_zero, keep_dims=False).output(0)
+    depth = ov_opset.add(max_element, const_one).output(0)
+    depth = ov_opset.maximum(depth, minlength).output(0)
+    depth_scalar = ov_opset.reduce_max(
+        depth, const_zero, keep_dims=False
+    ).output(0)
     one_hot = ov_opset.one_hot(
         x, depth_scalar, const_one, const_zero, axis=-1
     ).output(0)

--- a/keras/src/layers/preprocessing/image_preprocessing/equalization.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/equalization.py
@@ -95,8 +95,11 @@ class Equalization(BaseImagePreprocessingLayer):
         indices = self.backend.numpy.clip(indices, 0, nbins - 1)
         flat_indices = self.backend.numpy.reshape(indices, [-1])
 
-        if backend.backend() == "jax":
-            # for JAX bincount is never jittable because of output shape
+        if backend.backend() in ("jax", "openvino"):
+            # JAX: bincount output shape is never statically known (not
+            # jittable). OpenVINO: dynamic depth in one_hot causes shape
+            # propagation failures when equalization is applied repeatedly.
+            # Both backends use an explicit loop to keep the output shape fixed.
             histogram = self.backend.numpy.zeros(nbins, dtype="int32")
             for i in range(nbins):
                 matches = self.backend.cast(


### PR DESCRIPTION
## Description
Equalization._custom_histogram_fixed_width called bincount with a depth derived from max_element + 1 at runtime, giving the histogram a dynamic shape. When chained repeatedly inside AugMix, these dynamic shapes accumulate and cause OpenVINO's CPU plugin to fail with "memory desc is undefined" at compile time.

Fixed it by extend the existing JAX loop-based histogram path to also cover OpenVINO, keeping the output shape statically known as [nbins]. This leaves ops.bincount semantically correct.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
