### PR TITLE
Fix TraceContext error for NNX backend  reported in https://github.com/keras-team/keras/issues/23289

### DIFF
--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -329,22 +329,7 @@ if config.is_nnx_enabled():
 
 @contextlib.contextmanager
 def _nnx_stateful_trace_scope():
-    """Allow Keras layers to build while traced by `jax.eval_shape`.
-
-    Keras infers output shapes by running `call()` under `jax.eval_shape`,
-    which may lazily build layers as a side effect: creating sublayers and
-    variables, and setting attributes on layers that were created eagerly.
-    NNX stamps every object with the trace level active at creation time and
-    forbids mutating it from any other level, so this cross-trace mutation
-    raises `flax.errors.TraceContextError` (see issue #23289).
-
-    These mutations are safe: JAX tracing is data-driven, and initializers
-    only see concrete shapes, so the values assigned are concrete arrays.
-    Only shapes escape the trace. This scope pins NNX's notion of the
-    current trace to the outer trace so that mutations inside the trace
-    validate against the outer level, and objects created inside the trace
-    are stamped with the outer level and remain mutable after it exits.
-    """
+    """Allow Keras layers to build while traced by `jax.eval_shape`."""
     if not config.is_nnx_enabled():
         yield
         return

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -1,5 +1,4 @@
 import inspect
-import contextlib
 import math
 
 import jax
@@ -327,23 +326,6 @@ if config.is_nnx_enabled():
     NnxVariable.__setattr__ = __setattr__
 
 
-@contextlib.contextmanager
-def _nnx_stateful_trace_scope():
-    """Allow Keras layers to build while traced by `jax.eval_shape`."""
-    if not config.is_nnx_enabled():
-        yield
-        return
-    from flax.nnx import tracers as nnx_tracers
-
-    outer_trace = nnx_tracers.current_jax_trace()
-    original_current_jax_trace = nnx_tracers.current_jax_trace
-    nnx_tracers.current_jax_trace = lambda: outer_trace
-    try:
-        yield
-    finally:
-        nnx_tracers.current_jax_trace = original_current_jax_trace
-
-
 def should_shard_at_init(init_layout, shape):
     size_threshold = 250 * 1024 * 1024
     # We multiply by the mesh size here to take into account the worst case
@@ -493,12 +475,9 @@ def compute_output_spec(fn, *args, **kwargs):
             convert_keras_tensor_to_jax,
             (maybe_symbolic_args, maybe_symbolic_kwargs),
         )
-        with _nnx_stateful_trace_scope():
-            jax_out = jax.eval_shape(
-                wrapped_fn,
-                *maybe_symbolic_args_jax,
-                **maybe_symbolic_kwargs_jax,
-            )
+        jax_out = jax.eval_shape(
+            wrapped_fn, *maybe_symbolic_args_jax, **maybe_symbolic_kwargs_jax
+        )
 
         def convert_jax_spec_to_keras_tensor(x):
             if isinstance(x, jax.ShapeDtypeStruct):

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -1,4 +1,5 @@
 import inspect
+import contextlib
 import math
 
 import jax
@@ -247,10 +248,13 @@ if config.is_nnx_enabled():
                 stateless_value = scope.get_current_value(self)
                 if stateless_value is not None:
                     return self._maybe_autocast(stateless_value)
-            if not hasattr(self, "raw_value"):
+            if getattr(self, "raw_value", None) is None:
+                # Uninitialized variable (created under a stateless scope,
+                # which defers initialization). Return a placeholder, like
+                # `KerasVariable.value`, without mutating the variable.
                 if self._initializer is not None:
