### PR TITLE
docs: document PIL.Image.DecompressionBombError in load_img

### DIFF
--- a/keras/src/utils/image_utils.py
+++ b/keras/src/utils/image_utils.py
@@ -206,42 +206,42 @@ def load_img(
 ):
     """Loads an image into PIL format.
 
-    Example:
+        Example:
 
-    ```python
-    image = keras.utils.load_img(image_path)
-    input_arr = keras.utils.img_to_array(image)
-    input_arr = np.array([input_arr])  # Convert single image to a batch.
-    predictions = model.predict(input_arr)
-    ```
-    Note:
-        This function uses Pillow (`PIL.Image`) internally. If an oversized image
-        is loaded, Pillow may raise a `PIL.Image.DecompressionBombError`. This is 
-        a built-in security mechanism to prevent decompression bomb DOS attacks. 
-        The maximum image size is governed by `PIL.Image.MAX_IMAGE_PIXELS`. To change 
-        this limit, see the Pillow documentation:
-        
-https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.MAX_IMAGE_PIXELS
+        ```python
+        image = keras.utils.load_img(image_path)
+        input_arr = keras.utils.img_to_array(image)
+        input_arr = np.array([input_arr])  # Convert single image to a batch.
+        predictions = model.predict(input_arr)
+        ```
+        Note:
+            This function uses Pillow (`PIL.Image`) internally. If an oversized image
+            is loaded, Pillow may raise a `PIL.Image.DecompressionBombError`. This is
+            a built-in security mechanism to prevent decompression bomb DOS attacks.
+            The maximum image size is governed by `PIL.Image.MAX_IMAGE_PIXELS`. To change
+            this limit, see the Pillow documentation:
 
-    Args:
-        path: Path to image file.
-        color_mode: One of `"grayscale"`, `"rgb"`, `"rgba"`. Default: `"rgb"`.
-            The desired image format.
-        target_size: Either `None` (default to original size) or tuple of ints
-            `(img_height, img_width)`.
-        interpolation: Interpolation method used to resample the image if the
-            target size is different from that of the loaded image. Supported
-            methods are `"nearest"`, `"bilinear"`, and `"bicubic"`.
-            If PIL version 1.1.3 or newer is installed, `"lanczos"`
-            is also supported. If PIL version 3.4.0 or newer is installed,
-            `"box"` and `"hamming"` are also
-            supported. By default, `"nearest"` is used.
-        keep_aspect_ratio: Boolean, whether to resize images to a target
-            size without aspect ratio distortion. The image is cropped in
-            the center with target aspect ratio before resizing.
+    https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.MAX_IMAGE_PIXELS
 
-    Returns:
-        A PIL Image instance.
+        Args:
+            path: Path to image file.
+            color_mode: One of `"grayscale"`, `"rgb"`, `"rgba"`. Default: `"rgb"`.
+                The desired image format.
+            target_size: Either `None` (default to original size) or tuple of ints
+                `(img_height, img_width)`.
+            interpolation: Interpolation method used to resample the image if the
+                target size is different from that of the loaded image. Supported
+                methods are `"nearest"`, `"bilinear"`, and `"bicubic"`.
+                If PIL version 1.1.3 or newer is installed, `"lanczos"`
+                is also supported. If PIL version 3.4.0 or newer is installed,
+                `"box"` and `"hamming"` are also
+                supported. By default, `"nearest"` is used.
+            keep_aspect_ratio: Boolean, whether to resize images to a target
+                size without aspect ratio distortion. The image is cropped in
+                the center with target aspect ratio before resizing.
+
+        Returns:
+            A PIL Image instance.
     """
     if pil_image is None:
         raise ImportError(

--- a/keras/src/utils/image_utils.py
+++ b/keras/src/utils/image_utils.py
@@ -214,6 +214,14 @@ def load_img(
     input_arr = np.array([input_arr])  # Convert single image to a batch.
     predictions = model.predict(input_arr)
     ```
+    Note:
+        This function uses Pillow (`PIL.Image`) internally. If an oversized image
+        is loaded, Pillow may raise a `PIL.Image.DecompressionBombError`. This is 
+        a built-in security mechanism to prevent decompression bomb DOS attacks. 
+        The maximum image size is governed by `PIL.Image.MAX_IMAGE_PIXELS`. To change 
+        this limit, see the Pillow documentation:
+        
+https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.MAX_IMAGE_PIXELS
 
     Args:
         path: Path to image file.


### PR DESCRIPTION
### Description
This PR improves the documentation for keras.utils.load_img() #23317 .

When working with very large images, load_img() correctly inherits Pillow's built-in DOS attack protection (PIL.Image.MAX_IMAGE_PIXELS). If an image exceeds this pixel limit, Pillow throws a PIL.Image.DecompressionBombError. However, this expected behavior was not previously documented, which could lead to confusion when developers unexpectedly encountered the error.

### Changes Made
* Added a Note: section to the load_img docstring in keras/src/utils/image_utils.py.
* Explicitly stated that load_img uses Pillow internally and may throw a DecompressionBombError.
* Provided a link to the Pillow documentation so developers can understand and override PIL.Image.MAX_IMAGE_PIXELS if  needed for their specific use cases.

### Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.