### PR TITLE
[Performance] Optimize multi-step output concatenation using single-pass tree.map_structure

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -212,14 +212,14 @@ class JAXTrainer(base_trainer.Trainer):
             if concatenate_outputs:
 
                 def concatenate(outputs):
-                    output = outputs[0]
-                    for next_output in outputs[1:]:
-                        output = tree.map_structure(
-                            lambda t1, t2: jax.numpy.concatenate([t1, t2]),
-                            output,
-                            next_output,
-                        )
-                    return output
+                    if not outputs:
+                        return []
+                    if len(outputs) == 1:
+                        return outputs[0]
+                    return tree.map_structure(
+                        lambda *args: jax.numpy.concatenate(args, axis=0),
+                        *outputs,
+                    )
 
                 if not self.run_eagerly and self.jit_compile:
                     concatenate = jit(concatenate)

--- a/keras/src/backend/numpy/trainer.py
+++ b/keras/src/backend/numpy/trainer.py
@@ -74,16 +74,12 @@ class NumpyTrainer(base_trainer.Trainer):
             return self.predict_step(data)
 
         def multi_predict_steps(data):
-            outputs = one_predict_step(data[:1])
-
-            for single_step_data in data[1:]:
-                step_outputs = one_predict_step([single_step_data])
-                outputs = tree.map_structure(
-                    lambda t1, t2: np.concatenate([t1, t2]),
-                    outputs,
-                    step_outputs,
-                )
-            return outputs
+            if len(data) == 1:
+                return one_predict_step(data[:1])
+            all_outputs = [one_predict_step([d]) for d in data]
+            return tree.map_structure(
+                lambda *args: np.concatenate(args, axis=0), *all_outputs
+            )
 
         if self.steps_per_execution > 1:
             predict_step = multi_predict_steps

--- a/keras/src/backend/openvino/trainer.py
+++ b/keras/src/backend/openvino/trainer.py
@@ -194,16 +194,12 @@ class OpenVINOTrainer(base_trainer.Trainer):
             return self.predict_step(data)
 
         def multi_predict_steps(data):
-            outputs = one_predict_step(data[:1])
-
-            for single_step_data in data[1:]:
-                step_outputs = one_predict_step([single_step_data])
-                outputs = tree.map_structure(
-                    lambda t1, t2: np.concatenate([t1, t2]),
-                    outputs,
-                    step_outputs,
-                )
-            return outputs
+            if len(data) == 1:
+                return one_predict_step(data[:1])
+            all_outputs = [one_predict_step([d]) for d in data]
+            return tree.map_structure(
+                lambda *args: np.concatenate(args, axis=0), *all_outputs
+            )
 
         if self.steps_per_execution > 1:
             predict_step = multi_predict_steps

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -291,13 +291,12 @@ class TensorFlowTrainer(base_trainer.Trainer):
 
         @tf.autograph.experimental.do_not_convert
         def multi_step_on_data(data):
-            outputs = one_step_on_data_distributed(data[:1])
-            for single_step_data in data[1:]:
-                step_outputs = one_step_on_data_distributed([single_step_data])
-                outputs = tree.map_structure(
-                    lambda t1, t2: concat([t1, t2]), outputs, step_outputs
-                )
-            return outputs
+            if len(data) == 1:
+                return one_step_on_data_distributed(data[:1])
+            all_outputs = [one_step_on_data_distributed([d]) for d in data]
+            return tree.map_structure(
+                lambda *args: concat(list(args), axis=0), *all_outputs
+            )
 
         if self.steps_per_execution > 1:
             predict_function = multi_step_on_data


### PR DESCRIPTION
This PR optimizes performance when steps_per_execution > 1 by improving how prediction outputs are accumulated and concatenated across backends.

## Problem
Previously, step outputs were concatenated iteratively inside a loop (output = tree.map_structure(lambda t1, t2: concat([t1, t2]), output, next_output)). For $N$ steps, accumulating array outputs led to $O(N^2 \cdot M)$ memory copying complexity and generated $N-1$ temporary array allocations per leaf tensor.

