### PR TITLE
fix: serialize `sparse` argument in `CategoryEncoding.get_config()`

### DIFF
--- a/keras/src/layers/preprocessing/category_encoding.py
+++ b/keras/src/layers/preprocessing/category_encoding.py
@@ -148,6 +148,7 @@ class CategoryEncoding(DataLayer):
         config = {
             "num_tokens": self.num_tokens,
             "output_mode": self.output_mode,
+            "sparse": self.sparse,
         }
         base_config = super().get_config()
         return {**base_config, **config}

--- a/keras/src/layers/preprocessing/category_encoding_test.py
+++ b/keras/src/layers/preprocessing/category_encoding_test.py
@@ -271,6 +271,17 @@ class CategoryEncodingTest(testing.TestCase):
             output = output.numpy()
         self.assertAllClose(output, expected_output)
 
+    @parameterized.named_parameters([("dense", False), ("sparse", True)])
+    def test_get_config_includes_sparse(self, sparse):
+        layer = layers.CategoryEncoding(
+            num_tokens=4, output_mode="count", sparse=sparse
+        )
+        config = layer.get_config()
+        self.assertEqual(config["sparse"], sparse)
+        revived_layer = layers.CategoryEncoding.from_config(config)
+        self.assertEqual(revived_layer.sparse, sparse)
+        self.assertEqual(config, revived_layer.get_config())
+
     def test_category_encoding_without_num_tokens(self):
         with self.assertRaisesRegex(
             ValueError, r"num_tokens must be set to use this layer"

--- a/keras/src/layers/preprocessing/category_encoding_test.py
+++ b/keras/src/layers/preprocessing/category_encoding_test.py
@@ -272,13 +272,17 @@ class CategoryEncodingTest(testing.TestCase):
         self.assertAllClose(output, expected_output)
 
     @parameterized.named_parameters([("dense", False), ("sparse", True)])
-    def test_get_config_includes_sparse(self, sparse):
+    def test_get_config(self, sparse):
         layer = layers.CategoryEncoding(
             num_tokens=4, output_mode="count", sparse=sparse
         )
         config = layer.get_config()
+        self.assertEqual(config["num_tokens"], 4)
+        self.assertEqual(config["output_mode"], "count")
         self.assertEqual(config["sparse"], sparse)
         revived_layer = layers.CategoryEncoding.from_config(config)
+        self.assertEqual(revived_layer.num_tokens, 4)
+        self.assertEqual(revived_layer.output_mode, "count")
         self.assertEqual(revived_layer.sparse, sparse)
         self.assertEqual(config, revived_layer.get_config())
 


### PR DESCRIPTION
## Description

`CategoryEncoding.get_config()` omits the `sparse` constructor argument, so a layer built with `sparse=True` silently becomes `sparse=False` after any serialization round trip — `from_config(get_config())`, or `model.save()` followed by `load_model()`.

`sparse` controls the layer's actual output: it is forwarded to `encode_categorical_inputs(..., sparse=self.sparse)` in `call()` and to `KerasTensor(..., sparse=self.sparse)` in `compute_output_spec()`. A reloaded model therefore produces dense tensors where the original produced sparse ones, with no error or warning. For the wide `num_tokens` that motivate `sparse=True` in the first place, that turns a sparse pipeline dense on reload.

Repro (torch backend):

```python
layer = keras.layers.CategoryEncoding(num_tokens=4, output_mode="count", sparse=True)
"sparse" in layer.get_config()                                        # False
keras.layers.CategoryEncoding.from_config(layer.get_config()).sparse  # False

model.save(path); keras.saving.load_model(path).layers[0].sparse      # False
```

Every other preprocessing layer with a `sparse` argument already serializes it — `Discretization` (`discretization.py:288`), `HashedCrossing` (`hashed_crossing.py:184`), `Hashing` (`hashing.py:296`), `IndexLookup` (`index_lookup.py:394`, base of `IntegerLookup`/`StringLookup`) and `TextVectorization` (`text_vectorization.py:485`). `CategoryEncoding` is the only one that does not: the `sparse` argument was added in #19385 to close #19285, but `get_config()` was not updated at the time.

This PR adds `"sparse": self.sparse` to the config dict, matching the sibling layers.

**Backward compatibility:** configs saved before this change have no `"sparse"` key and still deserialize — `from_config` falls back to the constructor default `sparse=False`, which is exactly the behavior those models get today. Verified.

## Tests

Added a parameterized test to `category_encoding_test.py` covering the `get_config` / `from_config` round trip for both `sparse=True` and `sparse=False`, and asserting the revived layer's config matches the original (the pattern used in `discretization_test.py`). It fails on `master` with `KeyError: 'sparse'` and passes with this change. `ruff check` and `ruff format --check` are clean on both files.

Per the AI-Assisted Contribution Policy: an AI coding assistant was used to help prepare this fix and its test. I have reviewed and understand the change, reproduced the bug and verified the fix locally (including a real `model.save()` / `load_model()` round trip), and take full responsibility for the code.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