-                    self._initialize(
-                        self._initializer(self.shape, dtype=self.dtype)
+                    return self._maybe_autocast(
+                        self._initializer(self._shape, dtype=self._dtype)
                     )
                 else:
                     raise AttributeError(
@@ -321,6 +325,38 @@ if config.is_nnx_enabled():
         object.__setattr__(self, name, value)
 
     NnxVariable.__setattr__ = __setattr__
+
+
+@contextlib.contextmanager
+def _nnx_stateful_trace_scope():
+    """Allow Keras layers to build while traced by `jax.eval_shape`.
+
+    Keras infers output shapes by running `call()` under `jax.eval_shape`,
+    which may lazily build layers as a side effect: creating sublayers and
+    variables, and setting attributes on layers that were created eagerly.
+    NNX stamps every object with the trace level active at creation time and
+    forbids mutating it from any other level, so this cross-trace mutation
+    raises `flax.errors.TraceContextError` (see issue #23289).
+
+    These mutations are safe: JAX tracing is data-driven, and initializers
+    only see concrete shapes, so the values assigned are concrete arrays.
+    Only shapes escape the trace. This scope pins NNX's notion of the
+    current trace to the outer trace so that mutations inside the trace
+    validate against the outer level, and objects created inside the trace
+    are stamped with the outer level and remain mutable after it exits.
+    """
+    if not config.is_nnx_enabled():
+        yield
+        return
+    from flax.nnx import tracers as nnx_tracers
+
+    outer_trace = nnx_tracers.current_jax_trace()
+    original_current_jax_trace = nnx_tracers.current_jax_trace
+    nnx_tracers.current_jax_trace = lambda: outer_trace
+    try:
+        yield
+    finally:
+        nnx_tracers.current_jax_trace = original_current_jax_trace
 
 
 def should_shard_at_init(init_layout, shape):
@@ -472,9 +508,12 @@ def compute_output_spec(fn, *args, **kwargs):
             convert_keras_tensor_to_jax,
             (maybe_symbolic_args, maybe_symbolic_kwargs),
         )
-        jax_out = jax.eval_shape(
-            wrapped_fn, *maybe_symbolic_args_jax, **maybe_symbolic_kwargs_jax
-        )
+        with _nnx_stateful_trace_scope():
+            jax_out = jax.eval_shape(
+                wrapped_fn,
+                *maybe_symbolic_args_jax,
+                **maybe_symbolic_kwargs_jax,
+            )
 
         def convert_jax_spec_to_keras_tensor(x):
             if isinstance(x, jax.ShapeDtypeStruct):

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -97,12 +97,8 @@ Variable = JaxVariable
 if config.is_nnx_enabled():
     from flax import nnx
 
-    # `nnx.Variable` kept its value in a `raw_value` slot up to flax 0.11.
-    # In flax 0.12 it moved to `_raw_value`, and `raw_value` became a
-    # deprecated property whose setter enforces NNX's trace-level check.
-    # Keras assigns variable values itself (eagerly, or through a
-    # `StatelessScope` under JAX transforms), so it reads and writes that
-    # storage directly, as it did before the property existed.
+    # fallback logic for NNX Variable's raw_value attribute. This is needed for
+    # compatibility with older versions of NNX that don't have get_raw_value().
     _NNX_RAW_VALUE_ATTR = (
         "_raw_value" if hasattr(nnx.Variable, "get_raw_value") else "raw_value"
     )
@@ -113,11 +109,8 @@ if config.is_nnx_enabled():
     def _set_raw_value(variable, value):
         object.__setattr__(variable, _NNX_RAW_VALUE_ATTR, value)
 
-    # Trace levels enclosing Keras's symbolic shape inference, innermost
-    # last. `compute_output_spec` runs `call()` under `jax.eval_shape`,
-    # which may create layers and variables as a side effect. NNX stamps
-    # every object with the trace that was active when it was created and
-    # refuses to mutate it from any other trace. Objects created this way
+    # NNX stamps every object with the trace that was active when it was created 
+    # and refuses to mutate it from any other trace. Objects created this way
     # outlive the shape-inference trace and hold concrete values, so they
     # are stamped with the enclosing trace instead: once inference
     # returns, they behave exactly like eagerly created objects.

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -1,3 +1,4 @@
+import contextlib
 import inspect
 import math
 
@@ -96,6 +97,45 @@ Variable = JaxVariable
 if config.is_nnx_enabled():
     from flax import nnx
 
+    # `nnx.Variable` kept its value in a `raw_value` slot up to flax 0.11.
+    # In flax 0.12 it moved to `_raw_value`, and `raw_value` became a
+    # deprecated property whose setter enforces NNX's trace-level check.
+    # Keras assigns variable values itself (eagerly, or through a
+    # `StatelessScope` under JAX transforms), so it reads and writes that
+    # storage directly, as it did before the property existed.
+    _NNX_RAW_VALUE_ATTR = (
+        "_raw_value" if hasattr(nnx.Variable, "get_raw_value") else "raw_value"
+    )
+
+    def _get_raw_value(variable):
+        return getattr(variable, _NNX_RAW_VALUE_ATTR, None)
+
+    def _set_raw_value(variable, value):
+        object.__setattr__(variable, _NNX_RAW_VALUE_ATTR, value)
+
+    # Trace levels enclosing Keras's symbolic shape inference, innermost
+    # last. `compute_output_spec` runs `call()` under `jax.eval_shape`,
+    # which may create layers and variables as a side effect. NNX stamps
+    # every object with the trace that was active when it was created and
+    # refuses to mutate it from any other trace. Objects created this way
+    # outlive the shape-inference trace and hold concrete values, so they
+    # are stamped with the enclosing trace instead: once inference
+    # returns, they behave exactly like eagerly created objects.
+    _enclosing_traces = []
+
+    def stamp_with_enclosing_trace(obj):
+        """Stamp an NNX object with the trace enclosing shape inference."""
+        if not _enclosing_traces:
+            return
+        trace_state = getattr(obj, "_trace_state", None)  # nnx.Variable
+        if trace_state is None:  # nnx.Module, via its state object
+            for attr_value in vars(obj).values():
+                trace_state = getattr(attr_value, "_trace_state", None)
+                if trace_state is not None:
+                    break
+        if trace_state is not None:
+            object.__setattr__(trace_state, "_jax_trace", _enclosing_traces[0])
+
     class NnxVariable(JaxVariable, nnx.Variable):
         def __init__(
             self,
@@ -141,7 +181,9 @@ if config.is_nnx_enabled():
             )
 
             # The real value is now set in self._value, sync it to raw_value
-            object.__setattr__(self, "raw_value", self._value)
+            _set_raw_value(self, self._value)
+
+            stamp_with_enclosing_trace(self)
 
         def _initialize_with_initializer(self, initializer):
             value = self._convert_to_tensor(
@@ -151,9 +193,7 @@ if config.is_nnx_enabled():
 
         @property
         def _value(self):
-            if hasattr(self, "raw_value"):
-                return self.raw_value
-            return None
+            return _get_raw_value(self)
 
         @_value.setter
         def _value(self, new_keras_value):
@@ -173,8 +213,8 @@ if config.is_nnx_enabled():
 
             # Merge them. Keras state is primary. NNX specific state adds
             # to it.
-            if "raw_value" in nnx_specific_state:
-                keras_state["_value"] = nnx_specific_state["raw_value"]
+            if _NNX_RAW_VALUE_ATTR in nnx_specific_state:
+                keras_state["_value"] = nnx_specific_state[_NNX_RAW_VALUE_ATTR]
 
             # Add NNX attributes that are not in Keras's __dict__
             if "_trace_state" in nnx_specific_state:
@@ -186,7 +226,7 @@ if config.is_nnx_enabled():
 
             # Remove elements that might be problematic or redundant if
             # nnx.Variable's __getstate__
-            keras_state.pop("raw_value", None)
+            keras_state.pop(_NNX_RAW_VALUE_ATTR, None)
 
             return keras_state
 
@@ -202,7 +242,7 @@ if config.is_nnx_enabled():
             self.__dict__.update(state)
 
             # restore the nnx.Variable specific slotted attributes.
-            object.__setattr__(self, "raw_value", nnx_raw_value)
+            _set_raw_value(self, nnx_raw_value)
 
             if nnx_trace_state is not None:
                 object.__setattr__(self, "_trace_state", nnx_trace_state)
@@ -222,7 +262,7 @@ if config.is_nnx_enabled():
                 self._ndim = len(self._shape)
             else:
                 # Fallback if shape isn't immediately available.
-                self._ndim = len(self.raw_value.shape)
+                self._ndim = len(_get_raw_value(self).shape)
 
         def _direct_assign(self, value):
             # Apply JAX-specific distribution if layout is present
@@ -238,7 +278,7 @@ if config.is_nnx_enabled():
 
             # Set the value for both Keras and NNX parts
             # This ensures both systems see the same value
-            object.__setattr__(self, "raw_value", value)
+            _set_raw_value(self, value)
 
         @property
         def value(self):
@@ -247,7 +287,8 @@ if config.is_nnx_enabled():
                 stateless_value = scope.get_current_value(self)
                 if stateless_value is not None:
                     return self._maybe_autocast(stateless_value)
-            if getattr(self, "raw_value", None) is None:
+            current_value = _get_raw_value(self)
+            if current_value is None:
                 # Uninitialized variable (created under a stateless scope,
                 # which defers initialization). Return a placeholder, like
                 # `KerasVariable.value`, without mutating the variable.
@@ -260,7 +301,6 @@ if config.is_nnx_enabled():
                         "Variable is not properly initialized (raw_value "
                         "missing) and has no initializer."
                     )
-            current_value = self.raw_value
             if (
                 hasattr(self, "_var_metadata")
                 and "on_get_value" in self._var_metadata
@@ -273,12 +313,12 @@ if config.is_nnx_enabled():
     Variable = NnxVariable
 
     def _flatten_nnx_variable(variable):
-        children = (variable.raw_value,)
+        children = (_get_raw_value(variable),)
         # We copy __dict__ to avoid side effects
         keras_state = variable.__dict__.copy()
         # Remove elements that might be problematic or redundant if
         # nnx.Variable's __getstate__
-        keras_state.pop("raw_value", None)
+        keras_state.pop(_NNX_RAW_VALUE_ATTR, None)
         aux_data = (
             variable._var_metadata,
             getattr(variable, "_trace_state", None),
@@ -298,7 +338,7 @@ if config.is_nnx_enabled():
         if trace_state is not None:
             variable._trace_state = trace_state
         variable.__dict__.update(keras_state)
-        variable.raw_value = raw_value
+        _set_raw_value(variable, raw_value)
 
         return variable
 
@@ -316,7 +356,7 @@ if config.is_nnx_enabled():
         # if the Pytree registration is not respected by NNX.
         if (
             name != "_var_metadata"
-            and name not in ("_raw_value", "_trace_state")
+            and name not in ("raw_value", "_raw_value", "_trace_state")
             and hasattr(self, "_var_metadata")
         ):
             self._var_metadata[name] = value
@@ -390,9 +430,24 @@ def cast(x, dtype):
     return convert_to_tensor(x, dtype=dtype)
 
 
+@contextlib.contextmanager
+def _track_enclosing_trace():
+    """Record the trace enclosing symbolic shape inference, for NNX."""
+    if not config.is_nnx_enabled():
+        yield
+        return
+    from flax.nnx import tracers as nnx_tracers
+
+    _enclosing_traces.append(nnx_tracers.current_jax_trace())
+    try:
+        yield
+    finally:
+        _enclosing_traces.pop()
+
+
 # Shape / dtype / sparseness inference util
 def compute_output_spec(fn, *args, **kwargs):
-    with StatelessScope(), SymbolicScope():
+    with _track_enclosing_trace(), StatelessScope(), SymbolicScope():
         built_in_types = (type(None), int, float, str, bool, complex, bytes)
 
         # First, separate symbolic args from other args

--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -109,7 +109,7 @@ if config.is_nnx_enabled():
     def _set_raw_value(variable, value):
         object.__setattr__(variable, _NNX_RAW_VALUE_ATTR, value)
 
-    # NNX stamps every object with the trace that was active when it was created 
+    # NNX stamps every object with the trace that was active when it was created
     # and refuses to mutate it from any other trace. Objects created this way
     # outlive the shape-inference trace and hold concrete values, so they
     # are stamped with the enclosing trace instead: once inference

--- a/keras/src/backend/jax/core_test.py
+++ b/keras/src/backend/jax/core_test.py
@@ -66,3 +66,53 @@ class NnxVariableTest(testing.TestCase):
         state = jax.tree.map(lambda x: x + 1, state)
         variable2 = nnx.merge(graphdef, state)
         self.assertEqual(variable2._value, variable2.value)
+
+    def test_lazy_build_within_symbolic_trace(self):
+        # A layer without a `build()` method forces Keras to build it by
+        # running `call()` inside `jax.eval_shape` for shape inference.
+        # Sublayers created eagerly are then mutated (built) inside that
+        # trace, and their variables are created inside it. NNX forbids
+        # cross-trace mutation, which used to raise TraceContextError.
+        # See https://github.com/keras-team/keras/issues/23289.
+        class InnerNorm(keras.layers.Layer):
+            def build(self, input_shape):
+                self.weight = self.add_weight(
+                    name="weight",
+                    shape=(input_shape[-1],),
+                    initializer="ones",
+                )
+                self.built = True
+
+            def call(self, x):
+                return self.weight * x
+
+        class OuterBlock(keras.layers.Layer):
+            # No `build()`: triggers build-by-run inside `jax.eval_shape`.
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.norm = InnerNorm()
+
+            def call(self, x):
+                return self.norm(x) + x
+
+        inputs = keras.Input(shape=(4,))
+        outputs = OuterBlock()(inputs)
+        model = keras.Model(inputs, outputs)
+
+        y = model(np.ones((2, 4), "float32"))
+        self.assertEqual(y.shape, (2, 4))
+
+        # Variables created inside the trace must stay mutable after it.
+        inner = model.layers[1].norm
+        inner.weight.assign(np.full((4,), 2.0, "float32"))
+        self.assertAllClose(inner.weight.value, np.full((4,), 2.0))
+
+        # Training exercises `_losses_override` assignment in the jitted
+        # train step and end-to-end gradient flow.
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(
+            np.ones((8, 4), "float32"),
+            np.zeros((8, 4), "float32"),
+            epochs=1,
+            verbose=0,
+        )

--- a/keras/src/backend/jax/core_test.py
+++ b/keras/src/backend/jax/core_test.py
@@ -68,12 +68,6 @@ class NnxVariableTest(testing.TestCase):
         self.assertEqual(variable2._value, variable2.value)
 
     def test_lazy_build_within_symbolic_trace(self):
-        # A layer without a `build()` method forces Keras to build it by
-        # running `call()` inside `jax.eval_shape` for shape inference.
-        # Sublayers created eagerly are then mutated (built) inside that
-        # trace, and their variables are created inside it. NNX forbids
-        # cross-trace mutation, which used to raise TraceContextError.
-        # See https://github.com/keras-team/keras/issues/23289.
         class InnerNorm(keras.layers.Layer):
             def build(self, input_shape):
                 self.weight = self.add_weight(

--- a/keras/src/backend/jax/core_test.py
+++ b/keras/src/backend/jax/core_test.py
@@ -101,6 +101,18 @@ class NnxVariableTest(testing.TestCase):
         inner.weight.assign(np.full((4,), 2.0, "float32"))
         self.assertAllClose(inner.weight.value, np.full((4,), 2.0))
 
+        # They must also look like eagerly created objects to NNX, or its
+        # transforms cannot write back into them once tracing is over.
+        # The layer's trace state lives on its NNX state object, which is
+        # named differently across flax versions.
+        self.assertTrue(inner.weight._trace_state.is_valid())
+        layer_state = next(
+            state
+            for state in vars(inner).values()
+            if hasattr(state, "_trace_state")
+        )
+        self.assertTrue(layer_state._trace_state.is_valid())
+
         # Training exercises `_losses_override` assignment in the jitted
         # train step and end-to-end gradient flow.
         model.compile(optimizer="sgd", loss="mse")

--- a/keras/src/backend/jax/layer.py
+++ b/keras/src/backend/jax/layer.py
@@ -1,3 +1,4 @@
+from keras.src.backend.common.symbolic_scope import in_symbolic_scope
 from keras.src.backend.config import is_nnx_enabled
 
 if is_nnx_enabled():
@@ -6,6 +7,19 @@ if is_nnx_enabled():
     class BaseLayer(nnx.Module):
         def __init_subclass__(cls, **kwargs):
             super().__init_subclass__(pytree=False, **kwargs)
+
+        def __init__(self, *args, **kwargs):
+            object.__setattr__(
+                self, "_created_in_symbolic_scope", in_symbolic_scope()
+            )
+            super().__init__(*args, **kwargs)
+
+        def _check_valid_context(self, error_msg):
+            if in_symbolic_scope() or getattr(
+                self, "_created_in_symbolic_scope", False
+            ):
+                return
+            super()._check_valid_context(error_msg)
 else:
     BaseLayer = object
 

--- a/keras/src/backend/jax/layer.py
+++ b/keras/src/backend/jax/layer.py
@@ -16,8 +16,8 @@ if is_nnx_enabled():
 
         def _check_valid_context(self, error_msg):
             # NNX forbids mutating an object from a trace level other than
-            # the one it was created at. These mutations are safe, since 
-            # initializers only see concrete shapes and only shapes escape 
+            # the one it was created at. These mutations are safe, since
+            # initializers only see concrete shapes and only shapes escape
             # the trace.
             if in_symbolic_scope():
                 return

--- a/keras/src/backend/jax/layer.py
+++ b/keras/src/backend/jax/layer.py
@@ -16,12 +16,9 @@ if is_nnx_enabled():
 
         def _check_valid_context(self, error_msg):
             # NNX forbids mutating an object from a trace level other than
-            # the one it was created at. Keras infers shapes by running
-            # `call()` under `jax.eval_shape`, which builds layers as a
-            # side effect: it creates sublayers and variables and sets
-            # attributes on layers created outside the trace. These
-            # mutations are safe, since initializers only see concrete
-            # shapes and only shapes escape the trace.
+            # the one it was created at. These mutations are safe, since 
+            # initializers only see concrete shapes and only shapes escape 
+            # the trace.
             if in_symbolic_scope():
                 return
             super()._check_valid_context(error_msg)

--- a/keras/src/backend/jax/layer.py
+++ b/keras/src/backend/jax/layer.py
@@ -9,15 +9,20 @@ if is_nnx_enabled():
             super().__init_subclass__(pytree=False, **kwargs)
 
         def __init__(self, *args, **kwargs):
-            object.__setattr__(
-                self, "_created_in_symbolic_scope", in_symbolic_scope()
-            )
             super().__init__(*args, **kwargs)
+            from keras.src.backend.jax.core import stamp_with_enclosing_trace
+
+            stamp_with_enclosing_trace(self)
 
         def _check_valid_context(self, error_msg):
-            if in_symbolic_scope() or getattr(
-                self, "_created_in_symbolic_scope", False
-            ):
+            # NNX forbids mutating an object from a trace level other than
+            # the one it was created at. Keras infers shapes by running
+            # `call()` under `jax.eval_shape`, which builds layers as a
+            # side effect: it creates sublayers and variables and sets
+            # attributes on layers created outside the trace. These
+            # mutations are safe, since initializers only see concrete
+            # shapes and only shapes escape the trace.
+            if in_symbolic_scope():
                 return
             super()._check_valid_context(error_msg)
 else:

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1631,13 +1631,21 @@ class Layer(BackendLayer, Operation):
                 self._initialize_tracker()
             value = self._tracker.track(value)
 
-        # NNX-specific bypass for Keras-internal bookkeeping attributes that
-        # may be set during a traced call (e.g. inside the jitted train step):
-        # bypass nnx.Module.__setattr__ which cannot be called while tracing.
+        # NNX-specific bypass for Keras-internal bookkeeping attributes:
+        # some are set during a traced call (e.g. inside the jitted train
+        # step), which nnx.Module.__setattr__ forbids, and
+        # `_compiled_trainable_state` is a dict keyed by layer objects,
+        # which flax's attribute scanning cannot process.
         if (
             backend.backend() == "jax"
             and is_nnx_enabled()
-            and name in ("_called", "built", "_losses_override")
+            and name
+            in (
+                "_called",
+                "built",
+                "_losses_override",
+                "_compiled_trainable_state",
+            )
         ):
             object.__setattr__(self, name, value)
             return

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1631,12 +1631,13 @@ class Layer(BackendLayer, Operation):
                 self._initialize_tracker()
             value = self._tracker.track(value)
 
-        # NNX-specific bypass for `_called` and `built` attributes
-        # bypass nnx.Module.__setattr__ which cannot be called while tracing
+        # NNX-specific bypass for Keras-internal bookkeeping attributes that
+        # may be set during a traced call (e.g. inside the jitted train step):
+        # bypass nnx.Module.__setattr__ which cannot be called while tracing.
         if (
             backend.backend() == "jax"
             and is_nnx_enabled()
-            and (name == "_called" or name == "built")
+            and name in ("_called", "built", "_losses_override")
         ):
             object.__setattr__(self, name, value)
             return


### PR DESCRIPTION
## Description
Fixes #23289

NNX records the JAX trace active when an object is created and rejects any later mutation from a different trace level, so building inside `eval_shape` causes trace context error. T5 backbone encounters this error because it does not have a build method.

- Skip the trace-level check while Keras is doing symbolic shape inference. initializers only ever see shapes and dtypes, and only shapes escape the trace.
- Stamp layers and variables created during shape inference with the trace that encloses it, so once inference returns they behave like eagerly created objects. Without this, they stay pinned to a trace that no longer exists and `nnx.jit` can no longer write back into them.
- Read/write `nnx.Variable`'s underlying storage directly. flax 0.12 moved it from the `raw_value` slot to `_raw_value` behind a checked property; handle both.
- Bypass `nnx.Module.__setattr__` for `_losses_override` (assigned inside the jitted train step, which broke `fit()` for models with `add_loss`) and `_compiled_trainable_state` (a dict keyed by layer objects that flax 0.12 can't scan).
- Return an initializer placeholder from `NnxVariable.value` when the variable is uninitialized, matching `KerasVariable.value`, instead of passing `None` to `jnp.array`.


Repro and fix : https://colab.sandbox.google.com/drive/1fiQ9Gih7J9PUowHkhqYA20C1KB_193wC#scrollTo=R-sgx39sgd-m

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
