### PR TITLE
Fix flaky test_matrix_power: seed the input and condition the negative-power case

### DIFF
--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -726,7 +726,11 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(linalg.matrix_rank(a_symb).shape, (4,))
 
     def test_matrix_power(self):
-        x = np.random.rand(4, 3, 3).astype("float32")
+        # Seed for determinism: the negative-power case below inverts the
+        # input, so its accuracy tracks the conditioning of a randomly drawn
+        # matrix, and an unseeded input was a source of CI flakiness.
+        rng = np.random.default_rng(0)
+        x = rng.random((4, 3, 3)).astype("float32")
         # Positive power
         out = linalg.matrix_power(x, 3)
         expected = np.linalg.matrix_power(x, 3)
@@ -742,15 +746,17 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
         )
 
         # Zero power (2D)
-        x_2d = np.random.rand(3, 3).astype("float32")
+        x_2d = rng.random((3, 3)).astype("float32")
         out = linalg.matrix_power(x_2d, 0)
         expected = np.linalg.matrix_power(x_2d, 0)
         self.assertAllClose(
             out, expected, atol=1e-6, tpu_atol=1e-2, tpu_rtol=1e-2
         )
 
-        # Negative power
-        x_inv_stable = (x + np.eye(3)).astype("float32")
+        # Negative power. The diagonal shift is what keeps this well
+        # conditioned; `+ np.eye(3)` alone still left the condition number
+        # around 30, which a float32 inverse cannot hold to `atol`.
+        x_inv_stable = (x + 3 * np.eye(3)).astype("float32")
         out = linalg.matrix_power(x_inv_stable, -2)
         expected = np.linalg.matrix_power(x_inv_stable, -2)
         self.assertAllClose(
@@ -767,11 +773,11 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
 
         with self.assertRaises(ValueError):
             # Non-square
-            linalg.matrix_power(np.random.rand(4, 3, 2), 2)
+            linalg.matrix_power(rng.random((4, 3, 2)), 2)
 
         with self.assertRaises(ValueError):
             # Rank < 2
-            linalg.matrix_power(np.random.rand(4), 2)
+            linalg.matrix_power(rng.random((4,)), 2)
 
     @parameterized.named_parameters(
         ("tall_default_rcond", (7, 4), None),

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -726,9 +726,8 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(linalg.matrix_rank(a_symb).shape, (4,))
 
     def test_matrix_power(self):
-        # Seed for determinism: the negative-power case below inverts the
-        # input, so its accuracy tracks the conditioning of a randomly drawn
-        # matrix, and an unseeded input was a source of CI flakiness.
+        # Seeded: the negative-power case inverts the input, so its accuracy
+        # depends on how well conditioned the drawn matrix is.
         rng = np.random.default_rng(0)
         x = rng.random((4, 3, 3)).astype("float32")
         # Positive power
@@ -753,9 +752,8 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
             out, expected, atol=1e-6, tpu_atol=1e-2, tpu_rtol=1e-2
         )
 
-        # Negative power. The diagonal shift is what keeps this well
-        # conditioned; `+ np.eye(3)` alone still left the condition number
-        # around 30, which a float32 inverse cannot hold to `atol`.
+        # Negative power. The `3 *` keeps the matrix well conditioned so the
+        # float32 inverse stays within `atol`.
         x_inv_stable = (x + 3 * np.eye(3)).astype("float32")
         out = linalg.matrix_power(x_inv_stable, -2)
         expected = np.linalg.matrix_power(x_inv_stable, -2)


### PR DESCRIPTION
Fixes #23337

## Problem

The negative-power case in `test_matrix_power` inverts a float32 matrix and asserts `atol=rtol=1e-6` against an **unseeded** input. A float32 inverse's error scales with the condition number of the matrix, and `np.random.rand(4, 3, 3) + np.eye(3)` draws condition numbers from single digits into the hundreds — often enough to cross `1e-6` regardless of backend. Failing CI runs, root cause, and a deterministic repro are in #23337.

## Fix

- Seed the input (`np.random.default_rng(0)`), the same pattern `test_lstsq` already uses in this file.
- Raise the diagonal shift on the negative-power case from `x + np.eye(3)` to `x + 3 * np.eye(3)`, so the matrix is as well conditioned as its `x_inv_stable` name implies.

Tolerances are unchanged — conditioning the input fixes the cause instead of hiding it behind a looser assertion.

## Verification

Condition number at the seeded input: ~13.2 → ~2.1 (worst over 300 seeds: ~30.9 → ~2.3). Largest error as a fraction of the assertion tolerance, over 300 seeds:

| backend | worst diff / tolerance | margin |
|---|--:|--:|
| jax | 0.0402 | 25x |
| tensorflow | 0.0402 | 25x |
| torch | 0.0401 | 25x |
| numpy | 0.0 | exact |

`keras/src/ops/linalg_test.py` passes: jax 238, tensorflow 238, torch 238, numpy 237 (+1 skipped), openvino 205 (+33 skipped).

- [x]  I am a human, and not a bot.
- [x]  I will be responsible for responding to review comments in a timely manner.
- [x]  I will work with the maintainers to push this PR forward until submission.
