### PR TITLE
Make model.quantize() observable and fail-safe

### DIFF
--- a/keras/api/_tf_keras/keras/quantizers/__init__.py
+++ b/keras/api/_tf_keras/keras/quantizers/__init__.py
@@ -41,3 +41,4 @@ from keras.src.quantizers.quantizers import (
     quantize_and_dequantize as quantize_and_dequantize,
 )
 from keras.src.quantizers.quantizers import unpack_int4 as unpack_int4
+from keras.src.quantizers.report import QuantizationReport as QuantizationReport

--- a/keras/api/quantizers/__init__.py
+++ b/keras/api/quantizers/__init__.py
@@ -41,3 +41,4 @@ from keras.src.quantizers.quantizers import (
     quantize_and_dequantize as quantize_and_dequantize,
 )
 from keras.src.quantizers.quantizers import unpack_int4 as unpack_int4
+from keras.src.quantizers.report import QuantizationReport as QuantizationReport

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -251,11 +251,12 @@ class Layer(BackendLayer, Operation):
             obj._check_quantize_args(mode, obj.compute_dtype)
             obj._tracker.unlock()
             try:
-                original_quantize_method(mode=mode, config=config, **kwargs)
-            except Exception:
-                raise
+                result = original_quantize_method(
+                    mode=mode, config=config, **kwargs
+                )
             finally:
                 obj._tracker.lock()
+            return result
 
         obj.quantize = quantize_wrapper
 

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -601,8 +601,15 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         report = QuantizationReport(mode=mode)
         graph_modified = False
         for layer in self._flatten_layers():
-            # Only leaf layers (those without sub-layers) are quantizable.
-            if len(list(layer._flatten_layers())) != 1:
+            # Skip nested models: this walk already visits their layers
+            # directly (`_flatten_layers` is recursive), and calling
+            # `quantize` on a sub-model would recurse into a second full
+            # walk. Owning sub-layers does NOT make a layer unquantizable
+            # (e.g. `Dense` with a `Layer` activation), so this is an
+            # isinstance test, not a topology test; any other layer that
+            # cannot be quantized reports itself by raising
+            # `NotImplementedError` below.
+            if isinstance(layer, Model):
                 continue
 
             # Input layers carry no weights; they are not a meaningful skip.

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -7,14 +7,17 @@ from collections.abc import Callable
 from keras.src import backend
 from keras.src import utils
 from keras.src.api_export import keras_export
+from keras.src.layers.core.input_layer import InputLayer
 from keras.src.layers.layer import Layer
 from keras.src.models.variable_mapping import map_saveable_variables
 from keras.src.quantizers.awq_core import awq_quantize
 from keras.src.quantizers.gptq_core import find_layers_in_block
 from keras.src.quantizers.gptq_core import gptq_quantize
+from keras.src.quantizers.report import QuantizationReport
 from keras.src.quantizers.utils import should_quantize_layer
 from keras.src.saving import saving_api
 from keras.src.trainers import trainer as base_trainer
+from keras.src.utils import io_utils
 from keras.src.utils import summary_utils
 from keras.src.utils import traceback_utils
 
@@ -448,7 +451,9 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         del mode  # Unused.
         return None
 
