### PR TITLE
Re-allow dynamic (tensor) size in `ops.image.resize`.

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -360,7 +360,9 @@ def resize(
             "Expected `size` to be a tuple of 2 integers. "
             f"Received: size={size}"
         )
-    if size[0] <= 0 or size[1] <= 0:
+    if (isinstance(size[0], int) and size[0] <= 0) or (
+        isinstance(size[1], int) and size[1] <= 0
+    ):
         raise ValueError(
             f"`size` must have positive height and width. Received: size={size}"
         )


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/keras-team/keras/pull/22079

See https://github.com/keras-team/keras/pull/22079#issuecomment-5048052311

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
