### PR TITLE
Add IoU (Jaccard) Loss to Keras Losses

### DIFF
--- a/keras/api/_tf_keras/keras/losses/__init__.py
+++ b/keras/api/_tf_keras/keras/losses/__init__.py
@@ -29,6 +29,7 @@ from keras.src.losses.losses import CosineSimilarity as CosineSimilarity
 from keras.src.losses.losses import Dice as Dice
 from keras.src.losses.losses import Hinge as Hinge
 from keras.src.losses.losses import Huber as Huber
+from keras.src.losses.losses import IoU as IoU
 from keras.src.losses.losses import KLDivergence as KLDivergence
 from keras.src.losses.losses import LogCosh as LogCosh
 from keras.src.losses.losses import MeanAbsoluteError as MeanAbsoluteError
@@ -65,6 +66,7 @@ from keras.src.losses.losses import ctc as ctc
 from keras.src.losses.losses import dice as dice
 from keras.src.losses.losses import hinge as hinge
 from keras.src.losses.losses import huber as huber
+from keras.src.losses.losses import iou as iou
 from keras.src.losses.losses import kl_divergence as KLD
 from keras.src.losses.losses import kl_divergence as kld
 from keras.src.losses.losses import kl_divergence as kullback_leibler_divergence

--- a/keras/api/losses/__init__.py
+++ b/keras/api/losses/__init__.py
@@ -28,6 +28,7 @@ from keras.src.losses.losses import CosineSimilarity as CosineSimilarity
 from keras.src.losses.losses import Dice as Dice
 from keras.src.losses.losses import Hinge as Hinge
 from keras.src.losses.losses import Huber as Huber
+from keras.src.losses.losses import IoU as IoU
 from keras.src.losses.losses import KLDivergence as KLDivergence
 from keras.src.losses.losses import LogCosh as LogCosh
 from keras.src.losses.losses import MeanAbsoluteError as MeanAbsoluteError
@@ -64,6 +65,7 @@ from keras.src.losses.losses import ctc as ctc
 from keras.src.losses.losses import dice as dice
 from keras.src.losses.losses import hinge as hinge
 from keras.src.losses.losses import huber as huber
+from keras.src.losses.losses import iou as iou
 from keras.src.losses.losses import kl_divergence as kl_divergence
 from keras.src.losses.losses import log_cosh as log_cosh
 from keras.src.losses.losses import mean_absolute_error as mean_absolute_error

--- a/keras/src/losses/__init__.py
+++ b/keras/src/losses/__init__.py
@@ -13,6 +13,7 @@ from keras.src.losses.losses import CosineSimilarity
 from keras.src.losses.losses import Dice
 from keras.src.losses.losses import Hinge
 from keras.src.losses.losses import Huber
+from keras.src.losses.losses import IoU
 from keras.src.losses.losses import KLDivergence
 from keras.src.losses.losses import LogCosh
 from keras.src.losses.losses import LossFunctionWrapper
@@ -35,6 +36,7 @@ from keras.src.losses.losses import ctc
 from keras.src.losses.losses import dice
 from keras.src.losses.losses import hinge
 from keras.src.losses.losses import huber
+from keras.src.losses.losses import iou
 from keras.src.losses.losses import kl_divergence
 from keras.src.losses.losses import log_cosh
 from keras.src.losses.losses import mean_absolute_error
