### PR TITLE
[DoRA] Implement DoRA for Convolutional layers (BaseConv)

### DIFF
--- a/keras/src/layers/convolutional/base_conv.py
+++ b/keras/src/layers/convolutional/base_conv.py
@@ -85,6 +85,17 @@ class BaseConv(Layer):
             trainable matrices) during the forward pass. The delta is scaled by
             `lora_alpha / lora_rank`, allowing you to fine-tune the strength of
             the LoRA adjustment independently of `lora_rank`.
+        dora_rank: Optional integer. If set, the layer's forward pass
+            will implement DoRA (Weight-Decomposed Low-Rank Adaptation)
+            with the provided rank. DoRA decomposes the layer's kernel
+            into magnitude and direction components and applies LoRA
+            to the direction component. This can improve the learning
+            capacity of LoRA. You can also enable DoRA on an existing
+            layer by calling `layer.enable_dora(rank)`.
+        dora_alpha: Optional integer. If set, this parameter scales the
+            low-rank adaptation delta during the forward pass. The delta
+            is scaled by `dora_alpha / dora_rank`, allowing you to fine-tune
+            the strength of the DoRA adjustment independently of `dora_rank`.
     """
 
     def __init__(
@@ -108,6 +119,8 @@ class BaseConv(Layer):
         bias_constraint=None,
         lora_rank=None,
         lora_alpha=None,
+        dora_rank=None,
+        dora_alpha=None,
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -131,7 +144,14 @@ class BaseConv(Layer):
         self.bias_constraint = constraints.get(bias_constraint)
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else lora_rank
+        self.dora_rank = dora_rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else dora_rank
+        if self.lora_rank and self.dora_rank:
+            raise ValueError(
+                "Only one of `lora_rank` or `dora_rank` can be set."
+            )
         self.lora_enabled = False
+        self.dora_enabled = False
         self.input_spec = InputSpec(min_ndim=self.rank + 2)
         self.data_format = self.data_format
 
@@ -223,6 +243,8 @@ class BaseConv(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank, lora_alpha=self.lora_alpha)
+        if self.dora_rank:
+            self.enable_dora(self.dora_rank, dora_alpha=self.dora_alpha)
 
     @property
     def kernel(self):
@@ -240,6 +262,19 @@ class BaseConv(Layer):
                 ),
                 dtype=self.compute_dtype,
             )
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(kernel, lora_delta)
+            # Normalize along all axes except the last one (filters)
+            axis = tuple(range(len(kernel.shape) - 1))
+            norm = ops.stop_gradient(
+                ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
+            )
+            kernel = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
+            kernel = ops.cast(kernel, dtype=self.compute_dtype)
+
         return kernel
 
     def convolution_op(self, inputs, kernel):
@@ -298,6 +333,8 @@ class BaseConv(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
+        if self.dora_enabled:
+            raise ValueError("dora is already enabled. Cannot enable LoRA.")
         self._tracker.unlock()
 
         # LoRA weights should be float32 to avoid the risk of underflow or
@@ -324,6 +361,66 @@ class BaseConv(Layer):
         self.lora_rank = rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else rank
 
+    def enable_dora(
+        self,
+        rank,
+        dora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
+    ):
+        if self.kernel_constraint:
+            raise ValueError(
+                "DoRA is incompatible with kernel constraints. "
+                "In order to enable dora on this layer, remove the "
+                "`kernel_constraint` argument."
+            )
+        if not self.built:
+            raise ValueError(
+                "Cannot enable dora on a layer that isn't yet built."
+            )
+        if self.lora_enabled:
+            raise ValueError("LoRA is already enabled. Cannot enable DoRA.")
+        if self.dora_enabled:
+            raise ValueError(
+                "dora is already enabled. This can only be done once per layer."
+            )
+        self._tracker.unlock()
+
+        self.dora_kernel_a = self.add_weight(
+            name="dora_kernel_a",
+            shape=self._kernel.shape[:-1] + (rank,),
+            initializer=initializers.get(a_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+        self.dora_kernel_b = self.add_weight(
+            name="dora_kernel_b",
+            shape=(rank, self.filters),
+            initializer=initializers.get(b_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        # Initialize Magnitude Vector
+        # We reduce all axes except the last one (filters)
+        axis = tuple(range(len(self.kernel.shape) - 1))
+        initial_magnitude = ops.stop_gradient(
+            ops.sqrt(ops.sum(ops.square(self.kernel), axis=axis))
+        )
+        self.dora_magnitude = self.add_weight(
+            name="dora_magnitude",
+            shape=(self.filters,),
+            initializer=lambda *a, **kw: initial_magnitude,
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        self._kernel.trainable = False
+        self._tracker.lock()
+        self.dora_enabled = True
+        self.dora_rank = rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else rank
+
     def save_own_variables(self, store):
         # Do nothing if the layer isn't yet built
         if not self.built:
@@ -335,7 +432,7 @@ class BaseConv(Layer):
             store[str(i)] = variable
 
     def load_own_variables(self, store):
-        if not self.lora_enabled:
+        if not self.lora_enabled and not self.dora_enabled:
             self._check_load_own_variables(store)
         # Do nothing if the layer isn't yet built
         if not self.built:
@@ -348,6 +445,18 @@ class BaseConv(Layer):
         if self.lora_enabled:
             self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
             self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))
+        if self.dora_enabled:
+            self.dora_kernel_a.assign(ops.zeros(self.dora_kernel_a.shape))
+            self.dora_kernel_b.assign(ops.zeros(self.dora_kernel_b.shape))
+            # Temporarily disable to get base kernel
+            self.dora_enabled = False
+            base_kernel = self.kernel
+            self.dora_enabled = True
+
+            axis = tuple(range(len(base_kernel.shape) - 1))
+            self.dora_magnitude.assign(
+                ops.sqrt(ops.sum(ops.square(base_kernel), axis=axis))
+            )
 
     def get_config(self):
         config = super().get_config()
@@ -386,6 +495,9 @@ class BaseConv(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
             config["lora_alpha"] = self.lora_alpha
+        if self.dora_rank:
+            config["dora_rank"] = self.dora_rank
+            config["dora_alpha"] = self.dora_alpha
         return config
 
     def _check_load_own_variables(self, store):

--- a/keras/src/layers/convolutional/base_conv.py
+++ b/keras/src/layers/convolutional/base_conv.py
@@ -254,24 +254,30 @@ class BaseConv(Layer):
             )
         kernel = self._kernel
         if self.lora_enabled:
+            lora_delta = ops.matmul(
+                ops.reshape(self.lora_kernel_a, (-1, self.lora_rank)),
+                self.lora_kernel_b,
+            )
+            lora_delta = ops.reshape(lora_delta, kernel.shape)
             kernel = ops.cast(
                 ops.add(
                     kernel,
-                    (self.lora_alpha / self.lora_rank)
-                    * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
+                    (self.lora_alpha / self.lora_rank) * lora_delta,
                 ),
                 dtype=self.compute_dtype,
             )
         elif self.dora_enabled:
-            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
-                self.dora_kernel_a, self.dora_kernel_b
+            dora_delta = ops.matmul(
+                ops.reshape(self.dora_kernel_a, (-1, self.dora_rank)),
+                self.dora_kernel_b,
             )
-            W_combined = ops.add(kernel, lora_delta)
+            dora_delta = ops.reshape(dora_delta, kernel.shape)
+            W_combined = ops.add(
+                kernel, (self.dora_alpha / self.dora_rank) * dora_delta
+            )
             # Normalize along all axes except the last one (filters)
             axis = tuple(range(len(kernel.shape) - 1))
-            norm = ops.stop_gradient(
-                ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
-            )
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
             kernel = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
             kernel = ops.cast(kernel, dtype=self.compute_dtype)
 
@@ -404,13 +410,13 @@ class BaseConv(Layer):
         # Initialize Magnitude Vector
         # We reduce all axes except the last one (filters)
         axis = tuple(range(len(self.kernel.shape) - 1))
-        initial_magnitude = ops.stop_gradient(
-            ops.sqrt(ops.sum(ops.square(self.kernel), axis=axis))
+        initial_magnitude = ops.sqrt(
+            ops.sum(ops.square(self.kernel), axis=axis)
         )
         self.dora_magnitude = self.add_weight(
             name="dora_magnitude",
             shape=(self.filters,),
-            initializer=lambda *a, **kw: initial_magnitude,
+            initializer=initializers.Constant(initial_magnitude),
             dtype="float32",
             regularizer=self.kernel_regularizer,
         )

--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -717,6 +717,190 @@ class ConvBasicTest(testing.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
+    @parameterized.named_parameters(
+        {
+            "testcase_name": "conv1d_kernel_size3_strides1",
+            "conv_cls": layers.Conv1D,
+            "filters": 6,
+            "kernel_size": 3,
+            "strides": 1,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 1,
+            "input_shape": (None, 5, 4),
+            "output_shape": (None, 3, 6),
+        },
+        {
+            "testcase_name": "conv1d_kernel_size2_strides2",
+            "conv_cls": layers.Conv1D,
+            "filters": 6,
+            "kernel_size": 2,
+            "strides": 2,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 2,
+            "input_shape": (None, 5, 4),
+            "output_shape": (None, 2, 6),
+        },
+        {
+            "testcase_name": "conv2d_kernel_size3_strides1",
+            "conv_cls": layers.Conv2D,
+            "filters": 6,
+            "kernel_size": 3,
+            "strides": 1,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 1,
+            "input_shape": (None, 5, 5, 4),
+            "output_shape": (None, 3, 3, 6),
+        },
+        {
+            "testcase_name": "conv2d_kernel_size2_strides2",
+            "conv_cls": layers.Conv2D,
+            "filters": 6,
+            "kernel_size": 2,
+            "strides": 2,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 2,
+            "input_shape": (None, 5, 5, 4),
+            "output_shape": (None, 2, 2, 6),
+        },
+        {
+            "testcase_name": "conv3d_kernel_size3_strides1",
+            "conv_cls": layers.Conv3D,
+            "filters": 6,
+            "kernel_size": 3,
+            "strides": 1,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 1,
+            "input_shape": (None, 5, 5, 5, 4),
+            "output_shape": (None, 3, 3, 3, 6),
+        },
+        {
+            "testcase_name": "conv3d_kernel_size2_strides2",
+            "conv_cls": layers.Conv3D,
+            "filters": 6,
+            "kernel_size": 2,
+            "strides": 2,
+            "padding": "valid",
+            "data_format": "channels_last",
+            "dilation_rate": 1,
+            "groups": 2,
+            "input_shape": (None, 5, 5, 5, 4),
+            "output_shape": (None, 2, 2, 2, 6),
+        },
+    )
+    @pytest.mark.requires_trainable_backend
+    def test_enable_dora(
+        self,
+        conv_cls,
+        filters,
+        kernel_size,
+        strides,
+        padding,
+        data_format,
+        dilation_rate,
+        groups,
+        input_shape,
+        output_shape,
+    ):
+        if conv_cls not in (layers.Conv1D, layers.Conv2D, layers.Conv3D):
+            raise TypeError
+        layer = conv_cls(
+            filters=filters,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            dilation_rate=dilation_rate,
+            groups=groups,
+        )
+        layer.build(input_shape)
+        layer.enable_dora(2)
+        self.assertLen(layer.trainable_weights, 4)
+        self.assertLen(layer.non_trainable_weights, 1)
+        if backend.backend() == "torch":
+            self.assertLen(layer.torch_params, 5)
+        self.assertDType(layer.dora_kernel_a, "float32")
+        self.assertDType(layer.dora_kernel_b, "float32")
+        self.assertDType(layer.dora_magnitude, "float32")
+
+        # Try eager call
+        x = np.random.random((64,) + input_shape[1:])
+        y = np.random.random((64,) + output_shape[1:])
+        _ = layer(x[:2])
+
+        init_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        init_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        init_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        # Try calling fit()
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y)
+
+        final_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        final_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        final_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        diff_a = np.max(
+            np.abs(init_dora_a_kernel_value - final_dora_a_kernel_value)
+        )
+        diff_b = np.max(
+            np.abs(init_dora_b_kernel_value - final_dora_b_kernel_value)
+        )
+        diff_m = np.max(
+            np.abs(init_dora_magnitude_value - final_dora_magnitude_value)
+        )
+
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+        self.assertGreater(diff_m, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].dora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        new_model = models.Sequential(
+            [
+                conv_cls(
+                    filters=filters,
+                    kernel_size=kernel_size,
+                    strides=strides,
+                    padding=padding,
+                    data_format=data_format,
+                    dilation_rate=dilation_rate,
+                    groups=groups,
+                )
+            ]
+        )
+        new_model.build(input_shape)
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
     def test_lora_weight_name(self):
         class MyModel(models.Model):
             def __init__(self):
@@ -785,6 +969,49 @@ class ConvBasicTest(testing.TestCase):
             tpu_rtol=1e-3,
         )
 
+    def test_enable_dora_with_alpha(self):
+        layer = layers.Conv2D(filters=3, kernel_size=(2, 2), padding="valid")
+        input_shape = (1, 4, 4, 3)
+        layer.build(input_shape)
+
+        base_kernel = np.linspace(
+            0, 1, num=math.prod(layer.kernel.shape), dtype=np.float32
+        )
+        base_kernel = base_kernel.reshape(layer.kernel.shape)
+        layer._kernel.assign(base_kernel)
+
+        layer.enable_dora(rank=2, dora_alpha=3.0)
+        self.assertEqual(layer.dora_rank, 2)
+        self.assertEqual(layer.dora_alpha, 3.0)
+
+        dora_a_shape = layer.dora_kernel_a.shape
+        dora_b_shape = layer.dora_kernel_b.shape
+
+        dora_a = np.full(dora_a_shape, 0.1, dtype=np.float32)
+        dora_b = np.full(dora_b_shape, 0.2, dtype=np.float32)
+        layer.dora_kernel_a.assign(dora_a)
+        layer.dora_kernel_b.assign(dora_b)
+
+        scaling = 3.0 / 2
+        delta = np.matmul(dora_a.reshape(-1, 2), dora_b)
+        delta = delta.reshape(base_kernel.shape)
+        W_combined = base_kernel + scaling * delta
+
+        # Normalize along all axes except the last one
+        axis = tuple(range(len(W_combined.shape) - 1))
+        norm = np.sqrt(np.sum(np.square(W_combined), axis=axis))
+        expected_effective_kernel = ops.convert_to_numpy(
+            layer.dora_magnitude
+        ) * (W_combined / norm)
+
+        actual_effective_kernel = ops.convert_to_numpy(layer.kernel)
+        self.assertAllClose(
+            actual_effective_kernel,
+            expected_effective_kernel,
+            tpu_atol=1e-3,
+            tpu_rtol=1e-3,
+        )
+
     def test_lora_rank_argument(self):
         self.run_layer_test(
             layers.Conv2D,
@@ -802,6 +1029,26 @@ class ConvBasicTest(testing.TestCase):
             expected_num_non_trainable_weights=1,
             expected_num_seed_generators=0,
             expected_num_losses=2,  # we have 2 regularizers.
+            supports_masking=False,
+        )
+
+    def test_dora_rank_argument(self):
+        self.run_layer_test(
+            layers.Conv2D,
+            init_kwargs={
+                "filters": 5,
+                "kernel_size": 3,
+                "activation": "sigmoid",
+                "data_format": "channels_last",
+                "kernel_regularizer": "l2",
+                "dora_rank": 2,
+            },
+            input_shape=(2, 5, 5, 4),
+            expected_output_shape=(2, 3, 3, 5),
+            expected_num_trainable_weights=4,
+            expected_num_non_trainable_weights=1,
+            expected_num_seed_generators=0,
+            expected_num_losses=3,
             supports_masking=False,
         )
 

--- a/keras/src/layers/convolutional/conv_test.py
+++ b/keras/src/layers/convolutional/conv_test.py
@@ -997,12 +997,18 @@ class ConvBasicTest(testing.TestCase):
         delta = delta.reshape(base_kernel.shape)
         W_combined = base_kernel + scaling * delta
 
-        # Normalize along all axes except the last one
+        # Normalize along all axes except the last one.
         axis = tuple(range(len(W_combined.shape) - 1))
         norm = np.sqrt(np.sum(np.square(W_combined), axis=axis))
-        expected_effective_kernel = ops.convert_to_numpy(
-            layer.dora_magnitude
-        ) * (W_combined / norm)
+        normalized_w = np.divide(
+            W_combined,
+            norm,
+            out=np.zeros_like(W_combined),
+            where=norm != 0,
+        )
+        expected_effective_kernel = (
+            ops.convert_to_numpy(layer.dora_magnitude) * normalized_w
+        )
 
         actual_effective_kernel = ops.convert_to_numpy(layer.kernel)
         self.assertAllClose(
@@ -1010,6 +1016,22 @@ class ConvBasicTest(testing.TestCase):
             expected_effective_kernel,
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
+        )
+
+    def test_enable_dora_zero_norm(self):
+        layer = layers.Conv2D(filters=3, kernel_size=(2, 2), padding="valid")
+        input_shape = (1, 4, 4, 3)
+        layer.build(input_shape)
+
+        layer._kernel.assign(np.zeros(layer.kernel.shape, dtype=np.float32))
+        layer.enable_dora(rank=2)
+
+        layer.dora_kernel_a.assign(np.zeros(layer.dora_kernel_a.shape))
+        layer.dora_kernel_b.assign(np.zeros(layer.dora_kernel_b.shape))
+
+        actual_effective_kernel = ops.convert_to_numpy(layer.kernel)
+        self.assertAllClose(
+            actual_effective_kernel, np.zeros_like(actual_effective_kernel)
         )
 
     def test_lora_rank_argument(self):


### PR DESCRIPTION
## Description
Extends DoRA support to all convolutional layers (Conv1D, Conv2D, Conv3D) by implementing the logic in the BaseConv parent class.


   - Handles magnitude decomposition across multi-dimensional kernels (reducing all axes except the filter dimension).
   - Implements enable_dora() support for convolutional layers.
   - Updates forward pass logic to support kernel decomposition during inference and training.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
