### PR TITLE
Fix Logsumexp symbolic output dtype inference

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -71,6 +71,7 @@ def in_top_k(targets, predictions, k):
 
 
 def logsumexp(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
     return jax.scipy.special.logsumexp(x, axis=axis, keepdims=keepdims)
 
 

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -92,6 +92,7 @@ def in_top_k(targets, predictions, k):
 
 
 def logsumexp(x, axis=None, keepdims=False):
+    x = convert_to_tensor(x)
     dtype = dtypes.result_type(x.dtype, float)
     return scipy.special.logsumexp(x, axis=axis, keepdims=keepdims).astype(
         dtype

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -92,7 +92,10 @@ def in_top_k(targets, predictions, k):
 
 
 def logsumexp(x, axis=None, keepdims=False):
-    return scipy.special.logsumexp(x, axis=axis, keepdims=keepdims)
+    dtype = dtypes.result_type(x.dtype, float)
+    return scipy.special.logsumexp(x, axis=axis, keepdims=keepdims).astype(
+        dtype
+    )
 
 
 def cdist(x, y):

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -326,7 +326,10 @@ class Logsumexp(Operation):
 
     def compute_output_spec(self, x):
         output_shape = reduce_shape(x.shape, self.axis, self.keepdims)
-        return KerasTensor(shape=output_shape)
+        return KerasTensor(
+            shape=output_shape,
+            dtype=backend.standardize_dtype(x.dtype),
+        )
 
     def call(self, x):
         return backend.math.logsumexp(x, axis=self.axis, keepdims=self.keepdims)

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -327,8 +327,7 @@ class Logsumexp(Operation):
     def compute_output_spec(self, x):
         output_shape = reduce_shape(x.shape, self.axis, self.keepdims)
         return KerasTensor(
-            shape=output_shape,
-            dtype=backend.standardize_dtype(x.dtype),
+            shape=output_shape, dtype=result_type(x.dtype, float)
         )
 
     def call(self, x):

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1243,6 +1243,25 @@ class MathDtypeTest(testing.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_logsumexp(self, dtype):
+        import jax.numpy as jnp
+        import jax.scipy.special as jsp
+
+        x = knp.ones((2, 3), dtype=dtype)
+        x_jax = jnp.ones((2, 3), dtype=dtype)
+
+        expected_dtype = standardize_dtype(jsp.logsumexp(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(kmath.logsumexp(x).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(kmath.Logsumexp().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_rsqrt(self, dtype):
         import jax.lax as lax
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1467,6 +1467,13 @@ class LogsumexpTest(testing.TestCase):
         )
         self.assertAllClose(output, expected_output)
 
+    def test_logsumexp_list_input(self):
+        x = [[1.0, 2.0], [3.0, 4.0]]
+        logsumexp_op = kmath.Logsumexp()
+        output = logsumexp_op.call(x)
+        expected_output = np.log(np.sum(np.exp(x)))
+        self.assertAllClose(output, expected_output)
+
 
 class FFTTest(testing.TestCase):
     def test_fft_input_not_tuple_or_list(self):


### PR DESCRIPTION
## Description
Previously, symbolic `keras.ops.logsumexp()` preserved the input dtype, causing a mismatch with backend behavior for low-precision inputs such as `bfloat16`. JAX promotes `logsumexp` computation results to `float32`, but the symbolic output spec returned `bfloat16`.

This change aligns symbolic dtype inference with actual backend output behavior.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
