### PR TITLE
Make use of `Layer`'s propagation of call context arguments in `Model`s too.

### DIFF
--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1170,26 +1170,43 @@ class Layer(BackendLayer, Operation):
         )
         mapping = list(trainable_mapping) + list(non_trainable_mapping)
 
-        # Call in stateless scope
-        losses = None
-        with backend.StatelessScope(
-            state_mapping=mapping, collect_losses=return_losses
-        ) as scope:
-            if self.dtype_policy.quantization_mode is not None:
-                if self._remat_mode is not None:
+        # Caches info about `call()` signature, args, kwargs.
+        call_spec = CallSpec(
+            self._call_signature, self._call_context_args, args, kwargs
+        )
+
+        # Maintains info about the `Layer.call` stack across nested calls.
+        call_context = self._get_call_context()
+
+        for context_arg in self._call_context_args:
+            self._resolve_and_populate_arg(
+                context_arg, call_spec, call_context, kwargs
+            )
+
+        try:
+            # Call in stateless scope
+            losses = None
+            with backend.StatelessScope(
+                state_mapping=mapping, collect_losses=return_losses
+            ) as scope:
+                if self.dtype_policy.quantization_mode is not None:
+                    if self._remat_mode is not None:
+                        outputs = self.rematerialized_call(
+                            self.quantized_call, *args, **kwargs
+                        )(*args, **kwargs)
+                    else:
+                        outputs = self.quantized_call(*args, **kwargs)
+                elif self._remat_mode is not None:
                     outputs = self.rematerialized_call(
-                        self.quantized_call, *args, **kwargs
+                        self.call, *args, **kwargs
                     )(*args, **kwargs)
                 else:
-                    outputs = self.quantized_call(*args, **kwargs)
-            elif self._remat_mode is not None:
-                outputs = self.rematerialized_call(self.call, *args, **kwargs)(
-                    *args, **kwargs
-                )
-            else:
-                outputs = self.call(*args, **kwargs)
-            if return_losses:
-                losses = self.losses
+                    outputs = self.call(*args, **kwargs)
+                if return_losses:
+                    losses = self.losses
+        finally:
+            # Destroy call context if we created it
+            self._maybe_reset_call_context()
 
         # Gather updated non-trainable variables
         non_trainable_variables = []

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -171,7 +171,7 @@ class Functional(Function, Model):
             "Please use another name."
         )
 
-    def call(self, inputs, training=None, mask=None, **kwargs):
+    def call(self, inputs, training=None, mask=None):
         # Add support for training, masking
         inputs = self._standardize_inputs(inputs)
         if mask is None:
@@ -181,12 +181,7 @@ class Functional(Function, Model):
             for x, mask in zip(inputs, masks):
                 if mask is not None:
                     backend.set_keras_mask(x, mask)
-        outputs = self._run_through_graph(
-            inputs,
-            operation_fn=lambda op: operation_fn(
-                op, training=training, **kwargs
-            ),
-        )
+        outputs = self._run_through_graph(inputs)
         return unpack_singleton(outputs)
 
     def compute_output_spec(self, inputs, training=None, mask=None):
@@ -690,23 +685,6 @@ def functional_from_config(cls, config, custom_objects=None):
         trainable=trainable,
         **config,
     )
-
-
-def operation_fn(operation, **call_context_args):
-    """Wraps each op to inject the call-context args."""
-
-    def call(*args, **kwargs):
-        # Propagate all registered call-context args
-        for name, value in call_context_args.items():
-            if (
-                name in getattr(operation, "_call_context_args", {})
-                and value is not None
-            ):
-                kwargs[name] = value
-
-        return operation(*args, **kwargs)
-
-    return call
 
 
 def functional_like_constructor(cls):

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -307,20 +307,25 @@ class FunctionalTest(testing.TestCase):
         self.assertEqual(model.get_layer(name="dense_1").name, "dense_1")
 
     def test_training_arg(self):
-        test_obj = self
+        class CustomLayer(layers.Layer):
+            def call(self, inputs, training=False):
+                return inputs * 0.0 if training else inputs
 
-        class Canary(layers.Layer):
-            def call(self, x, training=False):
-                test_obj.assertTrue(training)
-                return x
+        inputs = layers.Input((20,))
+        outputs = CustomLayer()(inputs)
+        model = Functional(inputs=inputs, outputs=outputs)
+        self.assertAllClose(model(np.ones((4, 20))), 1.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=False), 1.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=True), 0.0)
 
-            def compute_output_spec(self, x, training=False):
-                return backend.KerasTensor(x.shape, dtype=x.dtype)
-
-        inputs = Input(shape=(3,), batch_size=2)
-        outputs = Canary()(inputs)
-        model = Functional(inputs, outputs)
-        model(np.random.random((2, 3)), training=True)
+        inputs = layers.Input((20,))
+        # This should hardcode `training=True` even if we pass
+        # `training=False` to the model.
+        outputs = CustomLayer()(inputs, training=True)
+        model = Functional(inputs=inputs, outputs=outputs)
+        self.assertAllClose(model(np.ones((4, 20))), 0.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=False), 0.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=True), 0.0)
 
     def test_mask_arg(self):
         # TODO