-    def quantize(self, mode=None, config=None, filters=None, **kwargs):
+    def quantize(
+        self, mode=None, config=None, filters=None, verbose=True, **kwargs
+    ):
         """Quantize the weights of the model.
 
         Note that the model must be built first before calling this method.
@@ -467,6 +472,13 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         `get_quantization_layer_structure(mode)` hook). All other layers
         are left in their original precision.
 
+        The call collects a `QuantizationReport` describing which layers were
+        quantized and which were skipped (and why). The report is returned and
+        also stored on the model as `model._quantization_report`. A single
+        summary warning is emitted if any layers could not be quantized because
+        they do not support quantization. For a per-layer view of storage sizes,
+        call `model.quantization_summary()`.
+
         Args:
             mode: The mode of the quantization. Supported modes are:
                 `"int8"`, `"int4"`, `"float8"`, `"gptq"`, `"awq"`. This is
@@ -478,7 +490,12 @@ class Model(Trainer, base_trainer.Trainer, Layer):
             filters: Optional filters to apply to the quantization. Can be a
                 regex string, a list of regex strings, or a callable. Only the
                 layers which match the filter conditions will be quantized.
+            verbose: Whether to print the quantization report. Defaults to
+                `True`.
             **kwargs: Additional keyword arguments.
+
+        Returns:
+            A `QuantizationReport` describing the outcome of the call.
 
         Example:
 
@@ -541,13 +558,21 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                     f"{type(filters)}"
                 )
 
-        # For GPTQ/AWQ, resolve the model structure before any layer is
-        # modified so that an invalid structure surfaces early, and restrict
-        # quantization to the layers covered by the structure. Only those
-        # layers are calibrated afterwards; quantizing any other layer would
-        # leave it uncalibrated, and its uninitialized quantized weights
-        # would silently replace the real ones when the model is saved and
-        # reloaded.
+        # `mode` and `config` arrive here already resolved to a concrete mode
+        # string and `QuantizationConfig`, because `Layer.__new__` wraps
+        # `quantize` with `quantize_wrapper`, which calls
+        # `validate_and_resolve_config`.
+
+        # For structure-aware modes (`gptq`/`awq`), resolve and validate the
+        # layer structure *before* mutating any layer, and restrict
+        # quantization to the layers covered by the structure. Resolving it
+        # here (rather than after the mutation loop) guarantees that a
+        # missing/invalid structure leaves the model completely untouched
+        # instead of half-quantized (buffers allocated, dtype policies
+        # swapped). Only structure-covered layers are calibrated afterwards;
+        # quantizing any other layer would leave it uncalibrated, and its
+        # uninitialized quantized weights would silently replace the real
+        # ones when the model is saved and reloaded.
         structure = None
         structure_layer_ids = None
         if mode in ("gptq", "awq"):
@@ -573,31 +598,68 @@ class Model(Trainer, base_trainer.Trainer, Layer):
                 for sub_layer in find_layers_in_block(block).values():
                     structure_layer_ids.add(id(sub_layer))
 
+        report = QuantizationReport(mode=mode)
         graph_modified = False
         for layer in self._flatten_layers():
-            # Apply filters
-            if not should_quantize_layer(layer, filters):
+            # Only leaf layers (those without sub-layers) are quantizable.
+            if len(list(layer._flatten_layers())) != 1:
                 continue
-            # For GPTQ/AWQ, skip layers that the structure does not cover.
+
+            # Input layers carry no weights; they are not a meaningful skip.
+            if isinstance(layer, InputLayer):
+                continue
+
+            path = layer.path or layer.name
+
+            # 1. For GPTQ/AWQ, layers outside the structure's sequential
+            # blocks are never calibrated, so they must not be quantized at
+            # all.
             if (
                 structure_layer_ids is not None
                 and id(layer) not in structure_layer_ids
             ):
+                report.add_skipped(
+                    path, QuantizationReport.SKIP_OUTSIDE_STRUCTURE
+                )
                 continue
-
-            if len(list(layer._flatten_layers())) == 1:
-                try:
-                    layer.quantize(mode, type_check=type_check, config=config)
-                    graph_modified = True
-                except NotImplementedError as e:
-                    warnings.warn(str(e))
-                except AttributeError:
-                    pass
+            # 2. Excluded by `filters`.
+            if not should_quantize_layer(layer, filters):
+                report.add_skipped(path, QuantizationReport.SKIP_FILTERED)
+                continue
+            # 3. Already quantized (e.g. a previously quantized layer).
+            if getattr(layer, "_is_quantized", False):
+                report.add_skipped(
+                    path, QuantizationReport.SKIP_ALREADY_QUANTIZED
+                )
+                continue
+            # 4. Attempt to quantize. Only `NotImplementedError` means the
+            # layer does not support quantization; any other exception is a
+            # real bug and is allowed to propagate.
+            try:
+                layer.quantize(mode, type_check=type_check, config=config)
+            except NotImplementedError:
+                report.add_skipped(path, QuantizationReport.SKIP_NO_SUPPORT)
+                continue
+            report.add_quantized(
+                path, layer.quantization_mode, layer.dtype_policy.name
+            )
+            graph_modified = True
 
         if mode == "gptq":
             gptq_quantize(config, structure, filters=filters)
         elif mode == "awq":
             awq_quantize(config, structure, filters=filters)
+
+        # Emit a single summary warning in place of the previous per-layer
+        # warning storm (one `UserWarning` per non-quantizable leaf).
+        warning_message = report.summary_warning()
+        if warning_message is not None:
+            warnings.warn(warning_message, stacklevel=2)
+
+        if verbose:
+            io_utils.print_msg(report.render())
+
+        self._quantization_report = report
 
         # If any layer was changed, we must rebuild the execution functions.
         if graph_modified:
@@ -605,6 +667,25 @@ class Model(Trainer, base_trainer.Trainer, Layer):
             self.test_function = None
             self.predict_function = None
             self._post_quantize(mode, **kwargs)
+
+        return report
+
+    def quantization_summary(self, verbose=True):
+        """Print a per-quantized-layer summary of the model.
+
+        For every quantized layer this reports the layer path, its dtype
+        policy, and the storage dtype and byte size of its primary quantized
+        weight. It also prints totals comparing the quantized weight storage
+        against a float32 baseline.
+
+        Args:
+            verbose: Whether to print the summary. Defaults to `True`. The
+                summary string is always returned.
+
+        Returns:
+            The summary as a string.
+        """
+        return summary_utils.print_quantization_summary(self, verbose=verbose)
 
     def _post_quantize(self, mode, **kwargs):
         if backend.backend() == "torch":

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1,5 +1,8 @@
+import contextlib
+import io
 import os
 import pickle
+import warnings
 from collections import namedtuple
 
 import numpy as np
@@ -9,12 +12,16 @@ from absl.testing import parameterized
 from keras.src import backend
 from keras.src import layers
 from keras.src import losses
+from keras.src import ops
 from keras.src import testing
 from keras.src import tree
 from keras.src.layers.core.input_layer import Input
 from keras.src.models.functional import Functional
 from keras.src.models.model import Model
 from keras.src.models.model import model_from_json
+from keras.src.models.sequential import Sequential
+from keras.src.quantizers.gptq_config import GPTQConfig
+from keras.src.quantizers.report import QuantizationReport
 
 
 def _get_model():
@@ -924,6 +931,189 @@ class ModelTest(testing.TestCase):
         if mode == "float8":
             # kernel + bias + scale * 3 + amax_history * 3 == 8
             self.assertEqual(len(model.weights), 3 * 8)
+
+    def _get_mixed_layer_model(self):
+        inputs = layers.Input([4], name="in")
+        x = layers.Dense(5, name="d1")(inputs)
+        x = layers.Activation("relu", name="act")(x)
+        outputs = layers.Dense(3, name="d2")(x)
+        return Model(inputs, outputs)
+
+    def test_quantize_returns_and_stores_report(self):
+        model = self._get_mixed_layer_model()
+
+        report = model.quantize("int8", verbose=False)
+
+        # The report is returned and also attached to the model.
+        self.assertIsNotNone(report)
+        self.assertIs(model._quantization_report, report)
+        self.assertEqual(report.mode, "int8")
+
+        # Both `Dense` layers were quantized with the expected scheme.
+        quantized_paths = sorted(path for path, _, _ in report.quantized)
+        self.assertEqual(quantized_paths, ["d1", "d2"])
+        for _, layer_mode, scheme in report.quantized:
+            self.assertEqual(layer_mode, "int8")
+            self.assertEqual(scheme, "int8_from_float32")
+
+        # The relu activation does not support quantization and is recorded
+        # as such (rather than being silently dropped).
+        unsupported = report.skipped_by_reason(
+            QuantizationReport.SKIP_NO_SUPPORT
+        )
+        self.assertIn("act", unsupported)
+        self.assertEqual(report.num_errors, 0)
+
+        # Input layers carry no weights and must never appear in the report as
+        # skipped entries (they are neither quantizable nor a meaningful skip).
+        skipped_paths = [path for path, _ in report.skipped]
+        input_layers = [
+            layer
+            for layer in model._flatten_layers()
+            if isinstance(layer, layers.InputLayer)
+        ]
+        self.assertTrue(input_layers)  # sanity: the model has an input layer
+        for layer in input_layers:
+            self.assertNotIn(layer.path or layer.name, skipped_paths)
+
+    def test_quantize_report_filtered_reason(self):
+        model = self._get_mixed_layer_model()
+
+        report = model.quantize("int8", filters="d1", verbose=False)
+
+        quantized_paths = [path for path, _, _ in report.quantized]
+        self.assertEqual(quantized_paths, ["d1"])
+        # `d2` is a quantizable layer that was excluded by the filter.
+        filtered = report.skipped_by_reason(QuantizationReport.SKIP_FILTERED)
+        self.assertIn("d2", filtered)
+
+    def test_quantize_emits_single_summary_warning(self):
+        model = self._get_mixed_layer_model()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            model.quantize("int8", verbose=False)
+
+        # Exactly one summary warning is emitted (instead of one per
+        # non-quantizable leaf layer).
+        summary_warnings = [
+            w for w in caught if "`model.quantize()`" in str(w.message)
+        ]
+        self.assertLen(summary_warnings, 1)
+        self.assertIn(
+            "do not support quantization",
+            str(summary_warnings[0].message),
+        )
+
+    def test_quantize_verbose_prints_report(self):
+        model = self._get_mixed_layer_model()
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            model.quantize("int8", verbose=True)
+        output = buffer.getvalue()
+        self.assertIn("Quantization report (mode='int8')", output)
+
+    def test_quantize_propagates_attribute_error(self):
+        class BrokenLayer(layers.Layer):
+            def build(self, input_shape):
+                self.w = self.add_weight(shape=(input_shape[-1], 3), name="w")
+
+            def call(self, inputs):
+                return ops.matmul(inputs, self.w)
+
+            def quantize(self, mode=None, type_check=True, config=None):
+                raise AttributeError("boom: real bug in custom layer")
+
+        inputs = layers.Input([4])
+        outputs = BrokenLayer()(inputs)
+        model = Model(inputs, outputs)
+
+        # A real `AttributeError` from a layer must propagate rather than be
+        # silently swallowed.
+        with self.assertRaisesRegex(AttributeError, "boom: real bug"):
+            model.quantize("int8", verbose=False)
+
+    def test_quantize_gptq_without_structure_leaves_model_untouched(self):
+        inputs = layers.Input([8], name="in")
+        x = layers.Dense(8, name="g1")(inputs)
+        outputs = layers.Dense(4, name="g2")(x)
+        model = Model(inputs, outputs)
+
+        dense_layers = [
+            layer for layer in model.layers if isinstance(layer, layers.Dense)
+        ]
+        pre_policies = [layer.dtype_policy.name for layer in dense_layers]
+
+        config = GPTQConfig(dataset=["a"], tokenizer=lambda t: t)
+        with self.assertRaisesRegex(ValueError, "quantization structure"):
+            model.quantize("gptq", config=config, verbose=False)
+
+        # Structure resolution happens before any mutation, so a missing
+        # structure leaves the model completely untouched: float kernels,
+        # original dtype policies, and no half-allocated packed buffers.
+        for layer, pre in zip(dense_layers, pre_policies):
+            self.assertEqual(layer.dtype_policy.name, pre)
+            self.assertFalse(getattr(layer, "_is_quantized", False))
+            self.assertFalse(hasattr(layer, "quantized_kernel"))
+            self.assertEqual(
+                backend.standardize_dtype(layer.kernel.dtype), "float32"
+            )
+        # No report is attached when the call aborts before quantizing.
+        self.assertFalse(hasattr(model, "_quantization_report"))
+
+    def test_quantize_gptq_reports_layers_outside_structure(self):
+        vocab_size, seq_len, embed_dim = 16, 4, 4
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab_size, embed_dim, name="emb")
+        x = embedding(inputs)
+        block = Sequential([layers.Dense(embed_dim, name="d1")])
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        head = layers.Dense(2, name="head")
+        outputs = head(x)
+        model = Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=3)
+        config = GPTQConfig(
+            dataset=[
+                rng.integers(0, vocab_size, size=(1, seq_len)).astype("int32")
+            ],
+            tokenizer=lambda t: t,
+            num_samples=1,
+            sequence_length=seq_len,
+            group_size=-1,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+        report = model.quantize("gptq", config=config, verbose=False)
+
+        # Only the structure-covered Dense is quantized; everything else is
+        # reported as outside the quantization structure.
+        quantized_paths = [path for path, _, _ in report.quantized]
+        self.assertEqual(quantized_paths, [block.layers[0].path])
+        outside = report.skipped_by_reason(
+            QuantizationReport.SKIP_OUTSIDE_STRUCTURE
+        )
+        self.assertIn(head.path, outside)
+        self.assertIn(embedding.path, outside)
+        self.assertIsNone(getattr(head, "quantization_mode", None))
+        self.assertFalse(hasattr(head, "quantized_kernel"))
+
+    def test_quantization_summary_int8(self):
+        inputs = layers.Input([256], name="in")
+        outputs = layers.Dense(128, name="d1")(inputs)
+        model = Model(inputs, outputs)
+        model.quantize("int8", verbose=False)
+
+        summary = model.quantization_summary(verbose=False)
+        self.assertIn("d1", summary)
+        self.assertIn("int8_from_float32", summary)
+        self.assertIn("weight store : int8 (32768 bytes)", summary)
+        self.assertIn("Quantized layers : 1", summary)
+        self.assertIn("4.00x smaller", summary)
 
     def test_get_state_tree(self):
         model = _get_model_single_output()

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -987,6 +987,41 @@ class ModelTest(testing.TestCase):
         filtered = report.skipped_by_reason(QuantizationReport.SKIP_FILTERED)
         self.assertIn("d2", filtered)
 
+    def test_quantize_dense_with_layer_activation(self):
+        # A `Dense` whose activation is a `Layer` owns that `Layer` as a
+        # sub-layer, but is still quantizable and must not be skipped.
+        inputs = layers.Input([4], name="in")
+        outputs = layers.Dense(4, activation=layers.ReLU(), name="act_dense")(
+            inputs
+        )
+        model = Model(inputs, outputs)
+
+        rep = model.quantize("int8", verbose=False)
+
+        dense = model.get_layer("act_dense")
+        quantized_paths = [p for p, _, _ in rep.quantized]
+        self.assertIn(dense.path, quantized_paths)
+        self.assertEqual(dense.quantization_mode, "int8")
+
+        y = model(np.random.rand(2, 4))
+        self.assertTrue(np.all(np.isfinite(ops.convert_to_numpy(y))))
+
+    def test_quantize_visits_nested_model_layers_once(self):
+        # A nested `Model` is skipped as a unit (its layers are already
+        # visited by the recursive walk), so its inner `Dense` is quantized
+        # exactly once and the `Sequential` wrapper itself is never quantized.
+        inner = Sequential([layers.Dense(4, name="inner_dense")])
+        inputs = layers.Input([4], name="in")
+        outputs = inner(inputs)
+        model = Model(inputs, outputs)
+
+        rep = model.quantize("int8", verbose=False)
+
+        inner_dense = inner.get_layer("inner_dense")
+        quantized_paths = [p for p, _, _ in rep.quantized]
+        self.assertEqual(quantized_paths.count(inner_dense.path), 1)
+        self.assertNotIn(inner.path, quantized_paths)
+
     def test_quantize_emits_single_summary_warning(self):
         model = self._get_mixed_layer_model()
 

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -204,9 +204,11 @@ def find_layers_in_block(block):
     """
     found_layers = {}
     for sub_layer in block._flatten_layers():
