### PR TITLE
Fix torch.compile graph break in torch backend's dot_product_attention

### DIFF
--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1450,15 +1450,15 @@ def _can_use_flash_attention(
 ):
     """Verify the availability of flash attention."""
     if (
-        hasattr(torch.compiler, "is_compiling")
+        not raise_error
+        and hasattr(torch.compiler, "is_compiling")
         and torch.compiler.is_compiling()
     ):
         # The probe below constructs a pybind11 `SDPAParams` object, which
-        # dynamo cannot trace, so running it would break the graph at every
-        # attention call. `raise_error` is deliberately not honored here:
-        # dynamo discards an exception raised while tracing and silently
-        # re-runs the frame eagerly, which skips this branch and leaves the
-        # frame uncompiled.
+        # dynamo cannot trace, so it breaks the graph at every attention call.
+        # Skipping it is safe: `scaled_dot_product_attention` still selects the
+        # flash kernel when the inputs allow. Auto-detection only, so an
+        # explicit `flash_attention=True` still reports an unsupported input.
         return False
 
     try:

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1449,6 +1449,18 @@ def _can_use_flash_attention(
     query, key, value, mask=None, is_causal=False, raise_error=False
 ):
     """Verify the availability of flash attention."""
+    if (
+        hasattr(torch.compiler, "is_compiling")
+        and torch.compiler.is_compiling()
+    ):
+        # The probe below constructs a pybind11 `SDPAParams` object, which
+        # dynamo cannot trace, so running it would break the graph at every
+        # attention call. `raise_error` is deliberately not honored here:
+        # dynamo discards an exception raised while tracing and silently
+        # re-runs the frame eagerly, which skips this branch and leaves the
+        # frame uncompiled.
+        return False
+
     try:
         from torch.backends.cuda import SDPAParams
         from torch.backends.cuda import can_use_flash_attention
