### PR TITLE
Pass the shape during `tf.Variable` initialization.

### DIFF
--- a/keras/src/backend/tensorflow/core.py
+++ b/keras/src/backend/tensorflow/core.py
@@ -42,6 +42,7 @@ class Variable(
         else:
             self._value = tf.Variable(
                 value,
+                shape=self._shape,
                 dtype=self._dtype,
                 trainable=self.trainable,
                 name=self.name,


### PR DESCRIPTION
On Tensorflow, when the initializer is a callable, calling the initializer maybe be delayed. This would cause the shape of the `tf.Variable` to be unknown between the moment the variable was created and the moment the initializer was actually called.

Note that passing `shape` even when `self._shape` is `None` is fine and behaves the same as before.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
