### PR TITLE
address comments on https://github.com/keras-team/keras/pull/23340

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2878,6 +2878,8 @@ def repeat(x, repeats, axis=None):
 
 def reshape(x, newshape):
     x = convert_to_tensor(x)
+    if isinstance(newshape, (int, np.integer)):
+        newshape = (newshape,)
     if isinstance(x, tf.SparseTensor):
         from keras.src.ops.operation_utils import compute_reshape_output_shape
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -7334,7 +7334,7 @@ def repeat(x, repeats, axis=None):
 class Reshape(Operation):
     def __init__(self, newshape, *, name=None):
         super().__init__(name=name)
-        self.newshape = operation_utils.standardize_reshape_shape(newshape)
+        self.newshape = newshape
 
     def call(self, x):
         return backend.numpy.reshape(x, self.newshape)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6587,6 +6587,10 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.Reshape(-1)(x), np.reshape(x, -1))
         self.assertAllClose(knp.reshape(x, -1), np.reshape(x, -1))
         self.assertAllClose(knp.Reshape(6)(x), np.reshape(x, 6))
+        self.assertAllClose(
+            backend.numpy.reshape(backend.convert_to_tensor(x), -1),
+            np.reshape(x, -1),
+        )
 
     def test_reshape_rejects_invalid_newshape(self):
         x = np.zeros(20, dtype="float32")

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -294,10 +294,11 @@ def compute_matmul_output_shape(shape1, shape2):
 def standardize_reshape_shape(newshape, newshape_arg_name="newshape"):
     """Normalize and validate the `newshape` argument of `reshape`.
 
-    NumPy accepts a bare integer, e.g. `np.reshape(x, -1)`, while backends
-    such as TensorFlow and PyTorch require a sequence of dimensions. Wrap
-    scalars so that every backend receives a tuple. Backend tensors are
-    returned as is, since their dimensions are only known at runtime.
+    NumPy accepts a bare integer, e.g. `np.reshape(x, -1)`, so wrap scalars
+    into a tuple for shape computations. Backends normalize the shapes they
+    receive themselves, since Keras also calls them directly. Backend
+    tensors are returned as is, since their dimensions are only known at
+    runtime.
     """
     if backend.is_tensor(newshape) or isinstance(newshape, KerasTensor):
         return newshape
@@ -346,7 +347,7 @@ def compute_reshape_output_shape(input_shape, newshape, newshape_arg_name):
 
     This utility does not special case the 0th dimension (batch size).
     """
-    validate_reshape_shape(newshape, newshape_arg_name)
+    newshape = standardize_reshape_shape(newshape, newshape_arg_name)
     # If `newshape` is a tensor, we infer the output rank based on its shape.
     # For example, a 1D tensor of shape (4,) indicates a 4D output shape.
     if backend.is_tensor(newshape) or isinstance(newshape, KerasTensor):


### PR DESCRIPTION
## Description
Moved the normalization into the backend. tensorflow was the only one missing it. numpy and jax accept it natively torch already normalized it in reshape()  and openvino already normalized it too

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
