### PR TITLE
Fix alpha and beta coefficient swap in Tversky loss

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2636,8 +2636,8 @@ def tversky(y_true, y_pred, alpha=0.5, beta=0.5, axis=None):
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    inputs = y_true
-    targets = y_pred
+    inputs = y_pred
+    targets = y_true
 
     intersection = ops.sum(inputs * targets, axis=axis)
     fp = ops.sum((1 - targets) * inputs, axis=axis)

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1926,13 +1926,13 @@ class TverskyTest(testing.TestCase):
         y_true = np.array(([[1, 2], [1, 2]]))
         y_pred = np.array(([[4, 1], [6, 1]]))
         output = losses.Tversky()(y_true, y_pred)
-        self.assertAllClose(output, -0.55555546)
+        self.assertAllClose(output, -0.55555558)
 
     def test_correctness_custom_coefficients(self):
         y_true = np.array(([[1, 2], [1, 2]]))
         y_pred = np.array(([[4, 1], [6, 1]]))
         output = losses.Tversky(alpha=0.2, beta=0.8)(y_true, y_pred)
-        self.assertAllClose(output, -0.29629636)
+        self.assertAllClose(output, -0.94444442)
 
     def test_binary_segmentation(self):
         y_true = np.array(
@@ -1942,7 +1942,7 @@ class TverskyTest(testing.TestCase):
             ([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 0, 1, 1]])
         )
         output = losses.Tversky()(y_true, y_pred)
-        self.assertAllClose(output, 0.77777773)
+        self.assertAllClose(output, 0.77777779)
 
     def test_binary_segmentation_with_axis(self):
         y_true = np.array(
@@ -1962,7 +1962,7 @@ class TverskyTest(testing.TestCase):
             ([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 0, 1, 1]])
         )
         output = losses.Tversky(alpha=0.2, beta=0.8)(y_true, y_pred)
-        self.assertAllClose(output, 0.7916667)
+        self.assertAllClose(output, 0.76190472)
 
     def test_binary_segmentation_custom_coefficients_with_axis(self):
         y_true = np.array(
@@ -1974,7 +1974,7 @@ class TverskyTest(testing.TestCase):
         output = losses.Tversky(
             alpha=0.2, beta=0.8, axis=(1, 2, 3), reduction=None
         )(y_true, y_pred)
-        self.assertAllClose(output, [0.5, 0.7222222])
+        self.assertAllClose(output, [0.5, 0.78494626])
 
     def test_dtype_arg(self):
         y_true = np.array(([[1, 2], [1, 2]]))


### PR DESCRIPTION
## Description
This PR corrects a bug in the Tversky loss implementation where the alpha and beta coefficients were swapped relative to their intended behavior and documentation.

### The Problem
In the Tversky loss formula:

$TI = \frac{TP}{TP + \alpha \cdot FP + \beta \cdot FN}$


   * alpha ($\alpha$) is intended to penalize False Positives (FP).
   * beta ($\beta$) is intended to penalize False Negatives (FN).


However, the internal implementation assigned inputs = y_true and targets = y_pred, which resulted in the fp variable actually calculating False Negatives and the fn variable calculating False Positives. This meant that increasing alpha incorrectly penalized False Negatives more heavily.

### The Fix
Swapped the internal inputs and targets assignments to correctly align with the labels (y_true) and predictions (y_pred).
   * inputs = y_pred
   * targets = y_true


  This ensures that:
   * fp = sum((1 - targets) * inputs) correctly identifies False Positives ($y_{true}=0, y_{pred}=1$).
   * fn = sum(targets * (1 - inputs)) correctly identifies False Negatives ($y_{true}=1, y_{pred}=0$).

Bug reproduction script: https://colab.research.google.com/drive/1CN_zvaXvs5wb8NeAfdGgyZDNPUjxS-TP?usp=sharing

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
