### PR TITLE
Fix multi_hot and unfold in graph mode for OpenVINO and TensorFlow

### DIFF
--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -869,10 +869,12 @@ def multi_hot(x, num_classes, axis=-1, dtype=None, sparse=False):
     reduction_axis = 1 if len(x.shape) > 1 else 0
     if backend.standardize_dtype(dtype) == "bool":
         outputs = one_hot(x, num_classes, axis=axis, dtype=dtype, sparse=sparse)
-        result = ov_opset.reduce_logical_or(outputs, reduction_axis)
+        result = ov_opset.reduce_logical_or(
+            get_ov_output(outputs), reduction_axis
+        )
     else:
         outputs = one_hot(x, num_classes, axis=axis, dtype=dtype)
-        result = ov_opset.reduce_max(outputs, reduction_axis)
+        result = ov_opset.reduce_max(get_ov_output(outputs), reduction_axis)
     return OpenVINOKerasTensor(result.output(0))
 
 
@@ -1352,27 +1354,35 @@ def unfold(input, kernel_size, dilation=1, padding=0, stride=1):
     p = _pair(padding)
     s = _pair(stride)
 
-    N, C, H, W = input.shape
-
     # ---- padding ----
     if any(_ > 0 for _ in p):
         input = onp.pad(input, ((0, 0), (0, 0), (p[0], p[0]), (p[1], p[1])))
 
+    image = get_ov_output(input)
+    C = image.get_partial_shape()[1].get_length()
+
     # ---- extract patches ----
     patches = ov_opset.extract_image_patches(
-        image=input,
+        image=image,
         sizes=[k[0], k[1]],
         strides=[s[0], s[1]],
         rates=[d[0], d[1]],
         auto_pad="VALID",
-    )  # (N, kH*kW*C, nH, nW)
-    N, D, nH, nW = patches.shape
-    patches = ov_opset.reshape(patches, [N, k[0], k[1], C, nH, nW], False)
-    patches = ov_opset.transpose(
-        patches, [0, 3, 1, 2, 4, 5]
-    )  # (N, C, kH, kW, nH, nW)
-    patches = ov_opset.reshape(patches, [N, C * k[0] * k[1], nH * nW], False)
-    return OpenVINOKerasTensor(patches.output(0))
+    ).output(0)  # (N, kH*kW*C, nH, nW)
+    patches_shape = patches.get_partial_shape()
+    nH = patches_shape[2].get_length()
+    nW = patches_shape[3].get_length()
+    # `-1` for the batch dim keeps the graph valid when it is dynamic, as it
+    # is under model.predict.
+    patches = ov_opset.reshape(
+        patches, [-1, k[0], k[1], C, nH, nW], False
+    ).output(0)
+    # (N, C, kH, kW, nH, nW)
+    patches = ov_opset.transpose(patches, [0, 3, 1, 2, 4, 5]).output(0)
+    patches = ov_opset.reshape(
+        patches, [-1, C * k[0] * k[1], nH * nW], False
+    ).output(0)
+    return OpenVINOKerasTensor(patches)
 
 
 def fold(x, output_size, kernel_size, dilation=1, padding=0, stride=1):

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -1886,13 +1886,15 @@ def unfold(input, kernel_size, dilation=1, padding=0, stride=1):
     )  # (N, nH, nW, kH*kW*C)
 
     N, nH, nW, D = patches.shape
+    # `-1` for the batch dim keeps the graph valid when it is dynamic, as it
+    # is for any functional model or model.predict.
     patches = tf.reshape(
-        patches, [N, nH, nW, k[0], k[1], C]
+        patches, [-1, nH, nW, k[0], k[1], C]
     )  # (N, nH, nW, kH, kW, C)
     patches = tf.transpose(
         patches, [0, 5, 3, 4, 1, 2]
     )  # (N, C, kH, kW, nH, nW)
-    patches = tf.reshape(patches, [N, C * k[0] * k[1], nH * nW])
+    patches = tf.reshape(patches, [-1, C * k[0] * k[1], nH * nW])
     return patches
 
 

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -313,6 +313,44 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knn.multi_hot(x, 5, 2).shape, (None, 5, 1))
         self.assertSparse(knn.multi_hot(x, 5, sparse=True))
 
+    def test_multi_hot_in_graph(self):
+        class MultiHotLayer(keras.Layer):
+            def call(self, x):
+                return ops.multi_hot(x, 5)
+
+            def compute_output_shape(self, input_shape):
+                # Avoids inferring the spec by calling `call` on an
+                # uninitialized placeholder, whose values are not valid
+                # indices for `one_hot`.
+                return (input_shape[0], 5)
+
+        class Model(keras.Model):
+            def __init__(self):
+                x = keras.Input(shape=(3,), dtype="int32")
+                y = MultiHotLayer()(x)
+                super().__init__(inputs=x, outputs=y)
+
+        # Make sure Keras is able to compile the model graph
+        model = Model()
+        x = ops.array([[0, 2, 4]], dtype="int32")
+        model.predict(x)
+
+    def test_unfold_in_graph(self):
+        class UnfoldLayer(keras.Layer):
+            def call(self, x):
+                return ops.unfold(x, kernel_size=2)
+
+        class Model(keras.Model):
+            def __init__(self):
+                x = keras.Input(shape=(2, 6, 6))
+                y = UnfoldLayer()(x)
+                super().__init__(inputs=x, outputs=y)
+
+        # Make sure Keras is able to compile the model graph
+        model = Model()
+        x = ops.ones((1, 2, 6, 6))
+        model.predict(x)
+
     @parameterized.named_parameters(
         named_product(dtype=["float32", "int32", "bool"], sparse=[False, True])
     )


### PR DESCRIPTION
## Description
`ops.multi_hot` and `ops.unfold` failed under symbolic graph tracing, i.e. any functional model or model.predict, since keras.Input always has a dynamic batch dim. Only eager calls with fully static shapes worked, which is what the existing tests do, so CI never caught it.

- OpenVINO multi_hot/unfold passed an OpenVINOKerasTensor straight into ov_opset, which falls back to np.array() -> __array__ -> convert_to_numpy. On constants that silently compiled a model at graph-build time and froze the result into a Constant, on a Parameter it raised.

- OpenVINO and TensorFlow unfold used the batch dim read off input.shape directly in reshape, which is None/dynamic during tracing. Replaced with -1. numpy/jax/torch are unaffected because they trace with concrete batch sizes.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