@@ -1552,25 +1564,6 @@ def dot_product_attention(
         value = torch.repeat_interleave(value, repeats=groups, dim=1)
 
     if flash_attention is None:
-        if (
-            hasattr(torch.compiler, "is_compiling")
-            and torch.compiler.is_compiling()
-        ):
-            # Probing for flash-attention support constructs a pybind11
-            # `SDPAParams` object, which dynamo cannot trace, so under
-            # `torch.compile` the probe breaks the graph at every attention
-            # call and costs far more than picking the kernel from Python
-            # saves. Defer the choice to `scaled_dot_product_attention`, which
-            # already dispatches to the fastest kernel its inputs allow.
-            attention_output = torch.nn.functional.scaled_dot_product_attention(
-                query,
-                key,
-                value,
-                attn_mask=mask,
-                is_causal=is_causal,
-                scale=scale,
-            )
-            return torch.transpose(attention_output, axis1, axis0)
         flash_attention = _can_use_flash_attention(
             query, key, value, mask, is_causal
         )

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1451,6 +1451,18 @@ def _can_use_flash_attention(
     query, key, value, mask=None, is_causal=False, raise_error=False
 ):
     """Verify the availability of flash attention."""
+    if (
+        hasattr(torch.compiler, "is_compiling")
+        and torch.compiler.is_compiling()
+    ):
+        # The probe below constructs a pybind11 `SDPAParams` object, which
+        # dynamo cannot trace, so running it would break the graph at every
+        # attention call. `raise_error` is deliberately not honored here:
+        # dynamo discards an exception raised while tracing and silently
+        # re-runs the frame eagerly, which skips this branch and leaves the
+        # frame uncompiled.
+        return False
+
     try:
         from torch.backends.cuda import SDPAParams
         from torch.backends.cuda import can_use_flash_attention
@@ -1554,25 +1566,6 @@ def dot_product_attention(
         value = torch.repeat_interleave(value, repeats=groups, dim=1)
 
     if flash_attention is None:
-        if (
-            hasattr(torch.compiler, "is_compiling")
-            and torch.compiler.is_compiling()
-        ):
-            # Probing for flash-attention support constructs a pybind11
-            # `SDPAParams` object, which dynamo cannot trace, so under
-            # `torch.compile` the probe breaks the graph at every attention
-            # call and costs far more than picking the kernel from Python
-            # saves. Defer the choice to `scaled_dot_product_attention`, which
-            # already dispatches to the fastest kernel its inputs allow.
-            attention_output = torch.nn.functional.scaled_dot_product_attention(
-                query,
-                key,
-                value,
-                attn_mask=mask,
-                is_causal=is_causal,
-                scale=scale,
-            )
-            return torch.transpose(attention_output, axis1, axis0)
         flash_attention = _can_use_flash_attention(
             query, key, value, mask, is_causal
         )

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1452,15 +1452,15 @@ def _can_use_flash_attention(
 ):
     """Verify the availability of flash attention."""
     if (
-        hasattr(torch.compiler, "is_compiling")
+        not raise_error
+        and hasattr(torch.compiler, "is_compiling")
         and torch.compiler.is_compiling()
     ):
         # The probe below constructs a pybind11 `SDPAParams` object, which
-        # dynamo cannot trace, so running it would break the graph at every
-        # attention call. `raise_error` is deliberately not honored here:
-        # dynamo discards an exception raised while tracing and silently
-        # re-runs the frame eagerly, which skips this branch and leaves the
-        # frame uncompiled.
+        # dynamo cannot trace, so it breaks the graph at every attention call.
+        # Skipping it is safe: `scaled_dot_product_attention` still selects the
+        # flash kernel when the inputs allow. Auto-detection only, so an
+        # explicit `flash_attention=True` still reports an unsupported input.
         return False
 
     try:

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1554,8 +1554,9 @@ def dot_product_attention(
         value = torch.repeat_interleave(value, repeats=groups, dim=1)
 
     if flash_attention is None:
-        if hasattr(torch.compiler, "is_compiling") and (
-            torch.compiler.is_compiling()
+        if (
+            hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
         ):
             # Probing for flash-attention support constructs a pybind11
             # `SDPAParams` object, which dynamo cannot trace, so under

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1554,6 +1554,24 @@ def dot_product_attention(
         value = torch.repeat_interleave(value, repeats=groups, dim=1)
 
     if flash_attention is None:
+        if hasattr(torch.compiler, "is_compiling") and (
+            torch.compiler.is_compiling()
+        ):
+            # Probing for flash-attention support constructs a pybind11
+            # `SDPAParams` object, which dynamo cannot trace, so under
+            # `torch.compile` the probe breaks the graph at every attention
+            # call and costs far more than picking the kernel from Python
+            # saves. Defer the choice to `scaled_dot_product_attention`, which
+            # already dispatches to the fastest kernel its inputs allow.
+            attention_output = torch.nn.functional.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=mask,
+                is_causal=is_causal,
+                scale=scale,
+            )
+            return torch.transpose(attention_output, axis1, axis0)
         flash_attention = _can_use_flash_attention(
             query, key, value, mask, is_causal
         )

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1552,6 +1552,24 @@ def dot_product_attention(
         value = torch.repeat_interleave(value, repeats=groups, dim=1)
 
     if flash_attention is None:
+        if hasattr(torch.compiler, "is_compiling") and (
+            torch.compiler.is_compiling()
+        ):
+            # Probing for flash-attention support constructs a pybind11
+            # `SDPAParams` object, which dynamo cannot trace, so under
+            # `torch.compile` the probe breaks the graph at every attention
+            # call and costs far more than picking the kernel from Python
+            # saves. Defer the choice to `scaled_dot_product_attention`, which
+            # already dispatches to the fastest kernel its inputs allow.
+            attention_output = torch.nn.functional.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=mask,
+                is_causal=is_causal,
+                scale=scale,
+            )
+            return torch.transpose(attention_output, axis1, axis0)
         flash_attention = _can_use_flash_attention(
             query, key, value, mask, is_causal
         )

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1552,8 +1552,9 @@ def dot_product_attention(
         value = torch.repeat_interleave(value, repeats=groups, dim=1)
 
     if flash_attention is None:
-        if hasattr(torch.compiler, "is_compiling") and (
-            torch.compiler.is_compiling()
+        if (
+            hasattr(torch.compiler, "is_compiling")
+            and torch.compiler.is_compiling()
         ):
             # Probing for flash-attention support constructs a pybind11
             # `SDPAParams` object, which dynamo cannot trace, so under

--- a/keras/src/backend/torch/nn_test.py
+++ b/keras/src/backend/torch/nn_test.py
@@ -23,11 +23,8 @@ class DotProductAttentionCompileTest(testing.TestCase):
         )
 
     def test_compiles_without_graph_break(self):
-        # `_can_use_flash_attention` builds a pybind11 `SDPAParams` object to
-        # probe kernel support, and dynamo cannot trace pybind11 constructors,
-        # so running the probe while tracing splits the graph at every
-        # attention call. `fullgraph=True` turns that into an error, which is
-        # what makes this a regression test rather than a smoke test.
+        # `fullgraph=True` turns a graph break into an error, which is what
+        # makes this a regression test rather than a smoke test.
         query, key, value = self._qkv()
 
         def attend():
@@ -39,7 +36,6 @@ class DotProductAttentionCompileTest(testing.TestCase):
     def test_compiled_matches_eager(self):
         query, key, value = self._qkv()
         rng = np.random.default_rng(1)
-        # A mask must broadcast to (batch, heads, q_len, kv_len).
         mask = ops.convert_to_tensor(
             rng.integers(0, 2, (2, 1, 16, 16)).astype("bool")
         )

--- a/keras/src/backend/torch/nn_test.py
+++ b/keras/src/backend/torch/nn_test.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 import torch
+from absl.testing import parameterized
 
 from keras.src import backend
 from keras.src import ops
@@ -22,37 +23,34 @@ class DotProductAttentionCompileTest(testing.TestCase):
             for _ in range(3)
         )
 
-    def test_compiles_without_graph_break(self):
-        # `fullgraph=True` turns a graph break into an error, which is what
-        # makes this a regression test rather than a smoke test.
+    @parameterized.named_parameters(
+        ("no_options", False, False, False, None),
+        ("is_causal", True, False, False, None),
+        ("mask", False, True, False, None),
+        ("mask_and_is_causal", True, True, False, None),
+        ("bias", False, False, True, None),
+        ("scale", False, False, False, 0.125),
+    )
+    def test_compiled_matches_eager(self, is_causal, use_mask, use_bias, scale):
         query, key, value = self._qkv()
-
-        def attend():
-            return ops.dot_product_attention(query, key, value, is_causal=True)
-
-        compiled = torch.compile(attend, fullgraph=True)
-        self.assertAllClose(compiled(), attend())
-
-    def test_compiled_matches_eager(self):
-        query, key, value = self._qkv()
+        kwargs = {"is_causal": is_causal}
+        if scale is not None:
+            kwargs["scale"] = scale
         rng = np.random.default_rng(1)
-        mask = ops.convert_to_tensor(
-            rng.integers(0, 2, (2, 1, 16, 16)).astype("bool")
+        # `mask` and `bias` must broadcast to (batch, heads, q_len, kv_len).
+        if use_mask:
+            kwargs["mask"] = ops.convert_to_tensor(
+                rng.integers(0, 2, (2, 1, 16, 16)).astype("bool")
+            )
+        if use_bias:
+            kwargs["bias"] = ops.convert_to_tensor(
+                rng.standard_normal((2, 1, 16, 16)).astype("float32")
+            )
+
+        # `fullgraph=True` turns a graph break into an error, so this also
+        # covers the untraceable flash attention probe regressing back in.
+        compiled = torch.compile(ops.dot_product_attention, fullgraph=True)
+        self.assertAllClose(
+            compiled(query, key, value, **kwargs),
+            ops.dot_product_attention(query, key, value, **kwargs),
         )
-        bias = ops.convert_to_tensor(
-            rng.standard_normal((2, 1, 16, 16)).astype("float32")
-        )
-
-        for kwargs in (
-            {},
-            {"is_causal": True},
-            {"mask": mask},
-            {"mask": mask, "is_causal": True},
-            {"bias": bias},
-            {"scale": 0.125},
-        ):
-
-            def attend(kwargs=kwargs):
-                return ops.dot_product_attention(query, key, value, **kwargs)
-
-            self.assertAllClose(torch.compile(attend)(), attend())

--- a/keras/src/backend/torch/nn_test.py
+++ b/keras/src/backend/torch/nn_test.py
@@ -1,0 +1,62 @@
+"""Tests for PyTorch backend nn utilities."""
+
+import numpy as np
+import pytest
+import torch
+
+from keras.src import backend
+from keras.src import ops
+from keras.src import testing
+
+
+@pytest.mark.skipif(
+    backend.backend() != "torch",
+    reason="This test is only applicable to the PyTorch backend.",
+)
+class DotProductAttentionCompileTest(testing.TestCase):
+    def _qkv(self, batch=2, seq=16, heads=4, head_dim=8):
+        rng = np.random.default_rng(0)
+        shape = (batch, seq, heads, head_dim)
+        return tuple(
+            ops.convert_to_tensor(rng.standard_normal(shape).astype("float32"))
+            for _ in range(3)
+        )
+
+    def test_compiles_without_graph_break(self):
+        # `_can_use_flash_attention` builds a pybind11 `SDPAParams` object to
+        # probe kernel support, and dynamo cannot trace pybind11 constructors,
+        # so running the probe while tracing splits the graph at every
+        # attention call. `fullgraph=True` turns that into an error, which is
+        # what makes this a regression test rather than a smoke test.
+        query, key, value = self._qkv()
+
+        def attend():
+            return ops.dot_product_attention(query, key, value, is_causal=True)
+
+        compiled = torch.compile(attend, fullgraph=True)
+        self.assertAllClose(compiled(), attend())
+
+    def test_compiled_matches_eager(self):
+        query, key, value = self._qkv()
+        rng = np.random.default_rng(1)
+        # A mask must broadcast to (batch, heads, q_len, kv_len).
+        mask = ops.convert_to_tensor(
+            rng.integers(0, 2, (2, 1, 16, 16)).astype("bool")
+        )
+        bias = ops.convert_to_tensor(
+            rng.standard_normal((2, 1, 16, 16)).astype("float32")
+        )
+
+        for kwargs in (
+            {},
+            {"is_causal": True},
+            {"mask": mask},
+            {"mask": mask, "is_causal": True},
+            {"bias": bias},
+            {"scale": 0.125},
+        ):
+
+            def attend(kwargs=kwargs):
+                return ops.dot_product_attention(query, key, value, **kwargs)
+
+            self.assertAllClose(torch.compile(attend)(), attend())


### PR DESCRIPTION
## Summary

`torch.compile` cannot trace the flash attention probe in the torch backend's
`dot_product_attention`, so it breaks the graph at every attention call. On a
six-layer transformer forward pass this produces 19 graph breaks and 20 separate
graphs.

`MultiHeadAttention` routes through `ops.dot_product_attention` when dropout is
0, attention scores are not returned, and inputs are 4D — the default path for
most models.

## Root cause

`dot_product_attention` calls `_can_use_flash_attention` when `flash_attention`
is `None` (the default), and again with `raise_error=True` when it is explicitly
`True`. That helper constructs a pybind11 `SDPAParams` object to probe kernel
support:

```python
spda_params = SDPAParams(query, key, value, mask, 0.0, is_causal, False)
```

Dynamo cannot trace a pybind11 constructor, so tracing stops there and resumes
afterwards — once per attention call.

## Change

Report flash attention as unavailable while tracing, so the probe is never
reached and the call takes its ordinary non-flash branch. `scaled_dot_product_attention`
then selects the kernel through its own dispatcher, which is what it does on the
non-flash branch already. `dot_product_attention` itself is unchanged — the whole
change is a 12-line early return at the top of `_can_use_flash_attention`.

**This applies to auto-detection only.** An explicit `flash_attention=True` still
runs the probe, still breaks the graph, and still raises
`Flash attention is not supported with the provided inputs` — deliberately. Making
the guard raise instead does not work: dynamo discards an exception raised while
tracing and re-runs the frame eagerly, where `is_compiling()` is `False`, so the
message never reaches the user and the frame is de-optimized rather than split.

Eager is unchanged by construction: `torch.compiler.is_compiling()` is `False`
outside `torch.compile`, so the probe and the pinned flash-attention kernel
context still run exactly as before.

## Results

`torch._dynamo.explain`, float32 unless noted. These counts are deterministic,
and are identical on an RTX 4050 (sm_89, torch 2.13.0+cu130) and an RTX PRO 6000
Blackwell (sm_120, torch 2.13.0+cu132):

| `flash_attention` | | graphs | breaks | ops captured |
|---|---|---|---|---|
| `None` (default) | before | 20 | 19 | 178 |
| `None` (default) | after | **1** | **0** | **367** |
| `True` | before | 2 | 1 | 16 |
| `True` | after | 2 | 1 | 16 |

Op count rises because a fragmented graph only captures a fraction of the model;
with one graph, dynamo captures all of it.

The `None` rows are the six-layer model below. The `True` rows are a single
`ops.dot_product_attention` call in float16, since float32 with
`flash_attention=True` raises on both master and this branch.

<details><summary>harness</summary>

```python
import keras, torch
from keras import layers
B, S, DM, H, LAYERS = 8, 128, 512, 8, 6
inp = keras.Input(shape=(S, DM)); x = inp
for _ in range(LAYERS):
    a = layers.MultiHeadAttention(num_heads=H, key_dim=DM // H)(x, x)
    x = layers.LayerNormalization()(x + a)
    f = layers.Dense(DM * 2, activation="relu")(x)
    x = layers.LayerNormalization()(x + layers.Dense(DM)(f))
model = keras.Model(inp, x).to("cuda")
t = torch.randn(B, S, DM, device="cuda")
print(torch._dynamo.explain(lambda z: model(z, training=False))(t))
```
</details>

Wall clock for the same six-layer forward, float32, on the RTX PRO 6000
Blackwell. Median of 8 A/B pairs with the order alternated per pair, each pair
30 repeats of 20 iterations timed with CUDA events. Running the base against an
identical checkout of itself measures run-to-run noise at 1.7% eager and 7.6%
compiled, putting the significance threshold at 2.5% and 11.4% respectively:

| | eager | compiled |
|---|---|---|
| before | 5.98 ms | 8.05 ms |
| after | 5.98 ms | **0.98 ms** |

Compiled is 8.2x faster, all 8 pairs agreeing in direction, 1.03x spread across
them. Eager lands at 1.005x, inside its threshold. Before this change,
`torch.compile` makes this model slower than its own eager forward.

## Behavior

Kernel dispatch is unchanged. Measured across fp16 / bf16 / fp32, with and without
a mask, and at head_dim 64, 128 and 320, the kernel selected by
`scaled_dot_product_attention` is identical to master in every case, in both eager
and compiled mode. On sm_120 that spans 72 configurations, with no difference in
any of them.

Under compile the auto-detect path no longer pins the kernel via
`sdpa_kernel([FLASH_ATTENTION])`, leaving the selection to the dispatcher. Where
the dispatcher lands on the kernel the pin would have chosen, output is
bit-identical: on sm_120, `max|compiled − eager|` is exactly 0.0 across 18
configurations spanning fp32 / fp16 / bf16, head_dim 64 and 128, plain, masked
and causal. Where it lands elsewhere the two can differ slightly; on sm_89 fp16
shows about 1.2e-04 and fp32 about 6e-08.

## Tests

`keras/src/backend/torch/nn_test.py` adds one parameterized test that compiles
`ops.dot_product_attention` with `fullgraph=True`, so a graph break becomes an
error, and compares against eager across six argument shapes: plain, causal,
masked, masked-and-causal, bias, and custom scale.

All six fail against master and pass with this change, both on a CPU-only torch
build as CI runs it and on CUDA (sm_120).

Scope, stated honestly: the cases are float32 and `flash_attention=None`, so they
cover the auto-detect path only. Grouped-query inputs, explicit `flash_attention`
values, and the hardware-dependent flash-vs-dispatcher divergence above are not
covered, and CI runs CPU-only so the kernel-dispatch matrix is not covered there
either.

- [x]  I am a human, and not a bot.
- [x]  I will be responsible for responding to review comments in a timely manner.
- [x]  I will work with the maintainers to push this PR forward until submission.
