### PR TITLE
Document that OpenVino minimum version is 2026.2.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following table lists the minimum supported versions of each backend for the
 | TensorFlow | 2.16.1                    |
 | JAX        | 0.4.20                    |
 | PyTorch    | 2.1.0                     |
-| OpenVINO   | 2025.3.0                  |
+| OpenVINO   | 2026.2.0                  |
 
 #### Adding GPU support
 


### PR DESCRIPTION
We're using some ops within opset16 that are only in 2026.2.0 and additionally we're using `erfinv` from opset 17.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
