### PR TITLE
Raise ValueError for out-of-bounds axis in LayerNormalization.build()

### DIFF
--- a/keras/src/layers/normalization/layer_normalization.py
+++ b/keras/src/layers/normalization/layer_normalization.py
@@ -5,6 +5,7 @@ from keras.src import initializers
 from keras.src import ops
 from keras.src import regularizers
 from keras.src.api_export import keras_export
+from keras.src.backend.common.backend_utils import canonicalize_axes
 from keras.src.layers.layer import Layer
 
 
@@ -150,28 +151,14 @@ class LayerNormalization(Layer):
         self.supports_masking = True
         self.autocast = False
 
-    def _validate_axis(self, input_shape):
-        if isinstance(self.axis, int):
-            axes = [self.axis]
-        else:
-            axes = self.axis
-
-        for axis in axes:
-            if axis >= len(input_shape) or axis < -len(input_shape):
-                raise ValueError(
-                    f"Axis {axis} is out of bounds for "
-                    f"input shape {input_shape}. "
-                    f"Received: axis={self.axis}"
-                )
-
     def build(self, input_shape):
-        self._validate_axis(input_shape)
-        if isinstance(self.axis, (list, tuple)):
-            self.axis = sorted(self.axis)
-            shape = tuple(input_shape[dim] for dim in self.axis)
-        else:
-            shape = (input_shape[self.axis],)
-            self.axis = [self.axis]
+        axes = canonicalize_axes(self.axis, len(input_shape))
+        if len(set(axes)) != len(axes):
+            raise ValueError(
+                f"Duplicate axes are not allowed. Received: axis={self.axis}"
+            )
+        self.axis = sorted(axes)
+        shape = tuple(input_shape[dim] for dim in self.axis)
         if self.scale or self.rms_scaling:
             self.gamma = self.add_weight(
                 name="gamma",
@@ -210,7 +197,7 @@ class LayerNormalization(Layer):
         return ops.cast(outputs, self.compute_dtype)
 
     def compute_output_shape(self, input_shape):
-        self._validate_axis(input_shape)
+        canonicalize_axes(self.axis, len(input_shape))
         return input_shape
 
     def get_config(self):

--- a/keras/src/layers/normalization/layer_normalization.py
+++ b/keras/src/layers/normalization/layer_normalization.py
@@ -150,7 +150,22 @@ class LayerNormalization(Layer):
         self.supports_masking = True
         self.autocast = False
 
+    def _validate_axis(self, input_shape):
+        if isinstance(self.axis, int):
+            axes = [self.axis]
+        else:
+            axes = self.axis
+
+        for axis in axes:
+            if axis >= len(input_shape) or axis < -len(input_shape):
+                raise ValueError(
+                    f"Axis {axis} is out of bounds for "
+                    f"input shape {input_shape}. "
+                    f"Received: axis={self.axis}"
+                )
+
     def build(self, input_shape):
+        self._validate_axis(input_shape)
         if isinstance(self.axis, (list, tuple)):
             self.axis = sorted(self.axis)
             shape = tuple(input_shape[dim] for dim in self.axis)
@@ -195,18 +210,7 @@ class LayerNormalization(Layer):
         return ops.cast(outputs, self.compute_dtype)
 
     def compute_output_shape(self, input_shape):
-        if isinstance(self.axis, int):
-            axes = [self.axis]
-        else:
-            axes = self.axis
-
-        for axis in axes:
-            if axis >= len(input_shape) or axis < -len(input_shape):
-                raise ValueError(
-                    f"Axis {axis} is out of bounds for "
-                    f"input shape {input_shape}. "
-                    f"Received: axis={self.axis}"
-                )
+        self._validate_axis(input_shape)
         return input_shape
 
     def get_config(self):

--- a/keras/src/layers/normalization/layer_normalization_test.py
+++ b/keras/src/layers/normalization/layer_normalization_test.py
@@ -107,6 +107,20 @@ class LayerNormalizationTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "is out of bounds"):
             layers.LayerNormalization(axis=99).compute_output_shape((2, 4))
 
+    def test_duplicate_axis(self):
+        # `[-1, 1]` refers to the same axis twice for a rank 2 input, which
+        # used to build mismatched weights and fail in the backend.
+        x = np.zeros((2, 4), dtype="float32")
+        with self.assertRaisesRegex(ValueError, "Duplicate axes"):
+            layers.LayerNormalization(axis=[-1, 1])(x)
+        with self.assertRaisesRegex(ValueError, "Duplicate axes"):
+            layers.LayerNormalization(axis=[1, 1])(x)
+
+    def test_axis_is_canonicalized(self):
+        layer = layers.LayerNormalization(axis=-1)
+        layer.build((2, 4))
+        self.assertEqual(layer.axis, [1])
+
     def test_correctness(self):
         layer = layers.LayerNormalization(dtype="float32")
         layer.build(input_shape=(2, 2, 2))

--- a/keras/src/layers/normalization/layer_normalization_test.py
+++ b/keras/src/layers/normalization/layer_normalization_test.py
@@ -89,6 +89,24 @@ class LayerNormalizationTest(testing.TestCase):
         ):
             layers.LayerNormalization(axis={"axis": -1})
 
+    def test_out_of_bounds_axis(self):
+        # `build()` used to index `input_shape` directly, so an out-of-bounds
+        # axis surfaced as a bare `IndexError: tuple index out of range`
+        # instead of the `ValueError` already raised by
+        # `compute_output_shape()`.
+        x = np.zeros((2, 4), dtype="float32")
+        for axis in (2, 99, -3, -99):
+            with self.assertRaisesRegex(ValueError, "is out of bounds"):
+                layers.LayerNormalization(axis=axis)(x)
+        # A list of axes is validated element-wise.
+        with self.assertRaisesRegex(ValueError, "is out of bounds"):
+            layers.LayerNormalization(axis=[0, 99])(x)
+        # `build()` and `compute_output_shape()` agree.
+        with self.assertRaisesRegex(ValueError, "is out of bounds"):
+            layers.LayerNormalization(axis=99).build((2, 4))
+        with self.assertRaisesRegex(ValueError, "is out of bounds"):
+            layers.LayerNormalization(axis=99).compute_output_shape((2, 4))
+
     def test_correctness(self):
         layer = layers.LayerNormalization(dtype="float32")
         layer.build(input_shape=(2, 2, 2))


### PR DESCRIPTION
LayerNormalization.compute_output_shape() already raises a descriptive ValueError when axis is out of bounds, but build() indexed input_shape directly and failed first with a bare IndexError: tuple index out of range, so the intended message was unreachable from the normal call path (eager, symbolic, and list-of-axes forms alike).

Extract the existing bounds check into _validate_axis() and call it from build() as well as compute_output_shape(), so both paths raise the same error.

## Description
<!-- Describe your changes here -->

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
