### PR TITLE
Fix robust sample_weight handling in FBetaScore

### DIFF
--- a/keras/src/metrics/f_score_metrics.py
+++ b/keras/src/metrics/f_score_metrics.py
@@ -177,10 +177,17 @@ class FBetaScore(Metric):
             sample_weight = ops.convert_to_tensor(
                 sample_weight, dtype=self.dtype
             )
+            if len(sample_weight.shape) < len(y_true.shape):
+                sample_weight = ops.expand_dims(
+                    sample_weight,
+                    axis=list(
+                        range(len(sample_weight.shape), len(y_true.shape))
+                    ),
+                )
 
         def _weighted_sum(val, sample_weight):
             if sample_weight is not None:
-                val = ops.multiply(val, ops.expand_dims(sample_weight, 1))
+                val = ops.multiply(val, sample_weight)
             return ops.sum(val, axis=self.axis)
 
         self.true_positives.assign(

--- a/keras/src/metrics/f_score_metrics_test.py
+++ b/keras/src/metrics/f_score_metrics_test.py
@@ -298,6 +298,31 @@ class FBetaScoreTest(testing.TestCase):
                 average="macro", beta=-0.5, threshold=None, dtype="float32"
             )
 
+    def test_fbeta_scalar_weight(self):
+        metric = f_score_metrics.FBetaScore(threshold=0.5)
+        y_true = np.array([[1, 1], [1, 0]], np.int32)
+        y_pred = np.array([[0.2, 0.6], [0.2, 0.6]], np.float32)
+        metric.update_state(y_true, y_pred, sample_weight=0.5)
+        result = metric.result()
+        # Class 0: y_true=[1, 1], y_pred=[0.2, 0.2] => TP=0, F1=0
+        # Class 1: y_true=[1, 0], y_pred=[0.6, 0.6] => F1=0.6666665
+        self.assertAllClose(result, [0.0, 0.6666665], atol=1e-5)
+
+    def test_fbeta_2d_weight(self):
+        metric = f_score_metrics.FBetaScore(threshold=0.5)
+        y_true = np.array([[1, 1], [1, 0]], np.int32)
+        y_pred = np.array([[0.2, 0.6], [0.2, 0.6]], np.float32)
+        # Valid 2D weight matching y_true shape
+        sample_weight = np.array([[0.5, 0.2], [0.3, 0.8]], np.float32)
+        metric.update_state(y_true, y_pred, sample_weight=sample_weight)
+        result = metric.result()
+        # Class 1 (idx 1):
+        # TP = 1*1*0.2 = 0.2
+        # FP = 1*(1-0)*0.8 = 0.8
+        # Precision = 0.2 / 1.0 = 0.2, Recall = 0.2 / 0.2 = 1.0
+        # F1 = 2 * 0.2 / 1.2 = 0.333333
+        self.assertAllClose(result, [0.0, 0.333333], atol=1e-5)
+
     def test_threshold_not_float_raises_value_error(self):
         expected_message_pattern = (
             "Invalid `threshold` argument value. "


### PR DESCRIPTION
## Description
This PR addresses a robustness bug in the FBetaScore (and by extension F1Score) metric where sample_weight handling was fragile and prone to crashes.

### The Issue
The previous implementation used a hardcoded ops.expand_dims(sample_weight, 1) inside the update_state logic. This resulted in two major issues:
   1. Crash on Scalar Weights: If a user passed a scalar weight (e.g., 0.5), expand_dims would fail because axis 1 is out of bounds for a rank-0 tensor.
   2. Broadcasting Errors on Multi-dimensional Weights: If a user passed a 2D weight matching the shape of y_true (valid Keras usage for per-class weighting), the hardcoded expansion would turn it into a 3D tensor, causing shape mismatches and incorrect mathematical results.

### The Fix
Replaced the hardcoded dimension expansion with a rank-matching loop:

   ``` 
while len(sample_weight.shape) < len(y_true.shape):
       sample_weight = ops.expand_dims(sample_weight, axis=-1) 
```
This ensures that sample_weight is correctly broadcasted to the rank of y_true regardless of whether it is a scalar, a 1D batch-level weight, or a 2D per-class weight. This aligns FBetaScore with standard Keras metric conventions.

Bug reproduction script: https://colab.research.google.com/drive/1edOOfdG6Jn7VH1UV4B4pDmOGRooi9le9?usp=sharing

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
