### PR TITLE
Fix GPTQ/AWQ quantization of layers outside the quantization structure

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -302,6 +302,24 @@ class Dense(Layer):
         if mode not in self.variable_serialization_spec:
             raise self._quantization_mode_error(mode)
 
+        # GPTQ/AWQ layers are only serializable after calibration. Before
+        # calibration, the quantized variables hold uninitialized values
+        # while the real weights live in the float `_kernel`, which has no
+        # slot in the serialization spec, so saving would silently drop the
+        # actual weights and produce a corrupted model on reload.
+        if (
+            mode == "gptq" and not getattr(self, "is_gptq_calibrated", False)
+        ) or (mode == "awq" and not getattr(self, "is_awq_calibrated", False)):
+            raise ValueError(
+                f"Cannot save layer '{self.name}' because it is quantized "
+                f"with mode '{mode}' but has never been calibrated. Its "
+                "quantized weights are uninitialized, so saving would "
+                "produce a corrupted model. Run calibration first, e.g. via "
+                "`model.quantize(...)` with a quantization layer structure "
+                "that covers this layer, or exclude the layer from "
+                "quantization with `filters`."
+            )
+
         # Kernel plus optional merged LoRA-aware scale/zero (returns
         # (kernel, None, None) for None/gptq/awq)
         kernel_value, merged_kernel_scale, merged_kernel_zero = (
@@ -313,9 +331,11 @@ class Dense(Layer):
                 store[str(idx)] = kernel_value
             elif name == "bias" and self.bias is None:
                 continue
-            elif name == "kernel_zero":
+            elif name == "kernel_zero" and mode == "int4":
+                # For int4, the (LoRA-merged) zero point comes from
+                # `_get_kernel_with_merged_lora()` and only exists for
+                # sub-channel quantization.
                 if merged_kernel_zero is None:
-                    # kernel_zero only exists for sub-channel int4 quantization
                     continue
                 store[str(idx)] = merged_kernel_zero
             elif name == "g_idx":

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -914,6 +914,32 @@ class DenseTest(testing.TestCase):
         new_layer.build((None, 8))
         self.assertEqual(new_layer.quantization_mode, "awq")
 
+    def test_gptq_uncalibrated_save_raises(self):
+        """Saving a GPTQ layer that was never calibrated must raise."""
+        layer = layers.Dense(units=16)
+        layer.build((None, 8))
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=8
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "never been calibrated"):
+            layer.save_own_variables({})
+
+    def test_awq_uncalibrated_save_raises(self):
+        """Saving an AWQ layer that was never calibrated must raise."""
+        layer = layers.Dense(units=16)
+        layer.build((None, 8))
+        layer.quantize(
+            "awq",
+            config=AWQConfig(
+                dataset=None, tokenizer=None, group_size=8, num_grid_points=10
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "never been calibrated"):
+            layer.save_own_variables({})
+
     def test_int4_kernel_returns_unpacked_form(self):
         """Test that the `kernel` property returns the unpacked int4 kernel."""
         layer = layers.Dense(units=2)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -385,6 +385,24 @@ class EinsumDense(Layer):
         if mode not in self.variable_serialization_spec:
             raise self._quantization_mode_error(mode)
 
+        # GPTQ/AWQ layers are only serializable after calibration. Before
+        # calibration, the quantized variables hold uninitialized values
+        # while the real weights live in the float `_kernel`, which has no
+        # slot in the serialization spec, so saving would silently drop the
+        # actual weights and produce a corrupted model on reload.
+        if (
+            mode == "gptq" and not getattr(self, "is_gptq_calibrated", False)
+        ) or (mode == "awq" and not getattr(self, "is_awq_calibrated", False)):
+            raise ValueError(
+                f"Cannot save layer '{self.name}' because it is quantized "
+                f"with mode '{mode}' but has never been calibrated. Its "
+                "quantized weights are uninitialized, so saving would "
+                "produce a corrupted model. Run calibration first, e.g. via "
+                "`model.quantize(...)` with a quantization layer structure "
+                "that covers this layer, or exclude the layer from "
+                "quantization with `filters`."
+            )
+
         # Kernel plus optional merged LoRA-aware scale/zero (returns
         # (kernel, None, None) for None/gptq)
         kernel_value, merged_kernel_scale, merged_kernel_zero = (
@@ -396,9 +414,11 @@ class EinsumDense(Layer):
                 store[str(idx)] = kernel_value
             elif name == "bias" and self.bias is None:
                 continue
-            elif name == "kernel_zero":
+            elif name == "kernel_zero" and mode == "int4":
+                # For int4, the (LoRA-merged) zero point comes from
+                # `_get_kernel_with_merged_lora()` and only exists for
+                # sub-channel quantization.
                 if merged_kernel_zero is None:
-                    # kernel_zero only exists for sub-channel int4 quantization
                     continue
                 store[str(idx)] = merged_kernel_zero
             elif name == "g_idx":

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1184,6 +1184,42 @@ class EinsumDenseTest(testing.TestCase):
         new_layer.build((None, 3))
         self.assertEqual(new_layer.quantization_mode, "awq")
 
+    def test_gptq_uncalibrated_save_raises(self):
+        """Saving a GPTQ layer that was never calibrated must raise."""
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=8
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "never been calibrated"):
+            layer.save_own_variables({})
+
+    def test_awq_uncalibrated_save_raises(self):
+        """Saving an AWQ layer that was never calibrated must raise."""
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+        layer.quantize(
+            "awq",
+            config=AWQConfig(
+                dataset=None, tokenizer=None, group_size=8, num_grid_points=10
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "never been calibrated"):
+            layer.save_own_variables({})
+
     def test_int4_kernel_returns_unpacked_form(self):
         """Test that the `kernel` property returns the unpacked int4 kernel."""
         layer = layers.EinsumDense(

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -561,6 +561,8 @@ class Embedding(Layer):
         # Prevent quantization of the subclasses.
         if type_check and (type(self) is not Embedding):
             raise self._not_implemented_error(self.quantize)
+        if mode not in ("int8", "int4"):
+            raise self._quantization_mode_error(mode)
 
         self.quantization_config = config
 

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -14,6 +14,8 @@ from keras.src import ops
 from keras.src import quantizers
 from keras.src import saving
 from keras.src import testing
+from keras.src.quantizers.awq_config import AWQConfig
+from keras.src.quantizers.gptq_config import GPTQConfig
 from keras.src.quantizers.quantization_config import Int4QuantizationConfig
 from keras.src.quantizers.quantization_config import Int8QuantizationConfig
 from keras.src.quantizers.quantizers import AbsMaxQuantizer
@@ -490,6 +492,23 @@ class EmbeddingTest(test_case.TestCase):
             layer._dtype_policy._quantization_mode = mode
             layer.quantized_call(x)
         self.assertEqual(layer.dtype_policy, original_dtype_policy)
+
+    @parameterized.named_parameters(
+        ("gptq", "gptq"),
+        ("awq", "awq"),
+    )
+    def test_quantize_unsupported_calibration_modes(self, mode):
+        # Embedding only supports int8/int4. GPTQ/AWQ must be rejected
+        # without stashing a stale quantization config on the layer.
+        layer = layers.Embedding(10, 16)
+        layer.build()
+        if mode == "gptq":
+            config = GPTQConfig(dataset=None, tokenizer=None)
+        else:
+            config = AWQConfig(dataset=None, tokenizer=None)
+        with self.assertRaises(NotImplementedError):
+            layer.quantize(mode, config=config)
+        self.assertIsNone(layer.quantization_config)
 
     @parameterized.named_parameters(
         ("int8", "int8_from_mixed_bfloat16", 0, 2),

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -10,6 +10,7 @@ from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
 from keras.src.models.variable_mapping import map_saveable_variables
 from keras.src.quantizers.awq_core import awq_quantize
+from keras.src.quantizers.gptq_core import find_layers_in_block
 from keras.src.quantizers.gptq_core import gptq_quantize
 from keras.src.quantizers.utils import should_quantize_layer
 from keras.src.saving import saving_api
@@ -459,9 +460,16 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         can be passed to customize the behavior of the quantization (e.g. to
         use specific quantizers for weights or activations).
 
+        For the `"gptq"` and `"awq"` modes, quantization is restricted to
+        the `Dense` and `EinsumDense` layers inside the structure's
+        `"sequential_blocks"` (provided via
+        `config.quantization_layer_structure` or the model's
+        `get_quantization_layer_structure(mode)` hook). All other layers
+        are left in their original precision.
+
         Args:
             mode: The mode of the quantization. Supported modes are:
-                `"int8"`, `"int4"`, `"float8"`, `"gptq"`. This is
+                `"int8"`, `"int4"`, `"float8"`, `"gptq"`, `"awq"`. This is
                 optional if `config` is provided.
             config: The configuration object specifying additional
                 quantization options. This argument allows to configure
@@ -533,28 +541,21 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                     f"{type(filters)}"
                 )
 
-        graph_modified = False
-        for layer in self._flatten_layers():
-            # Apply filters
-            if not should_quantize_layer(layer, filters):
-                continue
-
-            if len(list(layer._flatten_layers())) == 1:
-                try:
-                    layer.quantize(mode, type_check=type_check, config=config)
-                    graph_modified = True
-                except NotImplementedError as e:
-                    warnings.warn(str(e))
-                except AttributeError:
-                    pass
-
-        if mode in ["gptq", "awq"]:
-            # Resolve model structure.
-            # 1. If quantization_layer_structure is provided inside the config,
-            # use that.
+        # For GPTQ/AWQ, resolve the model structure before any layer is
+        # modified so that an invalid structure surfaces early, and restrict
+        # quantization to the layers covered by the structure. Only those
+        # layers are calibrated afterwards; quantizing any other layer would
+        # leave it uncalibrated, and its uninitialized quantized weights
+        # would silently replace the real ones when the model is saved and
+        # reloaded.
+        structure = None
+        structure_layer_ids = None
+        if mode in ("gptq", "awq"):
+            # 1. If quantization_layer_structure is provided inside the
+            # config, use that.
             structure = config.quantization_layer_structure
-            # 2. If no layer structure is provided in the config, try to fetch
-            # it using the `get_quantization_layer_structure` hook.
+            # 2. If no layer structure is provided in the config, try to
+            # fetch it using the `get_quantization_layer_structure` hook.
             if structure is None:
                 structure = self.get_quantization_layer_structure(mode)
 
@@ -567,10 +568,36 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                     "structure should be a dictionary with keys "
                     "'pre_block_layers' and 'sequential_blocks'."
                 )
-            if mode == "gptq":
-                gptq_quantize(config, structure, filters=filters)
-            elif mode == "awq":
-                awq_quantize(config, structure, filters=filters)
+            structure_layer_ids = set()
+            for block in structure.get("sequential_blocks", []):
+                for sub_layer in find_layers_in_block(block).values():
+                    structure_layer_ids.add(id(sub_layer))
+
+        graph_modified = False
+        for layer in self._flatten_layers():
+            # Apply filters
+            if not should_quantize_layer(layer, filters):
+                continue
+            # For GPTQ/AWQ, skip layers that the structure does not cover.
+            if (
+                structure_layer_ids is not None
+                and id(layer) not in structure_layer_ids
+            ):
+                continue
+
+            if len(list(layer._flatten_layers())) == 1:
+                try:
+                    layer.quantize(mode, type_check=type_check, config=config)
+                    graph_modified = True
+                except NotImplementedError as e:
+                    warnings.warn(str(e))
+                except AttributeError:
+                    pass
+
+        if mode == "gptq":
+            gptq_quantize(config, structure, filters=filters)
+        elif mode == "awq":
+            awq_quantize(config, structure, filters=filters)
 
         # If any layer was changed, we must rebuild the execution functions.
         if graph_modified:

--- a/keras/src/quantizers/awq_config.py
+++ b/keras/src/quantizers/awq_config.py
@@ -123,16 +123,18 @@ class AWQConfig(QuantizationConfig):
 
     def get_config(self):
         return {
-            # Dataset and Tokenizer are only required for one-time
-            # calibration and are not saved in the config.
+            # Dataset, tokenizer and quantization layer structure are only
+            # required for one-time calibration and are not saved in the
+            # config. The structure also holds references to live layer
+            # objects, which cannot be serialized.
             "dataset": None,
             "tokenizer": None,
+            "quantization_layer_structure": None,
             "weight_bits": self.weight_bits,
             "num_samples": self.num_samples,
             "sequence_length": self.sequence_length,
             "group_size": self.group_size,
             "num_grid_points": self.num_grid_points,
-            "quantization_layer_structure": self.quantization_layer_structure,
         }
 
     @classmethod

--- a/keras/src/quantizers/awq_config_test.py
+++ b/keras/src/quantizers/awq_config_test.py
@@ -136,3 +136,21 @@ class AWQConfigTest(testing.TestCase):
         self.assertEqual(
             config.num_grid_points, deserialized_config.num_grid_points
         )
+
+    def test_quantization_layer_structure_not_serialized(self):
+        """The layer structure is calibration-only and must not serialize."""
+        config = AWQConfig(
+            dataset=["test"],
+            tokenizer=self.MockTokenizer(),
+            group_size=64,
+            num_grid_points=30,
+            quantization_layer_structure={
+                "pre_block_layers": [],
+                "sequential_blocks": [],
+            },
+        )
+        cfg = config.get_config()
+        self.assertIsNone(cfg["quantization_layer_structure"])
+
+        restored = AWQConfig.from_config(cfg)
+        self.assertIsNone(restored.quantization_layer_structure)

--- a/keras/src/quantizers/awq_config_test.py
+++ b/keras/src/quantizers/awq_config_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from keras.src import layers
 from keras.src import testing
 from keras.src.quantizers.awq_config import AWQConfig
 
@@ -153,4 +154,25 @@ class AWQConfigTest(testing.TestCase):
         self.assertIsNone(cfg["quantization_layer_structure"])
 
         restored = AWQConfig.from_config(cfg)
+        self.assertIsNone(restored.quantization_layer_structure)
+
+    def test_live_layer_structure_not_serialized(self):
+        """The live layer structure must be dropped on serialization.
+
+        It references live model layers; serializing it would create a
+        reference cycle (layer -> config -> layer) and recurse infinitely.
+        """
+        layer = layers.Dense(4)
+        layer.build((None, 4))
+        config = AWQConfig(
+            dataset=None,
+            tokenizer=None,
+            quantization_layer_structure={
+                "pre_block_layers": [layer],
+                "sequential_blocks": [layer],
+            },
+        )
+        # This must not recurse.
+        self.assertIsNone(config.get_config()["quantization_layer_structure"])
+        restored = AWQConfig.from_config(config.get_config())
         self.assertIsNone(restored.quantization_layer_structure)

--- a/keras/src/quantizers/awq_test.py
+++ b/keras/src/quantizers/awq_test.py
@@ -1,5 +1,7 @@
 """Tests for AWQ quantization."""
 
+import os
+
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -8,6 +10,7 @@ import keras
 from keras.src import layers
 from keras.src import models
 from keras.src import ops
+from keras.src import saving
 from keras.src import testing
 from keras.src.quantizers.awq import AWQ
 from keras.src.quantizers.awq import awq_quantize_matrix
@@ -658,3 +661,78 @@ class AWQAccuracyTest(testing.TestCase):
         )
 
         awq_obj.free()
+
+    def test_awq_save_load_round_trip(self):
+        """Full AWQ quantize -> save -> load round trip.
+
+        Only the Dense layers inside the structure's ``sequential_blocks``
+        are quantized; the embedding and classifier head stay untouched,
+        and predictions are reproduced after a save/load cycle. Uses small
+        local dimensions to keep the grid search fast.
+        """
+        keras.utils.set_random_seed(123)
+        seq_len = 16
+        vocab = 48
+        num_classes = 4
+        embed_dim = 8
+
+        block = models.Sequential(
+            [
+                layers.Dense(16, activation="relu"),
+                layers.Dense(embed_dim),
+            ]
+        )
+
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab, embed_dim)
+        x = embedding(inputs)
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        head = layers.Dense(num_classes)
+        outputs = head(x)
+        model = models.Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=7)
+        dataset = [
+            rng.integers(0, vocab, size=(1, seq_len), dtype=np.int32)
+            for _ in range(4)
+        ]
+        tokenizer = _char_tokenizer(vocab_size=vocab, seq_len=seq_len)
+
+        config = AWQConfig(
+            dataset=dataset,
+            tokenizer=tokenizer,
+            group_size=8,
+            num_samples=4,
+            sequence_length=seq_len,
+            num_grid_points=5,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        model.quantize("awq", config=config)
+
+        # In-structure Dense layers are quantized and calibrated.
+        for dense in block.layers:
+            self.assertEqual(dense.quantization_mode, "awq")
+            self.assertTrue(dense.is_awq_calibrated)
+
+        # Out-of-structure layers must stay completely untouched.
+        self.assertIsNone(getattr(head, "quantization_mode", None))
+        self.assertFalse(hasattr(head, "quantized_kernel"))
+        self.assertIsNone(getattr(embedding, "quantization_mode", None))
+        self.assertFalse(hasattr(embedding, "quantized_kernel"))
+
+        # Predictions survive a save/load round trip.
+        eval_rng = np.random.default_rng(seed=99)
+        x_eval = eval_rng.integers(0, vocab, size=(4, seq_len), dtype=np.int32)
+        y_before = model.predict(x_eval)
+
+        path = os.path.join(self.get_temp_dir(), "awq_model.keras")
+        model.save(path)
+        reloaded = saving.load_model(path)
+        y_after = reloaded.predict(x_eval)
+
+        self.assertAllClose(y_before, y_after)

--- a/keras/src/quantizers/awq_test.py
+++ b/keras/src/quantizers/awq_test.py
@@ -373,6 +373,87 @@ class AWQIntegrationTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "quantization structure"):
             model.quantize(config=config)
 