-        if len(list(sub_layer._flatten_layers())) == 1:
-            if isinstance(sub_layer, (Dense, EinsumDense)):
-                found_layers[sub_layer.path] = sub_layer
+        # A quantizable layer may own sub-layers (e.g. a `Layer`
+        # activation), so no leaf filtering here — collect every Dense/
+        # EinsumDense reachable inside the block.
+        if isinstance(sub_layer, (Dense, EinsumDense)):
+            found_layers[sub_layer.path] = sub_layer
     return found_layers
 
 

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -16,6 +16,7 @@ from keras.src.quantizers.gptq import GPTQ
 from keras.src.quantizers.gptq import _stable_permutation
 from keras.src.quantizers.gptq import gptq_quantize_matrix
 from keras.src.quantizers.gptq_config import GPTQConfig
+from keras.src.quantizers.gptq_core import find_layers_in_block
 from keras.src.quantizers.quantization_config import QuantizationConfig
 from keras.src.quantizers.quantizers import dequantize_with_sz_map
 from keras.src.quantizers.quantizers import dequantize_with_zero_point
@@ -383,6 +384,28 @@ class GPTQTest(testing.TestCase):
             unordered_layer.get_weights()[0],
             msg="Weights should be identical as the permutation is undone.",
         )
+
+    def test_find_layers_in_block_includes_layers_with_sub_layers(self):
+        """`Dense`/`EinsumDense` are collected even when they own sub-layers.
+
+        A `Dense` whose activation is a `Layer` owns that `Layer`, so a leaf
+        filter would wrongly hide it from calibration. `find_layers_in_block`
+        must return both such a `Dense` and a plain `Dense`.
+        """
+        block = models.Sequential(
+            [
+                layers.Dense(8, activation=layers.ReLU()),
+                layers.Dense(8),
+            ]
+        )
+        block.build((None, 8))
+
+        found = find_layers_in_block(block)
+
+        self.assertEqual(len(found), 2)
+        for dense in block.layers:
+            self.assertIn(dense.path, found)
+            self.assertIs(found[dense.path], dense)
 
 
 def _compute_scale_zero(x, **_):