@@ -73,6 +75,7 @@ ALL_OBJECTS = {
     CategoricalHinge,
     # Image segmentation
     Dice,
+    IoU,
     Tversky,
     # Similarity
     Circle,
@@ -100,6 +103,7 @@ ALL_OBJECTS = {
     categorical_hinge,
     # Image segmentation
     dice,
+    iou,
     tversky,
     # Similarity
     circle,

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1438,6 +1438,60 @@ class Tversky(LossFunctionWrapper):
         return config
 
 
+@keras_export("keras.losses.IoU")
+class IoU(LossFunctionWrapper):
+    """Computes the IoU (Intersection over Union) loss value.
+
+    The IoU loss value is calculated between `y_true` and `y_pred`.
+
+    Arguments:
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        axis: Tuple for which dimensions the loss is calculated. Defaults to
+            `None`.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to different value
+            (via `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is
+            provided, then the `compute_dtype` will be utilized.
+
+    Returns:
+        IoU loss value.
+
+    Example:
+
+    >>> y_true = np.array([[1, 2], [1, 2]])
+    >>> y_pred = np.array([[4, 1], [6, 1]])
+    >>> loss = keras.losses.IoU()
+    >>> loss(y_true, y_pred)
+    -2.5
+    """
+
+    def __init__(
+        self,
+        reduction="sum_over_batch_size",
+        name="iou",
+        axis=None,
+        dtype=None,
+    ):
+        super().__init__(
+            iou, name=name, reduction=reduction, dtype=dtype, axis=axis
+        )
+        self.axis = axis
+
+    def get_config(self):
+        config = Loss.get_config(self)
+        config.update({"axis": self.axis})
+        return config
+
+
 @keras_export("keras.losses.Circle")
 class Circle(LossFunctionWrapper):
     """Computes Circle Loss between integer labels and L2-normalized embeddings.
@@ -2649,6 +2703,41 @@ def tversky(y_true, y_pred, alpha=0.5, beta=0.5, axis=None):
     )
 
     return 1 - tversky
+
+
+@keras_export("keras.losses.iou")
+def iou(y_true, y_pred, axis=None):
+    """Computes the IoU (Intersection over Union) loss value.
+
+    The IoU loss value is calculated between `y_true` and `y_pred`.
+
+    Formula:
+    ```python
+    loss = 1 - sum(y_true * y_pred) / (
+        sum(y_true) + sum(y_pred) - sum(y_true * y_pred))
+    ```
+
+    Args:
+        y_true: tensor of true targets.
+        y_pred: tensor of predicted targets.
+        axis: tuple for which dimensions the loss is calculated.
+
+    Returns:
+        IoU loss value.
+    """
+    y_pred = ops.convert_to_tensor(y_pred)
+    y_true = ops.cast(y_true, y_pred.dtype)
+
+    intersection = ops.sum(y_true * y_pred, axis=axis)
+    total = ops.sum(y_true, axis=axis) + ops.sum(y_pred, axis=axis)
+    union = total - intersection
+
+    iou = ops.divide(
+        intersection,
+        union + backend.epsilon(),
+    )
+
+    return 1 - iou
 
 
 @keras_export("keras.losses.circle")

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1918,6 +1918,49 @@ class DiceTest(testing.TestCase):
         self.assertDType(output, "bfloat16")
 
 
+class IoUTest(testing.TestCase):
+    def test_config(self):
+        self.run_class_serialization_test(losses.IoU(name="myiou"))
+
+    def test_correctness(self):
+        y_true = np.array(([[1, 2], [1, 2]]))
+        y_pred = np.array(([[4, 1], [6, 1]]))
+        # intersection = 1*4 + 2*1 + 1*6 + 2*1 = 4 + 2 + 6 + 2 = 14
+        # sum(y_true) = 1+2+1+2 = 6
+        # sum(y_pred) = 4+1+6+1 = 12
+        # union = 6 + 12 - 14 = 4
+        # IoU = 14 / 4 = 3.5
+        # Loss = 1 - 3.5 = -2.5
+        output = losses.IoU()(y_true, y_pred)
+        self.assertAllClose(output, -2.5)
+
+    def test_binary_segmentation(self):
+        y_true = np.array(
+            ([[1, 0, 1, 0], [0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, 1]])
+        )
+        y_pred = np.array(
+            ([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 0, 1, 1]])
+        )
+        output = losses.IoU()(y_true, y_pred)
+        self.assertAllClose(output, 0.875)
+
+    def test_binary_segmentation_with_axis(self):
+        y_true = np.array(
+            [[[[1.0], [1.0]], [[0.0], [0.0]]], [[[1.0], [1.0]], [[0.0], [0.0]]]]
+        )
+        y_pred = np.array(
+            [[[[0.0], [1.0]], [[0.0], [1.0]]], [[[0.4], [0.0]], [[0.0], [0.9]]]]
+        )
+        output = losses.IoU(axis=(1, 2, 3), reduction=None)(y_true, y_pred)
+        self.assertAllClose(output, [0.66666667, 0.86206897])
+
+    def test_dtype_arg(self):
+        y_true = np.array(([[1, 2], [1, 2]]))
+        y_pred = np.array(([[4, 1], [6, 1]]))
+        output = losses.IoU(dtype="bfloat16")(y_true, y_pred)
+        self.assertDType(output, "bfloat16")
+
+
 class TverskyTest(testing.TestCase):
     def test_config(self):
         self.run_class_serialization_test(losses.Tversky(name="mytversky"))


### PR DESCRIPTION
## Description
This PR implements the Intersection over Union (IoU) loss, also known as the Jaccard loss, as a standard loss function in Keras. This is widely used in computer vision tasks, particularly in image segmentation and object detection, to measure the overlap between predicted and ground truth masks.

### Formula
The implementation follows the standard Jaccard loss formula:

loss = 1 - sum(y_true * y_pred) / (sum(y_true) + sum(y_pred) - sum(y_true * y_pred))

A small epsilon is added to the denominator to prevent division by zero.

  Usage Example

```
   model.compile(optimizer='adam', loss=keras.losses.IoU())
   # or
   loss = keras.losses.iou(y_true, y_pred)
```
## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
