### PR TITLE
[Bug] Fail fast on invalid callbacks in CallbackList

### DIFF
--- a/keras/src/callbacks/callback_list.py
+++ b/keras/src/callbacks/callback_list.py
@@ -39,6 +39,13 @@ class CallbackList(Callback):
                 via `Callback.set_params`.
         """
         self.callbacks = tree.flatten(callbacks) if callbacks else []
+        for callback in self.callbacks:
+            if not isinstance(callback, Callback):
+                raise TypeError(
+                    "All callbacks must be instances of "
+                    "keras.callbacks.Callback. Received: "
+                    f"{callback} of type {type(callback)}"
+                )
         self._in_begin_end_block_count = 0
         self._executor = None
         self._async_train = False

--- a/keras/src/callbacks/callback_test.py
+++ b/keras/src/callbacks/callback_test.py
@@ -4,6 +4,7 @@ import pytest
 from keras.src import models
 from keras.src import testing
 from keras.src.callbacks.callback import Callback
+from keras.src.callbacks.callback_list import CallbackList
 
 
 class CallbackTest(testing.TestCase):
@@ -31,3 +32,12 @@ class CallbackTest(testing.TestCase):
         x = np.random.random((8, 1))
         y = np.random.random((8, 1))
         model.fit(x, y, callbacks=[CBK()], batch_size=2)
+
+    def test_invalid_callback_raises_error(self):
+        class FakeCallback:
+            pass
+
+        with self.assertRaisesRegex(
+            TypeError, "All callbacks must be instances of"
+        ):
+            CallbackList([FakeCallback()])


### PR DESCRIPTION
Fixes #23263 by validating that all callbacks are instances of Callback early during CallbackList initialization.

## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.