--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -787,6 +787,26 @@ class ModelTest(testing.TestCase):
         ref_keys = sorted(["loss", "output_a_loss", "output_b_loss"])
         self.assertListEqual(hist_keys, ref_keys)
 
+    def test_subclass_model_training_arg(self):
+        class CustomLayer(layers.Layer):
+            def call(self, inputs, training=False):
+                return inputs * 0.0 if training else inputs
+
+        class CustomModel(Model):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.layer = CustomLayer()
+
+            def call(self, inputs, training=False):
+                # We do not propagate `training` here on purpose.
+                # The call context should take care of it automatically.
+                return self.layer(inputs)
+
+        model = CustomModel()
+        self.assertAllClose(model(np.ones((4, 20))), 1.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=False), 1.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=True), 0.0)
+
     @parameterized.named_parameters(
         ("int8", "int8"),
         ("float8", "float8"),

--- a/keras/src/models/sequential.py
+++ b/keras/src/models/sequential.py
@@ -234,11 +234,9 @@ class Sequential(Model):
         outputs = x
         self._functional = Functional(inputs=inputs, outputs=outputs)
 
-    def call(self, inputs, training=None, mask=None, **kwargs):
+    def call(self, inputs, training=None, mask=None):
         if self._functional:
-            return self._functional.call(
-                inputs, training=training, mask=mask, **kwargs
-            )
+            return self._functional.call(inputs, training=training, mask=mask)
 
         # Fallback: Just apply the layer sequence.
         # This typically happens if `inputs` is a nested struct.
@@ -247,17 +245,10 @@ class Sequential(Model):
             # `outputs` are the outputs of `layer` applied to `inputs`. At the
             # end of each iteration `inputs` is set to `outputs` to prepare for
             # the next layer.
-            layer_kwargs = {
-                k: kwargs[k]
-                # only inject if this layer’s signature actually has that arg
-                for k in getattr(layer, "_call_has_context_arg", {})
-                if k in kwargs
-            }
             if layer._call_has_mask_arg:
-                layer_kwargs["mask"] = mask
-            if layer._call_has_training_arg and training is not None:
-                layer_kwargs["training"] = training
-            outputs = layer(inputs, **layer_kwargs)
+                outputs = layer(inputs, mask=mask)
+            else:
+                outputs = layer(inputs)
             inputs = outputs
 
             mask = tree.map_structure(backend.get_keras_mask, outputs)

--- a/keras/src/models/sequential_test.py
+++ b/keras/src/models/sequential_test.py
@@ -343,6 +343,16 @@ class SequentialTest(testing.TestCase):
         self.assertEqual(model.input_shape, (None, 2))
         self.assertEqual(model.output_shape, (None, 4))
 
+    def test_training_arg(self):
+        class CustomLayer(layers.Layer):
+            def call(self, inputs, training=False):
+                return inputs * 0.0 if training else inputs
+
+        model = Sequential([CustomLayer()])
+        self.assertAllClose(model(np.ones((4, 20))), 1.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=False), 1.0)
+        self.assertAllClose(model(np.ones((4, 20)), training=True), 0.0)
+
     def test_pickleable(self):
         model = Sequential(name="seq")
         model.add(layers.Dense(4))

--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -2229,19 +2229,21 @@ class TestTrainer(testing.TestCase):
         y = model.predict(x)
         self.assertEqual(type(y), tf.RaggedTensor)
 
-    def test_predict_dropout(self):
+    def test_functional_layer_training_overrides_model_training_argument(self):
         # Test that `predict` with a dropout op
         # has nondeterministic behavior across batches.
 
         inputs = layers.Input((20,))
+        # Passing `training=True` during construction will force dropout to be
+        # enabled even during predict.
         outputs = layers.Dropout(0.5, seed=1337)(inputs, training=True)
         model = keras.Model(inputs, outputs)
         out1 = model.predict(np.ones((4, 20)), batch_size=2)
-        self.assertGreater(5, np.sum(np.abs(out1[:2, :] - out1[2:4, :])))
+        self.assertNotAllClose(out1[:2, :], out1[2:4, :])
 
         out2 = model.predict_on_batch(np.ones((2, 20)))
         out3 = model.predict_on_batch(np.ones((2, 20)))
-        self.assertGreater(5, np.sum(np.abs(out2 - out3)))
+        self.assertNotAllClose(out2, out3)
 
     @pytest.mark.requires_trainable_backend
     def test_recompile(self):


### PR DESCRIPTION
Hardcoding `training=True` is supposed to work when call a layer while creating a functional model. The arguments passed during functional construction should take precedence over the call context arguments that are propagated. This was the behavior in Keras 2 and in fact there was a test in Keras 3 to check this behavior in `keras/src/trainers/trainer_test.py`. However, the test was setup incorrectly and would instead accidentally verify that the `training` argument was *not* applied.

- Remove ad-hoc propagation of context arguments in `Functional` and `Sequential`.
- Fix `Layer.stateless_call` which was missing the call context arguments propagation for the JAX backend.

Now a consistent flow is used for both layers and models:
- `__call__` detects context arguments and saves them in the `CallContext`
- `call` arguments are matched against the current `CallContext` and added as needed

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
