### PR TITLE
Validate the file name derived from `origin` in `get_file`

### DIFF
--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -324,7 +324,7 @@ def get_file(
         ):
             raise ValueError(
                 "Can't parse the file name from the origin provided: "
-                f"'{origin}'."
+                f"'{origin}'. "
                 "Please specify the `fname` argument."
             )
     else:

--- a/keras/src/utils/file_utils.py
+++ b/keras/src/utils/file_utils.py
@@ -314,7 +314,14 @@ def get_file(
 
     if not fname:
         fname = os.path.basename(urllib.parse.urlsplit(origin).path)
-        if not fname:
+        # `basename` strips separators, but a URL path ending in `/.` or `/..`
+        # (or, on Windows, in a drive letter) still yields a name that escapes
+        # `datadir` when joined to it.
+        if (
+            not fname
+            or fname in (os.curdir, os.pardir)
+            or os.path.splitdrive(fname)[0]
+        ):
             raise ValueError(
                 "Can't parse the file name from the origin provided: "
                 f"'{origin}'."

--- a/keras/src/utils/file_utils_test.py
+++ b/keras/src/utils/file_utils_test.py
@@ -476,6 +476,19 @@ class GetFileTest(test_case.TestCase):
         ):
             _ = file_utils.get_file("test.txt", origin, file_hash=hashval)
 
+    def test_get_file_with_unusable_origin_file_name(self):
+        """Test that an origin with no usable file name is rejected."""
+        cache_dir = self.get_temp_dir()
+        base = urllib.parse.urljoin(
+            "file://", urllib.request.pathname2url(os.path.abspath(cache_dir))
+        )
+
+        for origin in (f"{base}/", f"{base}/.", f"{base}/.."):
+            with self.assertRaisesRegex(
+                ValueError, "Can't parse the file name from the origin"
+            ):
+                _ = file_utils.get_file(origin=origin, cache_dir=cache_dir)
+
     def _create_tar_file(self, directory):
         """Helper function to create a tar file."""
         text_file_path = os.path.join(directory, "test.txt")


### PR DESCRIPTION
## Description

1. `get_file` rejects separators in the `fname` argument, but when `fname` is omitted the name comes from `basename(urlsplit(origin).path)`, which never reaches that check.
2. `basename` drops separators and still returns `..` for a URL path ending in `/..`, so the download and extraction targets resolve one level above `<cache_dir>/<cache_subdir>`: with `extract=True` the archive members are written into `cache_dir` itself, over files such as `keras.json`, and without it `get_file` returns a directory and never downloads at all.
3. Windows behaves the same way for a path ending in a drive letter, because `basename` keeps `C:` and the later `join` then drops `datadir`.

Treating those names as unparsable reuses the error the function already raises for a URL that carries no file name. The test covers the `/`, `/.` and `/..` forms; like #23287 the Windows case is not tested since there is no Windows runner.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ ] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
