### PR TITLE
Auto-infer output_size for padding="valid" in keras.ops.image.reconstruct_patches

### DIFF
--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -1025,28 +1025,25 @@ class ReconstructPatches(Operation):
         # the grid — `__init__` guarantees `padding="valid"` when
         # `output_size` is None. Unknown grid dims stay None.
         if self.output_size is None:
-            if any(g is None for g in grid):
-                spatial = (None,) * len(self.size)
-            else:
-                spatial = tuple(
-                    (g - 1) * s + k
-                    for g, s, k in zip(grid, self.strides, self.size)
-                )
+            spatial = tuple(
+                (g - 1) * s + k if isinstance(g, int) else None
+                for g, s, k in zip(grid, self.strides, self.size)
+            )
         else:
             spatial = self.output_size
             dim_names = ("depth", "height", "width")[-len(self.size) :]
-            for g, p, o, dim_name in zip(
-                grid, self.size, self.output_size, dim_names
+            for g, p, s, o, dim_name in zip(
+                grid, self.size, self.strides, self.output_size, dim_names
             ):
                 if not isinstance(g, int):
                     continue
                 if self.padding == "valid":
-                    if g * p != o:
+                    if (g - 1) * s + p != o:
                         raise ValueError(
                             f"`padding='valid'` requires output_size to "
-                            f"equal size * grid. Got output_size="
-                            f"{self.output_size}, grid {dim_name}={g}, "
-                            f"size={self.size}."
+                            f"equal (grid - 1) * stride + size. Got "
+                            f"output_size={self.output_size}, grid "
+                            f"{dim_name}={g}, stride={s}, size={p}."
                         )
                 elif not (g * p - p < o <= g * p):
                     raise ValueError(
@@ -1104,8 +1101,9 @@ def reconstruct_patches(
             tuple `(H, W)` for 2D, length 3 tuple `(D, H, W)` for 3D. With
             `padding="valid"` this may be omitted (`None`) and is then
             inferred from the patch grid; if given, it must equal
-            `grid * size` — the region covered by the extracted patches,
-            i.e. the original size cropped down to a multiple of `size`.
+            `(grid - 1) * stride + size` per dim — the region covered by
+            the extracted patches, i.e. the original size cropped down to
+            a multiple of `size` in the non-overlapping case.
             With `padding="same"` it is required: pass the original
             spatial shape so the padding added during extraction can be
             unambiguously removed.
@@ -1238,7 +1236,7 @@ def _infer_output_size_valid(patches, size, strides, data_format):
     else:
         grid_start = 1 if rank == n + 1 else 2
     grid = patches.shape[grid_start : grid_start + n]
-    if any(g is None for g in grid):
+    if any(not isinstance(g, int) for g in grid):
         raise ValueError(
             "Cannot auto-infer `output_size` for `padding='valid'`: at "
             "least one patch-grid dimension is unknown "
@@ -1266,6 +1264,12 @@ def _reconstruct_patches_2d(
         raise ValueError(
             f"Invalid `padding`. Expected 'same' or 'valid'. Got: {padding}"
         )
+    if len(patches.shape) not in (3, 4):
+        raise ValueError(
+            "`patches` has unexpected rank for 2D reconstruction. "
+            "Expected 3 (unbatched) or 4 (batched). "
+            f"Received shape: {patches.shape}"
+        )
     strides = _validate_reconstruct_strides(
         size, strides, "reconstruct_patches"
     )
@@ -1290,14 +1294,8 @@ def _reconstruct_patches_2d(
         # Patches are (flat, gH, gW) unbatched or (B, flat, gH, gW) batched.
         if len(patches.shape) == 3:
             patches = backend.numpy.transpose(patches, axes=(1, 2, 0))
-        elif len(patches.shape) == 4:
-            patches = backend.numpy.transpose(patches, axes=(0, 2, 3, 1))
         else:
-            raise ValueError(
-                "`patches` has unexpected rank for 2D channels_first "
-                "reconstruction. Expected 3 (unbatched) or 4 (batched). "
-                f"Received shape: {patches.shape}"
-            )
+            patches = backend.numpy.transpose(patches, axes=(0, 2, 3, 1))
         result = _reconstruct_patches_2d(
             patches, size, output_size, strides, padding, "channels_last"
         )
@@ -1307,13 +1305,6 @@ def _reconstruct_patches_2d(
 
     pH, pW = size
     H, W = output_size
-
-    if len(patches.shape) not in (3, 4):
-        raise ValueError(
-            "`patches` has unexpected rank for 2D reconstruction. "
-            "Expected 3 (unbatched) or 4 (batched). "
-            f"Received shape: {patches.shape}"
-        )
 
     _unbatched = False
     if len(patches.shape) == 3:
@@ -1364,11 +1355,13 @@ def _reconstruct_patches_2d(
         out_shape = [B, H, W, C]
         x = ops.slice(x, begin, out_shape)
     else:
-        if gH * pH != H or gW * pW != W:
+        sH, sW = strides
+        if (gH - 1) * sH + pH != H or (gW - 1) * sW + pW != W:
             raise ValueError(
                 f"`padding='valid'` requires output_size to equal "
-                f"size * grid. Got output_size=({H},{W}), "
-                f"grid=({gH},{gW}), size=({pH},{pW})."
+                f"(grid - 1) * stride + size. Got output_size=({H},{W}), "
+                f"grid=({gH},{gW}), strides=({sH},{sW}), "
+                f"size=({pH},{pW})."
             )
 
     if _unbatched:
@@ -1387,6 +1380,12 @@ def _reconstruct_patches_3d(
     if padding not in ("same", "valid"):
         raise ValueError(
             f"Invalid `padding`. Expected 'same' or 'valid'. Got: {padding}"
+        )
+    if len(patches.shape) not in (4, 5):
+        raise ValueError(
+            "`patches` has unexpected rank for 3D reconstruction. "
+            "Expected 4 (unbatched) or 5 (batched). "
+            f"Received shape: {patches.shape}"
         )
     strides = _validate_reconstruct_strides(
         size, strides, "reconstruct_patches"
@@ -1412,14 +1411,8 @@ def _reconstruct_patches_3d(
         # Patches are (flat, gD, gH, gW) unbatched or (B, flat, gD, gH, gW).
         if len(patches.shape) == 4:
             patches = backend.numpy.transpose(patches, axes=(1, 2, 3, 0))
-        elif len(patches.shape) == 5:
-            patches = backend.numpy.transpose(patches, axes=(0, 2, 3, 4, 1))
         else:
-            raise ValueError(
-                "`patches` has unexpected rank for 3D channels_first "
-                "reconstruction. Expected 4 (unbatched) or 5 (batched). "
-                f"Received shape: {patches.shape}"
-            )
+            patches = backend.numpy.transpose(patches, axes=(0, 2, 3, 4, 1))
         result = _reconstruct_patches_3d(
             patches, size, output_size, strides, padding, "channels_last"
         )
@@ -1429,13 +1422,6 @@ def _reconstruct_patches_3d(
 
     pD, pH, pW = size
     D, H, W = output_size
-
-    if len(patches.shape) not in (4, 5):
-        raise ValueError(
-            "`patches` has unexpected rank for 3D reconstruction. "
-            "Expected 4 (unbatched) or 5 (batched). "
-            f"Received shape: {patches.shape}"
-        )
 
     _unbatched = False
     if len(patches.shape) == 4:
@@ -1504,11 +1490,17 @@ def _reconstruct_patches_3d(
         out_shape = [B, D, H, W, C]
         x = ops.slice(x, begin, out_shape)
     else:
-        if gD * pD != D or gH * pH != H or gW * pW != W:
+        sD, sH, sW = strides
+        if (
+            (gD - 1) * sD + pD != D
+            or (gH - 1) * sH + pH != H
+            or (gW - 1) * sW + pW != W
+        ):
             raise ValueError(
                 f"`padding='valid'` requires output_size to equal "
-                f"size * grid. Got output_size=({D},{H},{W}), "
-                f"grid=({gD},{gH},{gW}), size=({pD},{pH},{pW})."
+                f"(grid - 1) * stride + size. Got output_size=({D},{H},{W}), "
+                f"grid=({gD},{gH},{gW}), strides=({sD},{sH},{sW}), "
+                f"size=({pD},{pH},{pW})."
             )
 
     if _unbatched:

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -932,7 +932,7 @@ class ReconstructPatches(Operation):
     def __init__(
         self,
         size,
-        output_size,
+        output_size=None,
         strides=None,
         padding="valid",
         data_format=None,
@@ -943,7 +943,9 @@ class ReconstructPatches(Operation):
         if isinstance(size, int):
             size = (size, size)
         self.size = tuple(size)
-        self.output_size = tuple(output_size)
+        self.output_size = (
+            tuple(output_size) if output_size is not None else None
+        )
         self.is_3d = len(self.size) == 3
         if strides is None:
             strides = self.size
@@ -952,6 +954,12 @@ class ReconstructPatches(Operation):
         self.strides = tuple(strides)
         self.padding = padding
         self.data_format = backend.standardize_data_format(data_format)
+        if self.output_size is None and self.padding != "valid":
+            raise ValueError(
+                "`output_size=None` (auto-infer) is only supported for "
+                "`padding='valid'`. For `padding='same'`, the original "
+                "size is ambiguous from patches alone — pass `output_size`."
+            )
 
     def call(self, patches):
         return _reconstruct_patches(
@@ -979,11 +987,9 @@ class ReconstructPatches(Operation):
         if self.is_3d:
             expected_ndim_batched = 5
             expected_ndim_unbatched = 4
-            spatial = self.output_size  # (D, H, W)
         else:
             expected_ndim_batched = 4
             expected_ndim_unbatched = 3
-            spatial = self.output_size  # (H, W)
 
         if original_ndim == expected_ndim_batched:
             batch = patches_shape[0]
@@ -1011,25 +1017,41 @@ class ReconstructPatches(Operation):
             # channels_first: the grid dims are the trailing dims,
             # (B, flat, *grid) batched or (flat, *grid) unbatched.
             grid = patches_shape[-len(self.size) :]
-        dim_names = ("depth", "height", "width")[-len(self.size) :]
-        for g, p, o, dim_name in zip(
-            grid, self.size, self.output_size, dim_names
-        ):
-            if not isinstance(g, int):
-                continue
-            if self.padding == "valid":
-                if g * p != o:
-                    raise ValueError(
-                        f"`padding='valid'` requires output_size to equal "
-                        f"size * grid. Got output_size={self.output_size}, "
-                        f"grid {dim_name}={g}, size={self.size}."
-                    )
-            elif not (g * p - p < o <= g * p):
-                raise ValueError(
-                    f"For `padding='same'`, `output_size` {dim_name} ({o}) "
-                    f"must be in the range ((g-1)*p, g*p], i.e. "
-                    f"({g * p - p}, {g * p}]. Got: grid={g}, patch={p}."
+
+        # Resolve the output spatial shape: use `output_size` if given
+        # (validating it against static grid dims), else auto-infer from
+        # the grid — `__init__` guarantees `padding="valid"` when
+        # `output_size` is None. Unknown grid dims stay None.
+        if self.output_size is None:
+            if any(g is None for g in grid):
+                spatial = (None,) * len(self.size)
+            else:
+                spatial = tuple(
+                    (g - 1) * s + k
+                    for g, s, k in zip(grid, self.strides, self.size)
                 )
+        else:
+            spatial = self.output_size
+            dim_names = ("depth", "height", "width")[-len(self.size) :]
+            for g, p, o, dim_name in zip(
+                grid, self.size, self.output_size, dim_names
+            ):
+                if not isinstance(g, int):
+                    continue
+                if self.padding == "valid":
+                    if g * p != o:
+                        raise ValueError(
+                            f"`padding='valid'` requires output_size to "
+                            f"equal size * grid. Got output_size="
+                            f"{self.output_size}, grid {dim_name}={g}, "
+                            f"size={self.size}."
+                        )
+                elif not (g * p - p < o <= g * p):
+                    raise ValueError(
+                        f"For `padding='same'`, `output_size` {dim_name} "
+                        f"({o}) must be in the range ((g-1)*p, g*p], i.e. "
+                        f"({g * p - p}, {g * p}]. Got: grid={g}, patch={p}."
+                    )
 
         if self.data_format == "channels_last":
             out_shape = list(spatial) + [channels_out]
@@ -1054,7 +1076,7 @@ class ReconstructPatches(Operation):
 def reconstruct_patches(
     patches,
     size,
-    output_size,
+    output_size=None,
     strides=None,
     padding="valid",
     data_format=None,
@@ -1078,11 +1100,13 @@ def reconstruct_patches(
             Length 2 tuple for 2D, length 3 tuple for 3D, or int.
         output_size: Target spatial shape of the reconstruction. Length 2
             tuple `(H, W)` for 2D, length 3 tuple `(D, H, W)` for 3D. With
-            `padding="valid"` this must equal `grid * size` — the region
-            covered by the extracted patches, i.e. the original size
-            cropped down to a multiple of `size`. With `padding="same"`,
-            pass the original spatial shape so the padding added during
-            extraction can be unambiguously removed.
+            `padding="valid"` this may be omitted (`None`) and is then
+            inferred from the patch grid; if given, it must equal
+            `grid * size` — the region covered by the extracted patches,
+            i.e. the original size cropped down to a multiple of `size`.
+            With `padding="same"` it is required: pass the original
+            spatial shape so the padding added during extraction can be
+            unambiguously removed.
         strides: Currently must equal `size` (non-overlapping). Defaults
             to `size`.
         padding: `"same"` or `"valid"`, matching the extraction.
@@ -1129,7 +1153,7 @@ def reconstruct_patches(
                 "Invalid `size` argument. Expected a tuple of length 2 or 3. "
                 f"Received: size={size} with length {len(size)}"
             )
-    if not isinstance(output_size, (tuple, list)):
+    if output_size is not None and not isinstance(output_size, (tuple, list)):
         raise TypeError(
             "Invalid `output_size` argument. Expected a tuple or list. "
             f"Received: output_size={output_size} of type "
@@ -1197,6 +1221,30 @@ def _validate_reconstruct_strides(size, strides, fn_name):
     return tuple(strides)
 
 
+def _infer_output_size_valid(patches, size, strides, data_format):
+    """Infer `output_size` from the patch grid for `padding='valid'`.
+
+    The forward `extract_patches` with `padding='valid'` produces a grid of
+    `g = (input - size) // stride + 1`, so the smallest input that yields
+    grid `g` is `(g - 1) * stride + size`. Requires statically-known grid
+    dims; raises otherwise so the caller can pass `output_size` explicitly.
+    """
+    rank = len(patches.shape)
+    n = len(size)
+    if data_format == "channels_last":
+        grid_start = 0 if rank == n + 1 else 1
+    else:
+        grid_start = 1 if rank == n + 1 else 2
+    grid = patches.shape[grid_start : grid_start + n]
+    if any(g is None for g in grid):
+        raise ValueError(
+            "Cannot auto-infer `output_size` for `padding='valid'`: at "
+            "least one patch-grid dimension is unknown "
+            f"(patches.shape={patches.shape}). Pass `output_size` explicitly."
+        )
+    return tuple((g - 1) * s + k for g, s, k in zip(grid, strides, size))
+
+
 def _reconstruct_patches_2d(
     patches,
     size,
@@ -1212,17 +1260,29 @@ def _reconstruct_patches_2d(
             "Invalid `size`. Expected length 2 for 2D reconstruction. "
             f"Got: size={size}"
         )
+    if padding not in ("same", "valid"):
+        raise ValueError(
+            f"Invalid `padding`. Expected 'same' or 'valid'. Got: {padding}"
+        )
+    strides = _validate_reconstruct_strides(
+        size, strides, "reconstruct_patches"
+    )
+    data_format = backend.standardize_data_format(data_format)
+    if output_size is None:
+        if padding != "valid":
+            raise ValueError(
+                "`output_size=None` (auto-infer) is only supported for "
+                "`padding='valid'`. For `padding='same'`, the original "
+                "size is ambiguous from patches alone — pass `output_size`."
+            )
+        output_size = _infer_output_size_valid(
+            patches, size, strides, data_format
+        )
     if len(output_size) != 2:
         raise ValueError(
             "Invalid `output_size`. Expected length 2 (H, W). "
             f"Got: output_size={output_size}"
         )
-    if padding not in ("same", "valid"):
-        raise ValueError(
-            f"Invalid `padding`. Expected 'same' or 'valid'. Got: {padding}"
-        )
-    _validate_reconstruct_strides(size, strides, "reconstruct_patches")
-    data_format = backend.standardize_data_format(data_format)
     if data_format == "channels_first":
         # Reconstruct in channels_last layout, then move channels back.
         # Patches are (flat, gH, gW) unbatched or (B, flat, gH, gW) batched.
@@ -1322,17 +1382,29 @@ def _reconstruct_patches_3d(
     padding="valid",
     data_format=None,
 ):
+    if padding not in ("same", "valid"):
+        raise ValueError(
+            f"Invalid `padding`. Expected 'same' or 'valid'. Got: {padding}"
+        )
+    strides = _validate_reconstruct_strides(
+        size, strides, "reconstruct_patches"
+    )
+    data_format = backend.standardize_data_format(data_format)
+    if output_size is None:
+        if padding != "valid":
+            raise ValueError(
+                "`output_size=None` (auto-infer) is only supported for "
+                "`padding='valid'`. For `padding='same'`, the original "
+                "size is ambiguous from patches alone — pass `output_size`."
+            )
+        output_size = _infer_output_size_valid(
+            patches, size, strides, data_format
+        )
     if len(output_size) != 3:
         raise ValueError(
             "Invalid `output_size`. Expected length 3 (D, H, W). "
             f"Got: output_size={output_size}"
         )
-    if padding not in ("same", "valid"):
-        raise ValueError(
-            f"Invalid `padding`. Expected 'same' or 'valid'. Got: {padding}"
-        )
-    _validate_reconstruct_strides(size, strides, "reconstruct_patches")
-    data_format = backend.standardize_data_format(data_format)
     if data_format == "channels_first":
         # Reconstruct in channels_last layout, then move channels back.
         # Patches are (flat, gD, gH, gW) unbatched or (B, flat, gD, gH, gW).

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -772,6 +772,49 @@ class ImageOpsStaticShapeTest(testing.TestCase):
                 data_format="channels_first",
             )
 
+    def test_reconstruct_patches_autoinfer_valid(self):
+        # output_size omitted -> inferred from the (static) patch grid.
+        patches = KerasTensor([2, 4, 4, 75])
+        out = kimage.reconstruct_patches(patches, size=(5, 5), padding="valid")
+        self.assertEqual(out.shape, (2, 20, 20, 3))
+        patches_3d = KerasTensor([2, 4, 4, 4, 375])
+        out = kimage.reconstruct_patches(
+            patches_3d, size=(5, 5, 5), padding="valid"
+        )
+        self.assertEqual(out.shape, (2, 20, 20, 20, 3))
+        # channels_first: grid dims are the trailing axes.
+        patches_cf = KerasTensor([2, 75, 4, 4])
+        out = kimage.reconstruct_patches(
+            patches_cf,
+            size=(5, 5),
+            padding="valid",
+            data_format="channels_first",
+        )
+        self.assertEqual(out.shape, (2, 3, 20, 20))
+
+    def test_reconstruct_patches_autoinfer_dynamic_grid_symbolic(self):
+        # Dynamic grid + auto-infer -> spatial dims stay unknown (no raise).
+        patches = KerasTensor([2, None, None, 75])
+        out = kimage.reconstruct_patches(patches, size=(5, 5), padding="valid")
+        self.assertEqual(out.shape, (2, None, None, 3))
+
+    def test_reconstruct_patches_autoinfer_same_raises(self):
+        # Auto-infer is valid-only; same requires explicit output_size.
+        patches = np.zeros((2, 4, 4, 75), dtype="float32")
+        with self.assertRaisesRegex(ValueError, "only supported for"):
+            kimage.reconstruct_patches(patches, size=(5, 5), padding="same")
+        patches_3d = np.zeros((2, 4, 4, 4, 375), dtype="float32")
+        with self.assertRaisesRegex(ValueError, "only supported for"):
+            kimage.reconstruct_patches(
+                patches_3d, size=(5, 5, 5), padding="same"
+            )
+        # The symbolic path raises at graph-construction time too, so a
+        # functional model can't be built that only fails on first call.
+        with self.assertRaisesRegex(ValueError, "only supported for"):
+            kimage.reconstruct_patches(
+                KerasTensor([2, 4, 4, 75]), size=(5, 5), padding="same"
+            )
+
     def test_reconstruct_patches_strides_overlap_not_implemented(self):
         # Overlapping strides (strides != size) are rejected at the op level.
         patches = np.zeros((1, 4, 4, 75), dtype="float32")
@@ -2753,6 +2796,30 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         )
         self.assertEqual(tuple(recon_cf.shape), (2, 6, 6, 6))
         self.assertAllClose(recon_cf, np.transpose(x, (3, 0, 1, 2)), atol=1e-6)
+
+    def test_reconstruct_patches_autoinfer(self):
+        # Omitting output_size reproduces the explicit result for valid.
+        x = _bf16_exact((2, 20, 20, 3))
+        patches = kimage.extract_patches(x, size=(5, 5), padding="valid")
+        out = kimage.reconstruct_patches(patches, size=(5, 5))
+        self.assertEqual(tuple(out.shape), x.shape)
+        self.assertAllClose(out, x, atol=1e-6)
+
+        # channels_first + auto-infer.
+        patches_cf = knp.transpose(patches, (0, 3, 1, 2))
+        out_cf = kimage.reconstruct_patches(
+            patches_cf, size=(5, 5), data_format="channels_first"
+        )
+        self.assertAllClose(out_cf, np.transpose(x, (0, 3, 1, 2)), atol=1e-6)
+
+        # 3D.
+        v = _bf16_exact((2, 9, 9, 9, 1))
+        patches_3d = kimage.extract_patches_3d(
+            v, size=(3, 3, 3), padding="valid"
+        )
+        out_3d = kimage.reconstruct_patches(patches_3d, size=(3, 3, 3))
+        self.assertEqual(tuple(out_3d.shape), v.shape)
+        self.assertAllClose(out_3d, v, atol=1e-6)
 
     def test_reconstruct_patches_int_dtype(self):
         # reconstruct_patches only reshapes/transposes/slices, so integer

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -598,9 +598,9 @@ class ImageOpsStaticShapeTest(testing.TestCase):
             )
 
     def test_reconstruct_patches_valid_size_mismatch(self):
-        # valid padding requires grid * size == output_size.
+        # valid padding requires (grid - 1) * stride + size == output_size.
         patches = np.zeros((1, 4, 4, 75), dtype="float32")
-        with self.assertRaisesRegex(ValueError, "size \\* grid"):
+        with self.assertRaisesRegex(ValueError, "requires output_size"):
             kimage.reconstruct_patches(
                 patches,
                 size=(5, 5),
@@ -608,7 +608,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
                 padding="valid",
             )
         patches_3d = np.zeros((1, 4, 4, 4, 375), dtype="float32")
-        with self.assertRaisesRegex(ValueError, "size \\* grid"):
+        with self.assertRaisesRegex(ValueError, "requires output_size"):
             kimage.reconstruct_patches(
                 patches_3d,
                 size=(5, 5, 5),
@@ -692,7 +692,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
                 padding="valid",
             )
         patches = KerasTensor([None, 4, 4, 75])
-        with self.assertRaisesRegex(ValueError, "size \\* grid"):
+        with self.assertRaisesRegex(ValueError, "requires output_size"):
             kimage.reconstruct_patches(
                 patches,
                 size=(5, 5),
@@ -707,7 +707,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
                 padding="same",
             )
         patches_3d = KerasTensor([None, 4, 4, 4, 375])
-        with self.assertRaisesRegex(ValueError, "size \\* grid"):
+        with self.assertRaisesRegex(ValueError, "requires output_size"):
             kimage.reconstruct_patches(
                 patches_3d,
                 size=(5, 5, 5),
@@ -745,7 +745,7 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(out.shape, (2, 3, 20, 20, 20))
         # The symbolic validation is data_format aware: the grid dims sit
         # at the end in channels_first, and a mismatch still raises.
-        with self.assertRaisesRegex(ValueError, "size \\* grid"):
+        with self.assertRaisesRegex(ValueError, "requires output_size"):
             kimage.reconstruct_patches(
                 KerasTensor([2, 75, 4, 4]),
                 size=(5, 5),
@@ -797,6 +797,10 @@ class ImageOpsStaticShapeTest(testing.TestCase):
         patches = KerasTensor([2, None, None, 75])
         out = kimage.reconstruct_patches(patches, size=(5, 5), padding="valid")
         self.assertEqual(out.shape, (2, None, None, 3))
+        # Mixed static/dynamic grid -> static dims are still resolved.
+        patches = KerasTensor([2, None, 4, 75])
+        out = kimage.reconstruct_patches(patches, size=(5, 5), padding="valid")
+        self.assertEqual(out.shape, (2, None, 20, 3))
 
     def test_reconstruct_patches_autoinfer_same_raises(self):
         # Auto-infer is valid-only; same requires explicit output_size.


### PR DESCRIPTION
## Description
Third PR in the `reconstruct_patches` series (follow-up issue: #23318),
following #22984 (op) and #23267 (`channels_first` support).

With `padding="valid"` and non-overlapping patches, the reconstructed region
is fully determined by the patch grid: `grid * size` per spatial dim. This PR
makes `output_size` optional in that case:  it defaults to `None` and is
inferred from the patch shape, so the common round-trip no longer requires
carrying the original size around:

```python
patches = keras.ops.image.extract_patches(images, size=(5, 5))
recon = keras.ops.image.reconstruct_patches(patches, size=(5, 5))
```

Details:

- Inference works in both the eager and symbolic paths and for both
  `data_format`s. At trace time, unknown (dynamic) grid dims produce an
  unknown symbolic spatial dim; on the eager path they raise a clear
  `ValueError` asking for an explicit `output_size`.
- When `output_size` *is* given with `padding="valid"`, it is now validated
  against the static grid dims (`output_size == grid * size`), turning silent
  shape mistakes into immediate errors.
- `padding="same"` still requires `output_size` (the original size is
  ambiguous from patches alone). This precondition is now also checked at
  graph-construction time in the `Operation.__init__`, not just on the first
  eager call — so a functional model can no longer be built that only fails
  once data flows through it.
- Backward compatible: `output_size` keeps its positional slot (now with
  default `None`), so all existing call sites are unaffected.

Tests cover eager + symbolic inference for 2D/3D, both data formats, the
`valid` output-size validation, dynamic-dim behavior, and the earlier
`same`-without-`output_size` error, on all backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