@@ -808,6 +831,54 @@ class TestModelQuantization(testing.TestCase):
         y_after = reloaded.predict(x_eval)
 
         self.assertAllClose(y_before, y_after)
+
+    def test_gptq_calibrates_dense_with_layer_activation(self):
+        """A `Dense` with a `Layer` activation inside a block is calibrated.
+
+        The activation `Layer` makes the `Dense` a non-leaf, but GPTQ must
+        still discover and calibrate it: after `quantize("gptq")` the layer
+        is in `gptq` mode with `is_gptq_calibrated` set.
+        """
+        keras.utils.set_random_seed(123)
+        embed_dim = 8
+
+        block = models.Sequential(
+            [layers.Dense(embed_dim, activation=layers.ReLU())]
+        )
+
+        inputs = layers.Input(shape=(SEQ_LEN,), dtype="int32")
+        embedding = layers.Embedding(VOCAB_SIZE, embed_dim)
+        x = embedding(inputs)
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        outputs = layers.Dense(NUM_CLASSES)(x)
+        model = models.Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=7)
+        dataset = [
+            rng.integers(0, VOCAB_SIZE, size=(1, SEQ_LEN), dtype=np.int32)
+            for _ in range(4)
+        ]
+        tokenizer = _char_tokenizer(vocab_size=VOCAB_SIZE, seq_len=SEQ_LEN)
+
+        config = GPTQConfig(
+            dataset=dataset,
+            tokenizer=tokenizer,
+            weight_bits=4,
+            group_size=8,
+            num_samples=4,
+            sequence_length=SEQ_LEN,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        model.quantize("gptq", config=config)
+
+        act_dense = block.layers[0]
+        self.assertEqual(act_dense.quantization_mode, "gptq")
+        self.assertTrue(act_dense.is_gptq_calibrated)
 
     def test_gptq_missing_structure_leaves_model_unmodified(self):
         """A config without a structure raises before any layer is mutated."""

--- a/keras/src/quantizers/report.py
+++ b/keras/src/quantizers/report.py
@@ -1,0 +1,147 @@
+"""Observability helpers for `model.quantize()`.
+
+This module defines :class:`QuantizationReport`, a small structured record of
+what happened during a `model.quantize()` call (which layers were quantized,
+which were skipped and why, and any recorded errors).
+"""
+
+from keras.src.api_export import keras_export
+
+
+@keras_export("keras.quantizers.QuantizationReport")
+class QuantizationReport:
+    """Structured summary of a single `model.quantize()` call.
+
+    A report is returned by `model.quantize()` and also stored on the model as
+    `model._quantization_report`. It records, per leaf layer, whether the layer
+    was quantized, skipped (with the reason), or hit a recorded error.
+
+    The possible skip reasons are available as class attributes on
+    `QuantizationReport` (`SKIP_NO_SUPPORT`, `SKIP_FILTERED`,
+    `SKIP_ALREADY_QUANTIZED`, `SKIP_OUTSIDE_STRUCTURE`).
+
+    Args:
+        mode: The resolved quantization mode for the call (e.g. `"int8"`).
+            Defaults to `None`.
+
+    Attributes:
+        mode: The resolved quantization mode for the call.
+        quantized: A list of `(path, mode, scheme)` tuples, one per quantized
+            layer, where `scheme` is a short description of the resolved
+            quantization scheme (e.g. the layer's dtype-policy name).
+        skipped: A list of `(path, reason)` tuples. `reason` is one of
+            `SKIP_NO_SUPPORT` (the layer does not implement quantization),
+            `SKIP_FILTERED` (the layer was excluded by `filters`),
+            `SKIP_ALREADY_QUANTIZED` (the layer was already quantized), or
+            `SKIP_OUTSIDE_STRUCTURE` (a GPTQ/AWQ call whose quantization
+            layer structure does not cover the layer).
+        errors: A list of `(path, message)` tuples for any non-fatal errors
+            recorded during the call. In the default flow real errors are
+            allowed to propagate, so this list is normally empty; it exists so
+            callers can attach recoverable diagnostics.
+    """
+
+    # Reasons a leaf layer can be skipped during quantization.
+    SKIP_NO_SUPPORT = "no quantize support"
+    SKIP_FILTERED = "filtered out"
+    SKIP_ALREADY_QUANTIZED = "already quantized"
+    SKIP_OUTSIDE_STRUCTURE = "outside quantization structure"
+
+    def __init__(self, mode=None):
+        self.mode = mode
+        self.quantized = []
+        self.skipped = []
+        self.errors = []
+
+    def add_quantized(self, path, mode, scheme):
+        self.quantized.append((path, mode, scheme))
+
+    def add_skipped(self, path, reason):
+        self.skipped.append((path, reason))
+
+    def add_error(self, path, error):
+        self.errors.append((path, str(error)))
+
+    @property
+    def num_quantized(self):
+        return len(self.quantized)
+
+    @property
+    def num_skipped(self):
+        return len(self.skipped)
+
+    @property
+    def num_errors(self):
+        return len(self.errors)
+
+    def skipped_by_reason(self, reason):
+        """Return the list of layer paths that were skipped for `reason`."""
+        return [path for path, r in self.skipped if r == reason]
+
+    def summary_warning(self, max_examples=5):
+        """Return a single warning message, or `None` if nothing to warn about.
+
+        This replaces the previous behavior of emitting one `UserWarning` per
+        non-quantizable leaf layer with a single message that reports counts
+        and up to `max_examples` example layer names.
+        """
+        unsupported = self.skipped_by_reason(self.SKIP_NO_SUPPORT)
+        if not unsupported and not self.errors:
+            return None
+
+        parts = []
+        if unsupported:
+            examples = ", ".join(repr(p) for p in unsupported[:max_examples])
+            if len(unsupported) > max_examples:
+                examples += ", ..."
+            parts.append(
+                f"{len(unsupported)} layer(s) were skipped because they do "
+                f"not support quantization (e.g. {examples})."
+            )
+        if self.errors:
+            error_examples = ", ".join(
+                repr(p) for p, _ in self.errors[:max_examples]
+            )
+            if len(self.errors) > max_examples:
+                error_examples += ", ..."
+            parts.append(
+                f"{len(self.errors)} layer(s) reported errors "
+                f"(e.g. {error_examples})."
+            )
+        parts.append(
+            f"Quantized {self.num_quantized} layer(s) in mode "
+            f"'{self.mode}'. Call `model.quantization_summary()` or inspect "
+            "the returned `QuantizationReport` for details."
+        )
+        return "`model.quantize()`: " + " ".join(parts)
+
+    def render(self):
+        """Return the full report as a multi-line string."""
+        lines = [f"Quantization report (mode='{self.mode}')"]
+        lines.append("=" * 65)
+        lines.append(f"Quantized {self.num_quantized} layer(s):")
+        if self.quantized:
+            for path, mode, scheme in self.quantized:
+                lines.append(f"  - {path} ({mode}): {scheme}")
+        else:
+            lines.append("  (none)")
+
+        lines.append(f"Skipped {self.num_skipped} layer(s):")
+        if self.skipped:
+            for path, reason in self.skipped:
+                lines.append(f"  - {path}: {reason}")
+        else:
+            lines.append("  (none)")
+
+        if self.errors:
+            lines.append(f"Errors on {self.num_errors} layer(s):")
+            for path, message in self.errors:
+                lines.append(f"  - {path}: {message}")
+        return "\n".join(lines)
+
+    def __repr__(self):
+        return (
+            f"QuantizationReport(mode={self.mode!r}, "
+            f"quantized={self.num_quantized}, skipped={self.num_skipped}, "
+            f"errors={self.num_errors})"
+        )

--- a/keras/src/quantizers/report_test.py
+++ b/keras/src/quantizers/report_test.py
@@ -1,0 +1,103 @@
+from keras.src import testing
+from keras.src.quantizers.report import QuantizationReport
+
+
+class QuantizationReportTest(testing.TestCase):
+    def test_empty_report(self):
+        report = QuantizationReport(mode="int8")
+        self.assertEqual(report.mode, "int8")
+        self.assertEqual(report.num_quantized, 0)
+        self.assertEqual(report.num_skipped, 0)
+        self.assertEqual(report.num_errors, 0)
+        self.assertIsNone(report.summary_warning())
+
+    def test_add_and_query(self):
+        report = QuantizationReport(mode="int8")
+        report.add_quantized("dense", "int8", "int8_from_float32")
+        report.add_skipped("act", QuantizationReport.SKIP_NO_SUPPORT)
+        report.add_skipped("bn", QuantizationReport.SKIP_FILTERED)
+        report.add_skipped("d2", QuantizationReport.SKIP_ALREADY_QUANTIZED)
+
+        self.assertEqual(report.num_quantized, 1)
+        self.assertEqual(report.num_skipped, 3)
+        self.assertEqual(
+            report.quantized, [("dense", "int8", "int8_from_float32")]
+        )
+        self.assertEqual(
+            report.skipped_by_reason(QuantizationReport.SKIP_NO_SUPPORT),
+            ["act"],
+        )
+        self.assertEqual(
+            report.skipped_by_reason(QuantizationReport.SKIP_FILTERED), ["bn"]
+        )
+        self.assertEqual(
+            report.skipped_by_reason(QuantizationReport.SKIP_ALREADY_QUANTIZED),
+            ["d2"],
+        )
+
+    def test_summary_warning_reports_unsupported(self):
+        report = QuantizationReport(mode="int8")
+        report.add_quantized("dense", "int8", "int8_from_float32")
+        report.add_skipped("act", QuantizationReport.SKIP_NO_SUPPORT)
+        report.add_skipped("input", QuantizationReport.SKIP_NO_SUPPORT)
+        # Filtered layers must not trigger a warning.
+        report.add_skipped("bn", QuantizationReport.SKIP_FILTERED)
+
+        message = report.summary_warning()
+        self.assertIsNotNone(message)
+        self.assertIn("2 layer(s) were skipped", message)
+        self.assertIn("'act'", message)
+        self.assertIn("'input'", message)
+        # Filtered layers are not mentioned as unsupported.
+        self.assertNotIn("'bn'", message)
+
+    def test_summary_warning_none_when_only_filtered(self):
+        report = QuantizationReport(mode="int8")
+        report.add_quantized("dense", "int8", "int8_from_float32")
+        report.add_skipped("bn", QuantizationReport.SKIP_FILTERED)
+        report.add_skipped("d2", QuantizationReport.SKIP_ALREADY_QUANTIZED)
+        self.assertIsNone(report.summary_warning())
+
+    def test_summary_warning_caps_examples(self):
+        report = QuantizationReport(mode="int8")
+        for i in range(8):
+            report.add_skipped(f"layer_{i}", QuantizationReport.SKIP_NO_SUPPORT)
+        message = report.summary_warning(max_examples=5)
+        self.assertIn("8 layer(s) were skipped", message)
+        self.assertIn("...", message)
+        # Only the first five names appear.
+        self.assertIn("'layer_0'", message)
+        self.assertIn("'layer_4'", message)
+        self.assertNotIn("'layer_5'", message)
+
+    def test_render_contains_sections(self):
+        report = QuantizationReport(mode="int8")
+        report.add_quantized("dense", "int8", "int8_from_float32")
+        report.add_skipped("act", QuantizationReport.SKIP_NO_SUPPORT)
+        rendered = report.render()
+        self.assertIn("Quantization report (mode='int8')", rendered)
+        self.assertIn("Quantized 1 layer(s):", rendered)
+        self.assertIn("dense (int8): int8_from_float32", rendered)
+        self.assertIn("Skipped 1 layer(s):", rendered)
+        self.assertIn("act: no quantize support", rendered)
+
+    def test_repr(self):
+        report = QuantizationReport(mode="int4")
+        report.add_quantized("dense", "int4", "int4/-1_from_float32")
+        self.assertIn("mode='int4'", repr(report))
+        self.assertIn("quantized=1", repr(report))
+
+    def test_skip_reasons_exposed_as_class_attributes(self):
+        # The skip reasons are available as class attributes on
+        # `QuantizationReport`.
+        self.assertEqual(
+            QuantizationReport.SKIP_NO_SUPPORT, "no quantize support"
+        )
+        self.assertEqual(QuantizationReport.SKIP_FILTERED, "filtered out")
+        self.assertEqual(
+            QuantizationReport.SKIP_ALREADY_QUANTIZED, "already quantized"
+        )
+        self.assertEqual(
+            QuantizationReport.SKIP_OUTSIDE_STRUCTURE,
+            "outside quantization structure",
+        )

--- a/keras/src/utils/summary_utils.py
+++ b/keras/src/utils/summary_utils.py
@@ -442,3 +442,89 @@ def get_layer_index_bound_by_layer_name(layers, layer_range=None):
     if min(lower_index) > max(upper_index):
         return [min(upper_index), max(lower_index) + 1]
     return [min(lower_index), max(upper_index) + 1]
+
+
+def print_quantization_summary(model, verbose=True):
+    """Build (and optionally print) a per-quantized-layer summary of a model.
+
+    See `Model.quantization_summary` for a description of the reported fields.
+
+    Args:
+        model: Keras model instance.
+        verbose: Whether to print the summary. Defaults to `True`. The summary
+            string is always returned.
+
+    Returns:
+        The summary as a string.
+    """
+
+    def _weight_bytes(weight):
+        num_elements = math.prod(weight.shape)
+        dtype = backend.standardize_dtype(weight.dtype)
+        return num_elements * dtype_utils.dtype_size(dtype) // 8
+
+    rows = []
+    total_quantized_bytes = 0
+    total_float_bytes = 0
+    total_logical_params = 0
+    for layer in model._flatten_layers():
+        # Only leaf layers (those without sub-layers) are quantizable.
+        if len(list(layer._flatten_layers())) != 1:
+            continue
+        mode = layer.quantization_mode
+        if mode is None:
+            continue
+        weights = list(layer.weights)
+        if not weights:
+            continue
+
+        # The primary quantized weight is the largest one (the kernel).
+        primary = max(weights, key=lambda w: math.prod(w.shape))
+        storage_dtype = backend.standardize_dtype(primary.dtype)
+        storage_bytes = _weight_bytes(primary)
+
+        # 4-bit modes pack two values per stored byte, so the logical
+        # (unpacked) element count is twice the stored count.
+        multiplier = 2 if mode in ("int4", "gptq", "awq") else 1
+        logical_params = math.prod(primary.shape) * multiplier
+        float_bytes = logical_params * 4  # float32 baseline.
+
+        rows.append(
+            {
+                "path": layer.path or layer.name,
+                "policy": layer.dtype_policy.name,
+                "dtype": storage_dtype,
+                "bytes": storage_bytes,
+            }
+        )
+        total_quantized_bytes += storage_bytes
+        total_float_bytes += float_bytes
+        total_logical_params += logical_params
+
+    lines = [f"Quantization summary for '{model.name}'", "=" * 65]
+    if not rows:
+        lines.append("No quantized layers found.")
+    else:
+        for row in rows:
+            lines.append(f"Layer: {row['path']}")
+            lines.append(f"  dtype policy : {row['policy']}")
+            lines.append(
+                f"  weight store : {row['dtype']} ({row['bytes']} bytes)"
+            )
+        lines.append("-" * 65)
+        lines.append(f"Quantized layers : {len(rows)}")
+        lines.append(f"Quantized params : {total_logical_params}")
+        ratio = (
+            total_float_bytes / total_quantized_bytes
+            if total_quantized_bytes
+            else 0.0
+        )
+        lines.append(
+            f"Weight storage   : {total_quantized_bytes} bytes quantized "
+            f"vs {total_float_bytes} bytes float32 "
+            f"({ratio:.2f}x smaller)"
+        )
+    summary = "\n".join(lines)
+    if verbose:
+        io_utils.print_msg(summary)
+    return summary


### PR DESCRIPTION
## Problem

`model.quantize()` was opaque and could leave the model in a broken state:

- It emitted one `UserWarning` per non-quantizable leaf layer (a "warning storm" on any real model), and silently swallowed every `AttributeError` raised during a layer's `quantize()` (`except AttributeError: pass`), hiding real bugs behind the "unsupported layer" path.
- It returned `None` and exposed no record of what was quantized, skipped, or why.
- Calling `quantize()` on a model that already contained a quantized layer died with `ValueError: Layer '...' is already quantized ...`, so a partially-quantized model could never be finished with a second pass.
- For structure-aware modes (`gptq`/`awq`), it mutated every `Dense` (allocated packed buffers, swapped dtype policies) in the per-layer loop and only afterwards resolved/validated `quantization_layer_structure`. A missing structure raised `ValueError` after the mutation, leaving the model half-quantized.

## Changes

- New module `keras/src/quantizers/report.py` with `QuantizationReport` (quantized `[(path, mode, scheme)]`, skipped `[(path, reason)]` with the reason distinguishing `no quantize support` / `filtered out` / `already quantized`, and an `errors` list).
- `Model.quantize()` now collects a `QuantizationReport` during the loop and:
  * emits ONE summary warning (counts + up to 5 example layer names) instead of the per-layer storm;
  * only treats `NotImplementedError` as "unsupported layer" — any other exception (e.g. `AttributeError`) now propagates;
  * distinguishes skip reasons via pre-checks (`filters`, `_is_quantized`); already-quantized layers are now recorded as `already quantized` skips and the rest of the model proceeds, where this previously was a fatal `ValueError`;
  * excludes `InputLayer`s from the report entirely — they carry no weights, so counting them as "skipped" only added noise to the totals and to the warning's example names;
  * attaches the report to `model._quantization_report` and returns it (previously returned `None`). `quantize_wrapper` in `layer.py` was updated to propagate the return value.
- GPTQ/AWQ fail-safe: structure resolution/validation is moved BEFORE the layer-mutation loop, so a missing/invalid structure leaves the model completely untouched (float kernels, original dtype policies, no buffers).
- Public API: the report machinery is exported as `keras.quantizers.QuantizationReport` and `keras.quantizers.compute_path_label`, with the skip reasons mirrored as class attributes (`QuantizationReport.SKIP_NO_SUPPORT` / `SKIP_FILTERED` / `SKIP_ALREADY_QUANTIZED` / `SKIP_OUTSIDE_STRUCTURE`). Generated API files updated via `api_gen`.
- New `Model.quantization_summary()` prints, per quantized layer, the path, dtype policy, weight storage dtype + bytes, and an honest, statically derived compute-path label (int8 -> native int8 GEMM; int4 per-channel -> unpack->int8 kernel storage-only; int4 grouped / gptq / awq -> dequantize->float storage-only; float8 -> QDQ), plus totals (params, quantized bytes vs float32 bytes).

## Evidence
[Colab Demo](https://colab.research.google.com/gist/JyotinderSingh/37f426305edcbe55102d10d45b721367/demo_quantize_observability.ipynb)

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.