### PR TITLE
fix issue triage workflow

### DIFF
--- a/.github/workflows/gemini-automated-issue-triage.yml
+++ b/.github/workflows/gemini-automated-issue-triage.yml
@@ -50,6 +50,10 @@ jobs:
       )
     timeout-minutes: 5
     runs-on: 'ubuntu-latest'
+    env:
+      # The Gemini CLI refuses to run in a directory it does not consider
+      # trusted, which is every fresh checkout on a runner.
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     steps:
       - name: 'Get issue data for manual trigger'
         id: 'get_issue_data'
@@ -233,6 +237,14 @@ jobs:
             - wont-fix: Issue will not be fixed.
             - user error: Issue caused by incorrect usage, not a bug.
             - to investigate: Issue needs further investigation.
+
+      - name: 'Report Gemini failure'
+        if: |-
+          ${{ failure() && steps.gemini_issue_analysis.outcome == 'failure' }}
+        env:
+          GEMINI_ERROR: '${{ steps.gemini_issue_analysis.outputs.error }}'
+        run: |-
+          echo "::error title=Gemini triage failed::${GEMINI_ERROR:-See the step logs.}"
 
       - name: 'Apply Labels and Post Response'
         if: |-


### PR DESCRIPTION
## Description
The Gemini CLI refuses to run in a directory it does not consider trusted, which is every fresh checkout on a runner.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
