### PR TITLE
[OpenVINO] Use native adaptive pooling ops

### DIFF
--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -11,6 +11,7 @@ from keras.src.backend.openvino.core import OPENVINO_DTYPES
 from keras.src.backend.openvino.core import OpenVINOKerasTensor
 from keras.src.backend.openvino.core import get_ov_output
 from keras.src.backend.openvino.core import ov_to_keras_type
+from keras.src.backend.openvino.core import shape_to_ov_output
 
 
 def relu(x):
@@ -377,7 +378,7 @@ def _adaptive_pool_ov(
     # AdaptiveAvgPool/AdaptiveMaxPool expect NCHW, and `output_shape` holds
     # only the spatial dims.
     current = _adjust_input(inputs, num_spatial_dims, data_format)
-    output_shape = ov_opset.constant(list(output_size), Type.i32).output(0)
+    output_shape = shape_to_ov_output(output_size)
 
     if pool_type == "avg":
         pooled = ov_opset.adaptive_avg_pool(current, output_shape).output(0)

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -364,127 +364,30 @@ def average_pool(
     )
 
 
-def _compute_adaptive_gather_indices(
-    input_dim, output_size, small_window, big_window
-):
-    """Compute gather indices for the two-pool gather method."""
-    window_starts = np.floor(
-        np.arange(output_size) * input_dim / output_size
-    ).astype(np.int32)
-    window_ends = np.minimum(
-        np.ceil(np.arange(1, output_size + 1) * input_dim / output_size).astype(
-            np.int32
-        ),
-        input_dim,
-    )
-    window_starts = np.minimum(window_starts, input_dim - 1)
-    window_sizes = window_ends - window_starts
-    small_pool_len = max(1, input_dim - small_window + 1)
-    return np.where(
-        window_sizes == big_window,
-        window_starts + small_pool_len,
-        window_starts,
-    ).tolist()
-
-
 def _adaptive_pool_ov(
     inputs, output_size, pool_type, data_format, num_spatial_dims
 ):
-    """Shared OpenVINO implementation for adaptive average/max pooling.
-
-    Uses the two-pool gather method: for each spatial axis independently,
-    apply pooling with the small and big kernel sizes (stride=1, VALID),
-    concatenate the results, then gather the correct output positions.
-    """
+    """Shared OpenVINO implementation for adaptive average/max pooling."""
     if isinstance(output_size, int):
         output_size = (output_size,) * num_spatial_dims
 
     data_format = backend.standardize_data_format(data_format)
     inputs = get_ov_output(inputs)
 
+    # AdaptiveAvgPool/AdaptiveMaxPool expect NCHW, and `output_shape` holds
+    # only the spatial dims.
     current = _adjust_input(inputs, num_spatial_dims, data_format)
+    output_shape = ov_opset.constant(list(output_size), Type.i32).output(0)
 
-    for spatial_idx in range(num_spatial_dims):
-        gather_axis = 2 + spatial_idx
-        current_ps = current.get_partial_shape()
-        input_dim = current_ps[gather_axis].get_length()
-        output_dim = output_size[spatial_idx]
+    if pool_type == "avg":
+        pooled = ov_opset.adaptive_avg_pool(current, output_shape).output(0)
+    else:
+        # AdaptiveMaxPool also returns the argmax indices as output 1.
+        pooled = ov_opset.adaptive_max_pool(
+            current, output_shape, index_element_type="i32"
+        ).output(0)
 
-        if input_dim == output_dim:
-            continue
-
-        small_w = int(np.ceil(input_dim / output_dim))
-        big_w = small_w + 1
-        gather_indices = _compute_adaptive_gather_indices(
-            input_dim, output_dim, small_w, big_w
-        )
-
-        strides = [1] * num_spatial_dims
-
-        small_kernel = [1] * num_spatial_dims
-        small_kernel[spatial_idx] = small_w
-
-        if pool_type == "avg":
-            small_pool = ov_opset.avg_pool(
-                current,
-                strides=strides,
-                pads_begin=[],
-                pads_end=[],
-                kernel_shape=small_kernel,
-                exclude_pad=True,
-                auto_pad="VALID",
-                dilations=[1] * num_spatial_dims,
-            ).output(0)
-        else:
-            small_pool = ov_opset.max_pool(
-                current,
-                strides=strides,
-                dilations=[1] * num_spatial_dims,
-                pads_begin=[],
-                pads_end=[],
-                kernel_shape=small_kernel,
-                auto_pad="VALID",
-            ).output(0)
-
-        if big_w <= input_dim:
-            big_kernel = [1] * num_spatial_dims
-            big_kernel[spatial_idx] = big_w
-
-            if pool_type == "avg":
-                big_pool = ov_opset.avg_pool(
-                    current,
-                    strides=strides,
-                    pads_begin=[],
-                    pads_end=[],
-                    kernel_shape=big_kernel,
-                    exclude_pad=True,
-                    auto_pad="VALID",
-                    dilations=[1] * num_spatial_dims,
-                ).output(0)
-            else:
-                big_pool = ov_opset.max_pool(
-                    current,
-                    strides=strides,
-                    dilations=[1] * num_spatial_dims,
-                    pads_begin=[],
-                    pads_end=[],
-                    kernel_shape=big_kernel,
-                    auto_pad="VALID",
-                ).output(0)
-
-            combined = ov_opset.concat(
-                [small_pool, big_pool], gather_axis
-            ).output(0)
-        else:
-            # big_w > input_dim: the big pool produces no outputs and all
-            # gather indices come from the small pool, so skip the big pool.
-            combined = small_pool
-
-        indices_node = ov_opset.constant(gather_indices, Type.i32).output(0)
-        axis_node = ov_opset.constant(gather_axis, Type.i32).output(0)
-        current = ov_opset.gather(combined, indices_node, axis_node).output(0)
-
-    result = _adjust_outputs(current, num_spatial_dims, data_format)
+    result = _adjust_outputs(pooled, num_spatial_dims, data_format)
     return OpenVINOKerasTensor(result)
 
 


### PR DESCRIPTION
## Description
`_adaptive_pool_ov` emulated adaptive pooling with a two-pool gather trick instead of using the native ops.

The emulation ran two full stride-1 pooling passes over the entire input per spatial axis. For (1, 64, 224, 224) -> 7×7, the H-axis pass alone materialised a (1, 64, 385, 224) tensor (~22 MB) to gather 7 rows out of it, then repeated for W. It also required statically-known spatial dims to precompute gather indices in Python; the native op does not.

Performance: 
- graph nodes 8/14/20 -> 4. 
- Op-level inference 1.2×-3.6× faster (~2.1× aggregate)

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