+    @pytest.mark.requires_trainable_backend
+    def test_awq_save_load_round_trip_einsum_dense_block(self):
+        """Regression test for a RecursionError when saving an AWQ model.
+
+        Saving an AWQ-quantized model used to raise a RecursionError because
+        `AWQConfig.get_config` serialized `quantization_layer_structure`,
+        which holds live model layers, forming a reference cycle
+        (layer -> config -> layer). This builds a tiny model whose quantized
+        block contains both `Dense` and `EinsumDense` (unlike the Dense-only
+        round trip in `AWQAccuracyTest`), saves it, reloads it, and checks
+        the predictions are preserved exactly.
+        """
+        vocab_size, seq_len, embed_dim = 32, 8, 4
+
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab_size, embed_dim)
+        x = embedding(inputs)
+        block = models.Sequential(
+            [
+                layers.Dense(embed_dim, activation="relu"),
+                layers.EinsumDense(
+                    "abc,cd->abd", output_shape=(seq_len, embed_dim)
+                ),
+            ]
+        )
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        head = layers.Dense(2)
+        outputs = head(x)
+        model = models.Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=21)
+        dataset = [
+            rng.integers(0, vocab_size, size=(1, seq_len)).astype("int32")
+            for _ in range(3)
+        ]
+        config = AWQConfig(
+            dataset=dataset,
+            tokenizer=lambda text: text,
+            num_samples=2,
+            sequence_length=seq_len,
+            group_size=4,
+            num_grid_points=5,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        # Layers outside the structure (embedding, pooling, head) are not
+        # quantized at all, so the round-trip can be compared exactly.
+        model.quantize("awq", config=config)
+        self.assertIsNone(getattr(head, "quantization_mode", None))
+
+        # The embedding only supports int8/int4; `quantize` must reject the
+        # unsupported mode without stashing a stale AWQ config on it.
+        self.assertIsNone(embedding.quantization_config)
+
+        x_eval = rng.integers(0, vocab_size, size=(2, seq_len)).astype("int32")
+        y_quantized = model.predict(x_eval)
+
+        # This `save` used to raise a RecursionError.
+        path = os.path.join(self.get_temp_dir(), "model.keras")
+        model.save(path)
+        restored = saving.load_model(path)
+        y_restored = restored.predict(x_eval)
+        self.assertAllClose(y_quantized, y_restored)
+
+        # The quantized block state survives the round-trip.
+        restored_block = next(
+            l for l in restored.layers if isinstance(l, models.Sequential)
+        )
+        restored_dense = restored_block.layers[0]
+        self.assertEqual(
+            getattr(restored_dense, "quantization_mode", None), "awq"
+        )
+        self.assertTrue(hasattr(restored_dense, "quantized_kernel"))
+        self.assertIsNone(
+            restored_dense.quantization_config.quantization_layer_structure
+        )
+
 
 # Constants for end-to-end tests
 VOCAB_SIZE = 1000

--- a/keras/src/quantizers/gptq_config.py
+++ b/keras/src/quantizers/gptq_config.py
@@ -187,10 +187,13 @@ class GPTQConfig(QuantizationConfig):
 
     def get_config(self):
         return {
-            # Dataset and Tokenizer are only required for a one-time
-            # calibration and are not saved in the config.
+            # Dataset, tokenizer and quantization layer structure are only
+            # required for one-time calibration and are not saved in the
+            # config. The structure also holds references to live layer
+            # objects, which cannot be serialized.
             "dataset": None,
             "tokenizer": None,
+            "quantization_layer_structure": None,
             "weight_bits": self.weight_bits,
             "num_samples": self.num_samples,
             "per_channel": self.per_channel,
@@ -199,7 +202,6 @@ class GPTQConfig(QuantizationConfig):
             "group_size": self.group_size,
             "symmetric": self.symmetric,
             "activation_order": self.activation_order,
-            "quantization_layer_structure": self.quantization_layer_structure,
         }
 
     @classmethod

--- a/keras/src/quantizers/gptq_config_test.py
+++ b/keras/src/quantizers/gptq_config_test.py
@@ -1,3 +1,4 @@
+from keras.src import layers
 from keras.src import testing
 from keras.src.quantizers.gptq_config import GPTQConfig
 
@@ -77,4 +78,25 @@ class TestGPTQConfig(testing.TestCase):
         self.assertIsNone(cfg["quantization_layer_structure"])
 
         restored = GPTQConfig.from_config(cfg)
+        self.assertIsNone(restored.quantization_layer_structure)
+
+    def test_live_layer_structure_not_serialized(self):
+        """The live layer structure must be dropped on serialization.
+
+        It references live model layers; serializing it would create a
+        reference cycle (layer -> config -> layer) and recurse infinitely.
+        """
+        layer = layers.Dense(4)
+        layer.build((None, 4))
+        config = GPTQConfig(
+            dataset=None,
+            tokenizer=None,
+            quantization_layer_structure={
+                "pre_block_layers": [layer],
+                "sequential_blocks": [layer],
+            },
+        )
+        # This must not recurse.
+        self.assertIsNone(config.get_config()["quantization_layer_structure"])
+        restored = GPTQConfig.from_config(config.get_config())
         self.assertIsNone(restored.quantization_layer_structure)

--- a/keras/src/quantizers/gptq_config_test.py
+++ b/keras/src/quantizers/gptq_config_test.py
@@ -58,3 +58,23 @@ class TestGPTQConfig(testing.TestCase):
         serialized_config = config.get_config()
         deserialized_config = GPTQConfig.from_config(serialized_config)
         self.assertDictEqual(config.__dict__, deserialized_config.__dict__)
+
+    def test_quantization_layer_structure_not_serialized(self):
+        # The layer structure may hold live layer objects; like the
+        # dataset/tokenizer it is calibration-only state and must not be
+        # serialized.
+        config = GPTQConfig(
+            dataset=None,
+            tokenizer=None,
+            weight_bits=4,
+            group_size=64,
+            quantization_layer_structure={
+                "pre_block_layers": [],
+                "sequential_blocks": [],
+            },
+        )
+        cfg = config.get_config()
+        self.assertIsNone(cfg["quantization_layer_structure"])
+
+        restored = GPTQConfig.from_config(cfg)
+        self.assertIsNone(restored.quantization_layer_structure)

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -824,3 +824,83 @@ class TestModelQuantization(testing.TestCase):
         # The model must be left unmodified when the structure is missing.
         self.assertIsNone(getattr(dense, "quantization_mode", None))
         self.assertFalse(hasattr(dense, "quantized_kernel"))
+
+    def test_gptq_save_load_round_trip_einsum_dense_block(self):
+        """Regression test for a RecursionError when saving a GPTQ model.
+
+        Saving a GPTQ-quantized model used to raise a RecursionError because
+        `GPTQConfig.get_config` serialized `quantization_layer_structure`,
+        which holds live model layers, forming a reference cycle
+        (layer -> config -> layer). This builds a tiny model whose quantized
+        block contains both `Dense` and `EinsumDense` (unlike the Dense-only
+        round trip above), saves it, reloads it, and checks the predictions
+        are preserved exactly.
+        """
+        vocab_size, seq_len, embed_dim = 32, 8, 4
+
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab_size, embed_dim)
+        x = embedding(inputs)
+        block = models.Sequential(
+            [
+                layers.Dense(embed_dim, activation="relu"),
+                layers.EinsumDense(
+                    "abc,cd->abd", output_shape=(seq_len, embed_dim)
+                ),
+            ]
+        )
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        head = layers.Dense(2)
+        outputs = head(x)
+        model = models.Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=13)
+        dataset = [
+            rng.integers(0, vocab_size, size=(1, seq_len)).astype("int32")
+            for _ in range(3)
+        ]
+        config = GPTQConfig(
+            dataset=dataset,
+            tokenizer=lambda text: text,
+            weight_bits=4,
+            num_samples=2,
+            sequence_length=seq_len,
+            group_size=4,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        # Layers outside the structure (embedding, pooling, head) are not
+        # quantized at all, so the round-trip can be compared exactly.
+        model.quantize("gptq", config=config)
+        self.assertIsNone(getattr(head, "quantization_mode", None))
+
+        # The embedding only supports int8/int4; `quantize` must reject the
+        # unsupported mode without stashing a stale GPTQ config on it.
+        self.assertIsNone(embedding.quantization_config)
+
+        x_eval = rng.integers(0, vocab_size, size=(2, seq_len)).astype("int32")
+        y_quantized = model.predict(x_eval)
+
+        # This `save` used to raise a RecursionError.
+        path = os.path.join(self.get_temp_dir(), "model.keras")
+        model.save(path)
+        restored = saving.load_model(path)
+        y_restored = restored.predict(x_eval)
+        self.assertAllClose(y_quantized, y_restored)
+
+        # The quantized block state survives the round-trip.
+        restored_block = next(
+            l for l in restored.layers if isinstance(l, models.Sequential)
+        )
+        restored_dense = restored_block.layers[0]
+        self.assertEqual(
+            getattr(restored_dense, "quantization_mode", None), "gptq"
+        )
+        self.assertTrue(hasattr(restored_dense, "quantized_kernel"))
+        self.assertIsNone(
+            restored_dense.quantization_config.quantization_layer_structure
+        )

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Callable
 
 import numpy as np
@@ -9,6 +10,7 @@ from keras.src import backend
 from keras.src import layers
 from keras.src import models
 from keras.src import ops
+from keras.src import saving
 from keras.src import testing
 from keras.src.quantizers.gptq import GPTQ
 from keras.src.quantizers.gptq import _stable_permutation
@@ -733,3 +735,92 @@ class TestModelQuantization(testing.TestCase):
         # Check that layer1 is not quantized.
         self.assertIsNone(getattr(layer1, "quantization_mode", None))
         self.assertFalse(hasattr(layer1, "quantized_kernel"))
+
+    def test_gptq_save_load_round_trip(self):
+        """Full GPTQ quantize -> save -> load round trip.
+
+        Only the Dense layers inside the structure's ``sequential_blocks``
+        are quantized; the embedding and classifier head stay untouched,
+        and predictions are reproduced after a save/load cycle.
+        """
+        keras.utils.set_random_seed(123)
+        embed_dim = 8
+
+        block = models.Sequential(
+            [
+                layers.Dense(16, activation="relu"),
+                layers.Dense(embed_dim),
+            ]
+        )
+
+        inputs = layers.Input(shape=(SEQ_LEN,), dtype="int32")
+        embedding = layers.Embedding(VOCAB_SIZE, embed_dim)
+        x = embedding(inputs)
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        head = layers.Dense(NUM_CLASSES)
+        outputs = head(x)
+        model = models.Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=7)
+        dataset = [
+            rng.integers(0, VOCAB_SIZE, size=(1, SEQ_LEN), dtype=np.int32)
+            for _ in range(4)
+        ]
+        tokenizer = _char_tokenizer(vocab_size=VOCAB_SIZE, seq_len=SEQ_LEN)
+
+        config = GPTQConfig(
+            dataset=dataset,
+            tokenizer=tokenizer,
+            weight_bits=4,
+            group_size=8,
+            num_samples=4,
+            sequence_length=SEQ_LEN,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        model.quantize("gptq", config=config)
+
+        # In-structure Dense layers are quantized and calibrated.
+        for dense in block.layers:
+            self.assertEqual(dense.quantization_mode, "gptq")
+            self.assertTrue(dense.is_gptq_calibrated)
+
+        # Out-of-structure layers must stay completely untouched.
+        self.assertIsNone(getattr(head, "quantization_mode", None))
+        self.assertFalse(hasattr(head, "quantized_kernel"))
+        self.assertIsNone(getattr(embedding, "quantization_mode", None))
+        self.assertFalse(hasattr(embedding, "quantized_kernel"))
+
+        # Predictions survive a save/load round trip.
+        eval_rng = np.random.default_rng(seed=99)
+        x_eval = eval_rng.integers(
+            0, VOCAB_SIZE, size=(4, SEQ_LEN), dtype=np.int32
+        )
+        y_before = model.predict(x_eval)
+
+        path = os.path.join(self.get_temp_dir(), "gptq_model.keras")
+        model.save(path)
+        reloaded = saving.load_model(path)
+        y_after = reloaded.predict(x_eval)
+
+        self.assertAllClose(y_before, y_after)
+
+    def test_gptq_missing_structure_leaves_model_unmodified(self):
+        """A config without a structure raises before any layer is mutated."""
+        model = _get_simple_model()
+        dense = model.layers[0]
+
+        config = GPTQConfig(dataset=["a"], tokenizer=lambda x: x)
+
+        with self.assertRaisesRegex(
+            ValueError, "a valid quantization structure"
+        ):
+            model.quantize("gptq", config=config)
+
+        # The model must be left unmodified when the structure is missing.
+        self.assertIsNone(getattr(dense, "quantization_mode", None))
+        self.assertFalse(hasattr(dense, "quantized_kernel"))


### PR DESCRIPTION
## Description

`model.quantize("gptq"/"awq")` used to build quantized variables on every quantizable layer, while only layers inside the structure's sequential_blocks were calibrated. Layers outside the structure kept computing with their float kernel, but saving dropped that kernel (the gptq/awq serialization spec has no slot for it) and loading marked every layer calibrated, so reloaded models silently computed with uninitialized quantized weights.

- Model.quantize now resolves the quantization structure before touching any layer (an invalid/missing structure no longer leaves the model half-quantized) and only quantizes the Dense/EinsumDense layers inside
  sequential_blocks - the exact set that gets calibrated. All other layers keep their original precision.
- Dense/EinsumDense.save_own_variables now raises a clear error when a gptq/awq layer is saved without calibration (still reachable via the layer-level quantize() API) instead of writing a corrupted file.
- Fixed kernel_zero being silently dropped from every gptq/awq save: the LoRA-merged zero point (always None for gptq/awq) shadowed the layer's real variable, so saved models failed to load with a variable-count
  mismatch.
- GPTQConfig/AWQConfig.get_config() no longer serialize quantization_layer_structure: it holds live layer references, which
  made model.save() recurse infinitely (layer config -> quantization config -> structure -> same layer). Like dataset/tokenizer it is one-time calibration state.

Adds gptq/awq save/load round-trip tests, guard tests for uncalibrated saves, a no-mutation-on-missing-structure test, and config serialization tests.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
