### PR TITLE
Fix OpenVino equalization test running too slow.

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -1,4 +1,3 @@
-EqualizationTest::test_equalizes_to_all_bins
 LinalgOpsCorrectnessTest::test_eig
 LinalgOpsCorrectnessTest::test_norm_2_-2
 LinalgOpsCorrectnessTest::test_norm_2_2

--- a/keras/src/layers/preprocessing/image_preprocessing/equalization_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/equalization_test.py
@@ -41,10 +41,10 @@ class EqualizationTest(testing.TestCase):
             np.float32
         )
         layer = layers.Equalization(value_range=(0, 255))
-        xs = layer(xs)
+        xs = ops.convert_to_numpy(layer(xs))
 
         for i in range(0, 256):
-            self.assertTrue(np.any(ops.convert_to_numpy(xs) == i))
+            self.assertTrue(np.any(xs == i))
 
     @parameterized.named_parameters(
         ("float32", np.float32), ("int32", np.int32), ("int64", np.int64)


### PR DESCRIPTION
`convert_to_numpy` is an expensive call on OpenVino. Only perform it once instead of 256 times in the test.

Context: https://github.com/keras-team/keras/pull/23147

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
