### PR TITLE
Implement gammainc function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -55,6 +55,7 @@ from keras.src.ops.math import erfinv as erfinv
 from keras.src.ops.math import extract_sequences as extract_sequences
 from keras.src.ops.math import fft as fft
 from keras.src.ops.math import fft2 as fft2
+from keras.src.ops.math import gammainc as gammainc
 from keras.src.ops.math import ifft2 as ifft2
 from keras.src.ops.math import in_top_k as in_top_k
 from keras.src.ops.math import irfft as irfft

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -55,6 +55,7 @@ from keras.src.ops.math import erfinv as erfinv
 from keras.src.ops.math import extract_sequences as extract_sequences
 from keras.src.ops.math import fft as fft
 from keras.src.ops.math import fft2 as fft2
+from keras.src.ops.math import gammainc as gammainc
 from keras.src.ops.math import ifft2 as ifft2
 from keras.src.ops.math import in_top_k as in_top_k
 from keras.src.ops.math import irfft as irfft

--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -308,3 +308,9 @@ def logdet(x):
     # `np.log(np.linalg.det(x))`. See
     # https://numpy.org/doc/stable/reference/generated/numpy.linalg.slogdet.html
     return slogdet(x)[1]
+
+
+def gammainc(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return jax.scipy.special.gammainc(x1, x2)

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -342,4 +342,5 @@ def logdet(x):
 def gammainc(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    return scipy.special.gammainc(x1, x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    return scipy.special.gammainc(x1, x2).astype(dtype)

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -337,3 +337,9 @@ def logdet(x):
     # In NumPy slogdet is more stable than `np.log(np.linalg.det(x))`. See
     # https://numpy.org/doc/stable/reference/generated/numpy.linalg.slogdet.html
     return slogdet(x)[1]
+
+
+def gammainc(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return scipy.special.gammainc(x1, x2)

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -13,3 +13,7 @@ MathOpsCorrectnessTest::test_erfinv_operation_basic
 MathOpsCorrectnessTest::test_erfinv_operation_dtype
 NNOpsCorrectnessTest::test_ctc_decode
 NNOpsDtypeTest::test_ctc_decode
+MathDtypeTest::test_gammainc
+MathOpsCorrectnessTest::test_gammainc
+MathOpsDynamicShapeTest::test_gammainc
+MathOpsStaticShapeTest::test_gammainc

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 
+from keras.src.backend import config
 from keras.src.backend import standardize_dtype
 from keras.src.backend.common import dtypes
 from keras.src.backend.tensorflow.core import cast
@@ -334,4 +335,9 @@ def logdet(x):
 def gammainc(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    return tf.math.igamma(x1, x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+
+    x1 = cast(x1, config.floatx())
+    x2 = cast(x2, config.floatx())
+
+    return cast(tf.math.igamma(x1, x2), dtype)

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -1,6 +1,5 @@
 import tensorflow as tf
 
-from keras.src.backend import config
 from keras.src.backend import standardize_dtype
 from keras.src.backend.common import dtypes
 from keras.src.backend.tensorflow.core import cast
@@ -337,7 +336,10 @@ def gammainc(x1, x2):
     x2 = convert_to_tensor(x2)
     dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
 
-    x1 = cast(x1, config.floatx())
-    x2 = cast(x2, config.floatx())
+    compute_dtype = dtype
+    if standardize_dtype(dtype) in ("float16", "bfloat16"):
+        compute_dtype = "float32"
+    x1 = cast(x1, compute_dtype)
+    x2 = cast(x2, compute_dtype)
 
     return cast(tf.math.igamma(x1, x2), dtype)

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -329,3 +329,9 @@ def erfinv(x):
 def logdet(x):
     x = convert_to_tensor(x)
     return tf.linalg.logdet(x)
+
+
+def gammainc(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return tf.math.igamma(x1, x2)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -2,7 +2,6 @@ import math
 
 import torch
 
-from keras.src.backend import config
 from keras.src.backend import standardize_dtype
 from keras.src.backend.common import dtypes
 from keras.src.backend.torch.core import cast
@@ -434,6 +433,9 @@ def gammainc(x1, x2):
     x2 = convert_to_tensor(x2)
     dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
 
-    x1 = cast(x1, config.floatx())
-    x2 = cast(x2, config.floatx())
+    compute_dtype = dtype
+    if standardize_dtype(dtype) in ("float16", "bfloat16"):
+        compute_dtype = "float32"
+    x1 = cast(x1, compute_dtype)
+    x2 = cast(x2, compute_dtype)
     return cast(torch.special.gammainc(x1, x2), dtype)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -424,3 +424,9 @@ def erfinv(x):
 def logdet(x):
     x = convert_to_tensor(x)
     return torch.logdet(x)
+
+
+def gammainc(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return torch.special.gammainc(x1, x2)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -2,7 +2,10 @@ import math
 
 import torch
 
+from keras.src.backend import config
 from keras.src.backend import standardize_dtype
+from keras.src.backend.common import dtypes
+from keras.src.backend.torch.core import cast
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import get_device
 from keras.src.backend.torch.numpy import pad
@@ -429,4 +432,8 @@ def logdet(x):
 def gammainc(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
-    return torch.special.gammainc(x1, x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+
+    x1 = cast(x1, config.floatx())
+    x2 = cast(x2, config.floatx())
+    return cast(torch.special.gammainc(x1, x2), dtype)

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -665,7 +665,7 @@ def gammainc(x1, x2):
     >>> x1 = keras.ops.convert_to_tensor([1.0, 2.0, 3.0])
     >>> x2 = keras.ops.convert_to_tensor([0.5, 1.0, 2.0])
     >>> keras.ops.gammainc(x1, x2)
-    array([0.39346933, 0.26424113, 0.32332358], dtype=float32)
+    array([0.39346936, 0.26424113, 0.3233236 ], dtype=float32)
     """
     if any_symbolic_tensors((x1, x2)):
         return Gammainc().symbolic_call(x1, x2)

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -644,11 +644,8 @@ class Gammainc(Operation):
 @keras_export("keras.ops.gammainc")
 def gammainc(x1, x2):
     """Computes the regularized lower incomplete gamma function.
-
     The regularized lower incomplete gamma function is defined as:
-
         P(x1, x2) = 1 / Γ(x1) * ∫₀ˣ² t^(x1 - 1) e^(-t) dt
-
     where `Γ(x1)` is the gamma function.
 
     Args:

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -629,6 +629,49 @@ def fft2(x):
     return backend.math.fft2(x)
 
 
+class Gammainc(Operation):
+    def compute_output_spec(self, x1, x2):
+        output_shape = broadcast_shapes(x1.shape, x2.shape)
+        return KerasTensor(
+            shape=output_shape,
+            dtype=result_type(x1.dtype, x2.dtype, float),
+        )
+
+    def call(self, x1, x2):
+        return backend.math.gammainc(x1, x2)
+
+
+@keras_export("keras.ops.gammainc")
+def gammainc(x1, x2):
+    """Computes the regularized lower incomplete gamma function.
+
+    The regularized lower incomplete gamma function is defined as:
+
+        P(x1, x2) = 1 / Γ(x1) * ∫₀ˣ² t^(x1 - 1) e^(-t) dt
+
+    where `Γ(x1)` is the gamma function.
+
+    Args:
+        x1: A tensor containing the shape parameter.
+        x2: A tensor containing the upper limit of integration. Must be
+            broadcast-compatible with `x1`.
+
+    Returns:
+        A tensor containing the regularized lower incomplete gamma function
+        evaluated elementwise.
+
+    Example:
+
+    >>> x1 = keras.ops.convert_to_tensor([1.0, 2.0, 3.0])
+    >>> x2 = keras.ops.convert_to_tensor([0.5, 1.0, 2.0])
+    >>> keras.ops.gammainc(x1, x2)
+    array([0.39346933, 0.26424113, 0.32332358], dtype=float32)
+    """
+    if any_symbolic_tensors((x1, x2)):
+        return Gammainc().symbolic_call(x1, x2)
+    return backend.math.gammainc(x1, x2)
+
+
 class IFFT2(Operation):
     def compute_output_spec(self, x):
         axes = (-2, -1)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -168,6 +168,19 @@ class MathOpsDynamicShapeTest(testing.TestCase):
         y = kmath.erfinv(x)
         self.assertEqual(y.shape, (None, 2, 3))
 
+    def test_gammanic(self):
+        x1 = KerasTensor((None, 2, 3))
+        x2 = KerasTensor((None, 2, 3))
+
+        z = kmath.gammanic(x1, x2)
+        self.assertEqual(z.shape, (None, 2, 3))
+
+        x1 = KerasTensor((None, 2, 3))
+        x2 = KerasTensor((1, 2, 3))
+
+        z = kmath.gammanic(x1, x2)
+        self.assertEqual(z.shape, (None, 2, 3))
+
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     def test_segment_reduce(self, segment_reduce_op):
         # 1D case
@@ -382,6 +395,13 @@ class MathOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((1, 2, 3))
         y = kmath.erfinv(x)
         self.assertEqual(y.shape, (1, 2, 3))
+
+    def test_gammanic(self):
+        x1 = KerasTensor((1, 2, 3))
+        x2 = KerasTensor((1, 2, 3))
+
+        z = kmath.gammanic(x1, x2)
+        self.assertEqual(z.shape, (1, 2, 3))
 
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     @pytest.mark.skipif(
@@ -1129,6 +1149,18 @@ class MathOpsCorrectnessTest(testing.TestCase):
         y = KerasTensor(shape=(1, 2), dtype="float32")
         out = kmath.cdist(x, y)
         self.assertEqual(out.shape, (None, 1))
+
+    def test_gammanic(self):
+        import scipy.special
+
+        x1 = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+        x2 = np.array([[0.5, 1.0], [2.0, 5.0]], dtype="float32")
+
+        out = kmath.gammanic(x1, x2)
+        expected = scipy.special.gammaincc(x1, x2)
+
+        self.assertAllClose(out, expected)
+        self.assertEqual(out.shape, (2, 2))
 
 
 class MathDtypeTest(testing.TestCase):

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -168,17 +168,17 @@ class MathOpsDynamicShapeTest(testing.TestCase):
         y = kmath.erfinv(x)
         self.assertEqual(y.shape, (None, 2, 3))
 
-    def test_gammanic(self):
+    def test_gammainc(self):
         x1 = KerasTensor((None, 2, 3))
         x2 = KerasTensor((None, 2, 3))
 
-        z = kmath.gammanic(x1, x2)
+        z = kmath.gammainc(x1, x2)
         self.assertEqual(z.shape, (None, 2, 3))
 
         x1 = KerasTensor((None, 2, 3))
         x2 = KerasTensor((1, 2, 3))
 
-        z = kmath.gammanic(x1, x2)
+        z = kmath.gammainc(x1, x2)
         self.assertEqual(z.shape, (None, 2, 3))
 
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
@@ -396,11 +396,11 @@ class MathOpsStaticShapeTest(testing.TestCase):
         y = kmath.erfinv(x)
         self.assertEqual(y.shape, (1, 2, 3))
 
-    def test_gammanic(self):
+    def test_gammainc(self):
         x1 = KerasTensor((1, 2, 3))
         x2 = KerasTensor((1, 2, 3))
 
-        z = kmath.gammanic(x1, x2)
+        z = kmath.gammainc(x1, x2)
         self.assertEqual(z.shape, (1, 2, 3))
 
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
@@ -1150,14 +1150,14 @@ class MathOpsCorrectnessTest(testing.TestCase):
         out = kmath.cdist(x, y)
         self.assertEqual(out.shape, (None, 1))
 
-    def test_gammanic(self):
+    def test_gammainc(self):
         import scipy.special
 
         x1 = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
         x2 = np.array([[0.5, 1.0], [2.0, 5.0]], dtype="float32")
 
-        out = kmath.gammanic(x1, x2)
-        expected = scipy.special.gammaincc(x1, x2)
+        out = kmath.gammainc(x1, x2)
+        expected = scipy.special.gammainc(x1, x2)
 
         self.assertAllClose(out, expected)
         self.assertEqual(out.shape, (2, 2))

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1242,6 +1242,36 @@ class MathDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
+    @parameterized.named_parameters(
+        named_product(
+            dtypes=list(itertools.combinations(FLOAT_DTYPES + INT_DTYPES, 2))
+        )
+    )
+    def test_gammainc(self, dtypes):
+        import jax.numpy as jnp
+        import jax.scipy.special
+
+        dtype1, dtype2 = dtypes
+
+        x1 = knp.ones((2, 3), dtype=dtype1)
+        x2 = knp.ones((2, 3), dtype=dtype2)
+
+        x1_jax = jnp.ones((2, 3), dtype=dtype1)
+        x2_jax = jnp.ones((2, 3), dtype=dtype2)
+
+        expected_dtype = standardize_dtype(
+            jax.scipy.special.gammainc(x1_jax, x2_jax).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(kmath.gammainc(x1, x2).dtype),
+            expected_dtype,
+        )
+        self.assertEqual(
+            standardize_dtype(kmath.Gammainc().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_logsumexp(self, dtype):
         import jax.numpy as jnp


### PR DESCRIPTION
## Description
Adds `keras.ops.gammainc`, which computes the regularized lower incomplete gamma function element-wise for the input tensors `x1` and `x2`.
Supported across NumPy, TensorFlow, PyTorch, and JAX backends. Not supported on OpenVINO.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
