### PR TITLE
docs: note Pillow DecompressionBombError in load_img()

### DIFF
--- a/keras/src/utils/image_utils.py
+++ b/keras/src/utils/image_utils.py
@@ -234,6 +234,14 @@ def load_img(
 
     Returns:
         A PIL Image instance.
+
+    Note:
+        This function uses Pillow (`PIL.Image`) for decoding and therefore
+        inherits Pillow's decompression-bomb protection. Images whose pixel
+        count exceeds `PIL.Image.MAX_IMAGE_PIXELS` raise
+        `PIL.Image.DecompressionBombError`. To load larger images, raise or
+        disable that limit (see the
+        [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open)).
     """
     if pil_image is None:
         raise ImportError(


### PR DESCRIPTION
Document that keras.utils.load_img() inherits Pillow's MAX_IMAGE_PIXELS limit and may raise DecompressionBombError for oversized images. Closes keras-team/keras#23317.

## Description
<!-- Describe your changes here -->

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
