### PR TITLE
Fix swapped false-positive/false-negative terms in tversky loss

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2640,8 +2640,8 @@ def tversky(y_true, y_pred, alpha=0.5, beta=0.5, axis=None):
     targets = y_pred
 
     intersection = ops.sum(inputs * targets, axis=axis)
-    fp = ops.sum((1 - targets) * inputs, axis=axis)
-    fn = ops.sum(targets * (1 - inputs), axis=axis)
+    fp = ops.sum(targets * (1 - inputs), axis=axis)
+    fn = ops.sum((1 - targets) * inputs, axis=axis)
 
     tversky = ops.divide(
         intersection,

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1932,7 +1932,7 @@ class TverskyTest(testing.TestCase):
         y_true = np.array(([[1, 2], [1, 2]]))
         y_pred = np.array(([[4, 1], [6, 1]]))
         output = losses.Tversky(alpha=0.2, beta=0.8)(y_true, y_pred)
-        self.assertAllClose(output, -0.29629636)
+        self.assertAllClose(output, -0.9444444)
 
     def test_binary_segmentation(self):
         y_true = np.array(
@@ -1962,7 +1962,7 @@ class TverskyTest(testing.TestCase):
             ([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 0, 1, 1]])
         )
         output = losses.Tversky(alpha=0.2, beta=0.8)(y_true, y_pred)
-        self.assertAllClose(output, 0.7916667)
+        self.assertAllClose(output, 0.7619048)
 
     def test_binary_segmentation_custom_coefficients_with_axis(self):
         y_true = np.array(
@@ -1974,7 +1974,30 @@ class TverskyTest(testing.TestCase):
         output = losses.Tversky(
             alpha=0.2, beta=0.8, axis=(1, 2, 3), reduction=None
         )(y_true, y_pred)
-        self.assertAllClose(output, [0.5, 0.7222222])
+        self.assertAllClose(output, [0.5, 0.7849462])
+
+    def test_alpha_beta_weight_fp_and_fn(self):
+        # `alpha` weights false positives and `beta` weights false negatives,
+        # as documented. With a false-positive-only prediction (TP=1, FP=1,
+        # FN=0) the loss must depend on `alpha` and be invariant to `beta`.
+        y_true = np.array([[1.0, 0.0]])
+        y_pred = np.array([[1.0, 1.0]])
+        self.assertAllClose(
+            losses.Tversky(alpha=0.2, beta=0.8)(y_true, y_pred), 0.16666667
+        )
+        self.assertAllClose(
+            losses.Tversky(alpha=0.8, beta=0.2)(y_true, y_pred), 0.44444445
+        )
+        # Symmetrically, a false-negative-only prediction (TP=1, FP=0, FN=1)
+        # must depend on `beta` and be invariant to `alpha`.
+        y_true = np.array([[1.0, 1.0]])
+        y_pred = np.array([[1.0, 0.0]])
+        self.assertAllClose(
+            losses.Tversky(alpha=0.8, beta=0.2)(y_true, y_pred), 0.16666667
+        )
+        self.assertAllClose(
+            losses.Tversky(alpha=0.2, beta=0.8)(y_true, y_pred), 0.44444445
+        )
 
     def test_dtype_arg(self):
         y_true = np.array(([[1, 2], [1, 2]]))


### PR DESCRIPTION
## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.

---

### Summary

`keras.losses.tversky` swaps the false-positive and false-negative terms, so `alpha` and `beta` are applied to the opposite terms from what the docstring documents.

The docstring states:
- `alpha: coefficient controlling incidence of false positives.`
- `beta: coefficient controlling incidence of false negatives.`

But with `inputs = y_true` and `targets = y_pred`:

```python
fp = ops.sum((1 - targets) * inputs, axis=axis)  # y_true=1, y_pred=0 -> a false NEGATIVE, named fp
fn = ops.sum(targets * (1 - inputs), axis=axis)  # y_pred=1, y_true=0 -> a false POSITIVE, named fn
```

So the denominator effectively computes `TP + alpha*FN + beta*FP` instead of the canonical Tversky index `TP + alpha*FP + beta*FN` (Salehi et al., 2017, which the docstring cites).

This is invisible at the default `alpha == beta == 0.5` (where Tversky reduces to Dice), which is why it went unnoticed — but any asymmetric choice gives wrong values.

### Reproduction

`y_true=[[1,1,0,0,0]]`, `y_pred=[[1,0,1,1,0]]` → TP=1, FP=2, FN=1, with `alpha=0.2` (should weight FP), `beta=0.8` (should weight FN):

```python
import keras, numpy as np
y_true = np.array([[1.,1.,0.,0.,0.]]); y_pred = np.array([[1.,0.,1.,1.,0.]])
keras.losses.tversky(y_true, y_pred, alpha=0.2, beta=0.8)
# current:   0.6428572   (== 1 - TP/(TP + 0.2*FN + 0.8*FP))
# canonical: 0.5454545   (== 1 - TP/(TP + 0.2*FP + 0.8*FN))
```

### Fix

Swap the two expressions so `fp`/`fn` match their names and `alpha`/`beta` weight the documented terms:

```python
fp = ops.sum(targets * (1 - inputs), axis=axis)
fn = ops.sum((1 - targets) * inputs, axis=axis)
```

Symmetric-coefficient results (including the default) are **unchanged** — `test_correctness`, `test_binary_segmentation`, and `test_binary_segmentation_with_axis` all still pass untouched. The three custom-coefficient tests are updated to the corrected values, and a new test `test_alpha_beta_weight_fp_and_fn` asserts that `alpha` weights false positives and `beta` weights false negatives (using FP-only and FN-only predictions).

Full `TverskyTest` passes locally (9/9, numpy backend); `ruff` clean.

### AI usage disclosure

Per the AI-assisted contribution policy: an AI coding assistant helped locate the swapped terms and draft this change. I reviewed and understand the fix, reproduced the incorrect values against the canonical formula and the docstring, and re-derived every updated test expectation by running the corrected code.
