### PR TITLE
Fix NumPy normalization for axis=0 in the keras.utils.normalize

### DIFF
--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -28,7 +28,9 @@ def normalize(x, axis=-1, order=2):
         norm[norm == 0] = 1
 
         # axis cannot be `None`
-        axis = axis or -1
+        if axis is None:
+            axis = -1
+
         return x / np.expand_dims(norm, axis)
 
     # Backend tensor input

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -28,7 +28,7 @@ def normalize(x, axis=-1, order=2):
         norm[norm == 0] = 1
 
         # axis cannot be `None`
-        if axis is None:
+        if axis == None:
             axis = -1
 
         return x / np.expand_dims(norm, axis)

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -28,7 +28,7 @@ def normalize(x, axis=-1, order=2):
         norm[norm == 0] = 1
 
         # axis cannot be `None`
-        if axis == None:
+        if axis is None:
             axis = -1
 
         return x / np.expand_dims(norm, axis)

--- a/keras/src/utils/numerical_utils_test.py
+++ b/keras/src/utils/numerical_utils_test.py
@@ -93,7 +93,7 @@ class TestNumericalUtils(testing.TestCase):
         self.assertIsInstance(out, np.ndarray)
         self.assertEqual(out.shape, x.shape)
         self.assertAllClose(out, expected)
-    
+
     def test_build_pos_neg_masks(self):
         query_labels = np.array([0, 1, 2, 2, 0])
         key_labels = np.array([0, 1, 2, 0, 2])

--- a/keras/src/utils/numerical_utils_test.py
+++ b/keras/src/utils/numerical_utils_test.py
@@ -73,6 +73,27 @@ class TestNumericalUtils(testing.TestCase):
         self.assertTrue(backend.is_tensor(out))
         self.assertAllClose(backend.convert_to_numpy(out), expected)
 
+    def test_normalize_numpy_axis_zero(self):
+        x = np.array(
+            [
+                [3.0, 0.0, 12.0],
+                [4.0, 5.0, 0.0],
+            ]
+        )
+
+        expected = np.array(
+            [
+                [0.6, 0.0, 1.0],
+                [0.8, 1.0, 0.0],
+            ]
+        )
+
+        out = numerical_utils.normalize(x, axis=0)
+
+        self.assertIsInstance(out, np.ndarray)
+        self.assertEqual(out.shape, x.shape)
+        self.assertAllClose(out, expected)
+    
     def test_build_pos_neg_masks(self):
         query_labels = np.array([0, 1, 2, 2, 0])
         key_labels = np.array([0, 1, 2, 0, 2])


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->
the original normalize function handled everything correctly, except for when the value is 0, because python treats 0 the same 
way as false in this case:

(original)
`# axis cannot be None
axis = axis or -1
`
which can result in error, for example:

`
import numpy as np

import keras 
print(keras.__version__)
print(keras.__file__)

x = np.array([
    [3.0, 0.0, 12.0],
    [4.0, 5.0, 0.0],
])

print(keras.utils.normalize(x, axis=0))

`
outputs:
`
    return x / np.expand_dims(norm, axis)

           ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
ValueError: operands could not be broadcast together with shapes (2,3) (3,1) 
`
while it should be:
`
[[0.6 0.  1. ]
 [0.8 1.  0. ]]
`, 

The L2 norms along axis 0 are:

[5.0, 5.0, 12.0]

So, the expected output is:

[
    [0.6, 0.0, 1.0],
    [0.8, 1.0, 0.0],
]

Also added the 0 case in the tests

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