## Solution
Replaced the iterative loop with a single-pass batch map (tree.map_structure(lambda *args: concat(args, axis=0), *all_outputs)).

## Benchmarking
Current implementation: https://colab.research.google.com/drive/11Z_97irfepxHzZ6GKl4g1SNssvc-2fT3?resourcekey=0-eUd79QJDxdJreOHJV9x0jw&usp=sharing

After the fix: https://colab.research.google.com/drive/1XLfCukfLcvY-8bFMBMc5hnKbUi9T0FtD?resourcekey=0-Wi18tWg1GsLrJWT9FuJE-A&usp=sharing

### Benchmark Comparison (JAX Backend)

#### **1. Eager Mode (`jit_compile=False`)**
| `steps_per_execution` | Baseline | Updated | Speedup |
| :--- | :--- | :--- | :--- |
| 1 | 5.86s | **4.25s** | 1.38x |
| 10 | 3.64s | **2.62s** | 1.39x |
| 50 | 3.98s | **2.58s** | 1.54x |
| 500 | 17.36s | **2.68s** | **6.49x** |
| 1000 | 23.54s | **2.98s** | **7.90x** |
| 5000 | 136.51s | **2.89s** | **47.23x** |

#### **2. JIT Compiled (`jit_compile=True`)**
| `steps_per_execution` | Baseline | Updated | Speedup |
| :--- | :--- | :--- | :--- |
| 1 | 2.09s | 2.32s | 0.90x |
| 10 | 1.58s | **0.71s** | **2.21x** |
| 50 | 1.50s | **0.68s** | **2.21x** |
| 500 | 3.75s | **1.79s** | **2.10x** |
| 1000 | 5.25s | **3.03s** | **1.74x** |
| 5000 | 31.12s | **23.99s** | **1.30x** |

> **Note on JAX JIT vs. Eager at high step counts ($N=5000$):**  
> At standard `steps_per_execution` values ($N=10\text{--}50$), JIT compiled mode provides optimal performance (**0.68s vs 2.58s** in Eager). At extreme step counts ($N=5000$), JIT runtime includes XLA graph tracing and unrolling overhead for 5,000 steps, whereas Eager mode avoids graph compilation entirely and benefits directly from $O(N)$ single-pass concatenation (**2.89s**).

### **3. TensorFlow Backend**

| `steps_per_execution` | Baseline | Updated | Speedup |
| :--- | :--- | :--- | :--- |
| **1** | 5.64s | **5.23s** | **1.08x** |
| **10** | **1.44s** | 1.85s | 0.78x |
| **50** | 1.52s | **1.36s** | **1.11x** |
| **500** | 5.75s | **4.28s** | **1.34x** |
| **1000** | 11.84s | **8.57s** | **1.38x** |
| **5000** | 82.03s | **22.23s** | **3.69x** |

### **4. NumPy Backend**

| `steps_per_execution` | Baseline | Updated | Speedup |
| :--- | :--- | :--- | :--- |
| **1** | 3.69s | 6.67s | 0.55x |
| **10** | 2.20s | **2.13s** | **1.03x** |
| **50** | 1.97s | **1.66s** | **1.19x** |
| **500** | 2.08s | **1.64s** | **1.27x** |
| **1000** | 2.23s | **1.75s** | **1.28x** |
| **5000** | 3.42s | **1.63s** | **2.10x** |

### **5. OpenVINO Backend**

| `steps_per_execution` | Baseline | Updated | Speedup |
| :--- | :--- | :--- | :--- |
| **1** | 1.43s | 1.44s | 0.99x |
| **10** | 0.72s | 0.76s | 0.95x |
| **50** | 0.60s | **0.54s** | **1.11x** |
| **500** | 0.68s | **0.47s** | **1.45x** |
| **1000** | 0.81s | **0.50s** | **1.62x** |
| **5000** | 2.09s | **0.47s** | **4.45x** |

---

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
