### PR TITLE
Only warn about running out of data when `steps_per_epoch` was set

### DIFF
--- a/keras/src/trainers/epoch_iterator.py
+++ b/keras/src/trainers/epoch_iterator.py
@@ -160,8 +160,11 @@ class EpochIterator:
             yield
         except StopIteration:
             if self._num_batches is None:
+                # Running out of data is how an unknown epoch size gets
+                # discovered, not an interruption.
                 self._num_batches = self._steps_seen
-            self._interrupted_warning()
+            if self.steps_per_epoch:
+                self._interrupted_warning()
             self._current_iterator = None
             self.data_adapter.on_epoch_end()
 

--- a/keras/src/trainers/epoch_iterator_test.py
+++ b/keras/src/trainers/epoch_iterator_test.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -58,6 +60,28 @@ class TestEpochIterator(testing.TestCase):
         self.assertLen(steps_seen, steps_per_epoch - 2)
 
         self.assertIsInstance(iterator, epoch_iterator.EpochIterator)
+
+    def test_unknown_length_input_does_not_warn(self):
+        # Reaching the end of an input of unknown length is how the epoch size
+        # gets discovered, not an interruption, so it should not warn.
+        num_batches = 4
+
+        def generator_example():
+            for i in range(num_batches):
+                yield (np.array([i]), np.array([i * 2]))
+
+        iterator = epoch_iterator.EpochIterator(x=generator_example())
+        self.assertIsNone(iterator.num_batches)
+
+        steps_seen = []
+        with warnings.catch_warnings(record=True) as raised:
+            warnings.simplefilter("always")
+            for step, _, _ in iterator:
+                steps_seen.append(step)
+        self.assertLen(steps_seen, num_batches)
+        self.assertEmpty(
+            [w for w in raised if "ran out of data" in str(w.message)]
+        )
 
     def test_unsupported_y_arg_tfdata(self):
         with self.assertRaisesRegex(ValueError, "`y` should not be passed"):


### PR DESCRIPTION
## Description

`EpochIterator.catch_stop_iteration` warns `"Your input ran out of data; interrupting training"` whenever the underlying iterator raises `StopIteration`. When the input length is unknown, that happens on the first epoch of every `fit()` call, because iterating to the end is how the epoch size gets discovered:

```python
steps_per_epoch = self.steps_per_epoch or self._num_batches or -1
if steps_per_epoch > 0:
    ...
else:
    # No length known: iterate until StopIteration.
```

Nothing has gone wrong in that case, and the advice the warning gives (make sure the input can generate at least `steps_per_epoch * epochs` batches) does not apply when the caller never set `steps_per_epoch`.

`_enumerate_iterator` already guards its own call to the same warning:

```python
if self._num_batches and self._steps_seen >= self._num_batches:
    if self.steps_per_epoch:
        self._interrupted_warning()
```

This applies that condition in `catch_stop_iteration` as well, so both paths follow one rule: warn only when the caller declared how many steps to expect and the input did not deliver.

It affects any adapter that reports `num_batches` as `None`: python generators, `PyDataset` without `__len__`, torch `DataLoader` over an `IterableDataset`, and `GrainDatasetAdapter`, which returns `None` unconditionally. I ran into it while migrating KerasHub's data pipeline to Grain (keras-team/keras-hub#2879), where a 4 batch input trains correctly as `[4, 4, 4]` but warns on all three epochs. With this change it warns on none of them.

## Tests

`test_insufficient_data` passes unchanged. It sets `steps_per_epoch=6` against 4 batches of data, which is exactly the case the warning exists for.

Added `test_unknown_length_input_does_not_warn`, which fails on master with `AssertionError: [<warnings.WarningMessage ...>] has length of 1.` and passes here.

```
pytest keras/src/trainers/ -q     # torch 364 passed, 45 skipped
```

## Notes

Two adjacent problems I looked at and deliberately left alone.

**`GrainDatasetAdapter.num_batches` always returns `None`.** Reporting `len(dataset)` looks tempting since `grain.MapDataset` guarantees `__len__`, but `len()` is only an upper bound after `filter()`, and `FilterMapDataset` is not part of Grain's public API, so an adapter cannot detect that case. The existing `test_num_batches` already asserts `None` for the `repeat()` and `filter()` cases.

**The discovered epoch size is one execution too large.** `_steps_seen` is advanced before a step is attempted, so the step that raised `StopIteration` gets counted: a 4 batch input ends up with `num_batches == 5`. That is why a re-iterable input still hits `StopIteration` on every later epoch, now silently. Fixing it properly means accounting for the partial buffer that `__next__` still returns when `steps_per_execution > 1`, which needs a signature change to `catch_stop_iteration`, a method the jax and tensorflow trainers both call and `TFEpochIterator` overrides. I tried the naive `_steps_seen - steps_per_execution` and it broke `test_steps_per_execution_steps_count_unknown_dataset_size` on torch, so it belongs in its own PR rather than here.

Per the AI-Assisted Contribution Policy: I used an AI coding agent while working on this, to trace the two `_interrupted_warning()` call sites, check Grain's `__len__` semantics against the installed source, and draft the regression test. I have reviewed and tested the change, I understand the fix, and I take responsibility for it.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
