### PR TITLE
[DoRA] Implement DoRA for EinsumDense layer

### DIFF
--- a/keras/src/layers/attention/multi_head_attention_test.py
+++ b/keras/src/layers/attention/multi_head_attention_test.py
@@ -902,6 +902,78 @@ class MultiHeadAttentionTest(testing.TestCase):
         model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
+    @pytest.mark.requires_trainable_backend
+    def test_dora(self):
+        layer = layers.MultiHeadAttention(
+            num_heads=3,
+            key_dim=8,
+            use_bias=False,
+            use_gate=True,
+        )
+        query = np.random.random((1, 2, 2))
+        key = np.random.random((1, 2, 2))
+        value = np.random.random((1, 2, 2))
+        layer(query, key, value)  # build
+
+        layer.query_dense.enable_dora(2)
+        layer.key_dense.enable_dora(2)
+        layer.value_dense.enable_dora(2)
+
+        # Try eager call
+        x = {
+            "query": query,
+            "key": key,
+            "value": value,
+        }
+        y = np.random.random((1, 2, 2))
+        _ = layer(**x)
+
+        # Try calling fit()
+        inputs = {
+            "query": layers.Input((2, 2)),
+            "key": layers.Input((2, 2)),
+            "value": layers.Input((2, 2)),
+        }
+        outputs = layer(inputs["query"], inputs["key"], inputs["value"])
+        model = models.Model(inputs, outputs)
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        inputs = {
+            "query": layers.Input((2, 2)),
+            "key": layers.Input((2, 2)),
+            "value": layers.Input((2, 2)),
+        }
+        outputs = layers.MultiHeadAttention(
+            num_heads=3,
+            key_dim=8,
+            use_bias=False,
+            use_gate=True,
+        )(inputs["query"], inputs["key"], inputs["value"])
+        new_model = models.Model(inputs, outputs)
+
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
     @parameterized.parameters([((1, 2, 3),), ((2, 3, 5),)])
     def test_symbolic_return_attention_scores(self, shape):
         mha = layers.MultiHeadAttention(num_heads=4, key_dim=2)

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -326,9 +326,7 @@ class EinsumDense(Layer):
             W_combined = ops.add(kernel, lora_delta)
             # Normalize along all axes except the last one
             axis = tuple(range(len(kernel.shape) - 1))
-            norm = ops.stop_gradient(
-                ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
-            )
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
             kernel = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
             kernel = ops.cast(kernel, dtype=self.compute_dtype)
 
@@ -436,9 +434,9 @@ class EinsumDense(Layer):
             raise ValueError(
                 "dora is already enabled. This can only be done once per layer."
             )
-        if self.quantization_mode == "gptq":
+        if self.quantization_mode is not None:
             raise NotImplementedError(
-                "dora is not currently supported with GPTQ quantization."
+                "DoRA is not currently supported with quantized layers."
             )
         self._tracker.unlock()
         if self.quantization_mode == "int4":
@@ -464,13 +462,13 @@ class EinsumDense(Layer):
         # Initialize Magnitude Vector
         # We reduce all axes except the last one
         axis = tuple(range(len(self.kernel.shape) - 1))
-        initial_magnitude = ops.stop_gradient(
-            ops.sqrt(ops.sum(ops.square(self.kernel), axis=axis))
+        initial_magnitude = ops.sqrt(
+            ops.sum(ops.square(self.kernel), axis=axis)
         )
         self.dora_magnitude = self.add_weight(
             name="dora_magnitude",
             shape=(kernel_shape_for_lora[-1],),
-            initializer=lambda *a, **kw: initial_magnitude,
+            initializer=initializers.Constant(initial_magnitude),
             dtype="float32",
             regularizer=self.kernel_regularizer,
         )

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -70,6 +70,17 @@ class EinsumDense(Layer):
             trainable matrices) during the forward pass. The delta is scaled by
             `lora_alpha / lora_rank`, allowing you to fine-tune the strength of
             the LoRA adjustment independently of `lora_rank`.
+        dora_rank: Optional integer. If set, the layer's forward pass
+            will implement DoRA (Weight-Decomposed Low-Rank Adaptation)
+            with the provided rank. DoRA decomposes the layer's kernel
+            into magnitude and direction components and applies LoRA
+            to the direction component. This can improve the learning
+            capacity of LoRA. You can also enable DoRA on an existing
+            `EinsumDense` layer by calling `layer.enable_dora(rank)`.
+        dora_alpha: Optional integer. If set, this parameter scales the
+            low-rank adaptation delta during the forward pass. The delta
+            is scaled by `dora_alpha / dora_rank`, allowing you to fine-tune
+            the strength of the DoRA adjustment independently of `dora_rank`.
         **kwargs: Base layer keyword arguments, such as `name` and `dtype`.
 
     Examples:
@@ -138,6 +149,8 @@ class EinsumDense(Layer):
         bias_constraint=None,
         lora_rank=None,
         lora_alpha=None,
+        dora_rank=None,
+        dora_alpha=None,
         gptq_unpacked_column_size=None,
         quantization_config=None,
         **kwargs,
@@ -158,8 +171,16 @@ class EinsumDense(Layer):
         self.bias_constraint = constraints.get(bias_constraint)
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else lora_rank
+        self.dora_rank = dora_rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else dora_rank
+        if self.lora_rank and self.dora_rank:
+            raise ValueError(
+                "Only one of `lora_rank` or `dora_rank` can be set."
+            )
         self.lora_enabled = False
+        self.dora_enabled = False
         self.gptq_unpacked_column_size = gptq_unpacked_column_size
+
         self.quantization_config = quantization_config
 
     def _update_kernel_initializer(self, input_axes, output_axes):
@@ -233,6 +254,8 @@ class EinsumDense(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank, lora_alpha=self.lora_alpha)
+        if self.dora_rank:
+            self.enable_dora(self.dora_rank, dora_alpha=self.dora_alpha)
 
     @property
     def kernel(self):
@@ -297,6 +320,18 @@ class EinsumDense(Layer):
                 ),
                 dtype=self.compute_dtype,
             )
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(kernel, lora_delta)
+            # Normalize along all axes except the last one
+            axis = tuple(range(len(kernel.shape) - 1))
+            norm = ops.stop_gradient(
+                ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
+            )
+            kernel = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
+            kernel = ops.cast(kernel, dtype=self.compute_dtype)
 
         return kernel
 
@@ -338,6 +373,8 @@ class EinsumDense(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
+        if getattr(self, "dora_enabled", False):
+            raise ValueError("dora is already enabled. Cannot enable LoRA.")
         if self.quantization_mode == "gptq":
             raise NotImplementedError(
                 "lora is not currently supported with GPTQ quantization."
@@ -377,6 +414,74 @@ class EinsumDense(Layer):
         self.lora_rank = rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else rank
 
+    def enable_dora(
+        self,
+        rank,
+        dora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
+    ):
+        if self.kernel_constraint:
+            raise ValueError(
+                "DoRA is incompatible with kernel constraints. "
+                "In order to enable dora on this layer, remove the "
+                "`kernel_constraint` argument."
+            )
+        if not self.built:
+            raise ValueError(
+                "Cannot enable dora on a layer that isn't yet built."
+            )
+        if self.lora_enabled:
+            raise ValueError("LoRA is already enabled. Cannot enable DoRA.")
+        if self.dora_enabled:
+            raise ValueError(
+                "dora is already enabled. This can only be done once per layer."
+            )
+        if self.quantization_mode == "gptq":
+            raise NotImplementedError(
+                "dora is not currently supported with GPTQ quantization."
+            )
+        self._tracker.unlock()
+        if self.quantization_mode == "int4":
+            kernel_shape_for_lora = tuple(self.original_kernel_shape)
+        else:
+            kernel_shape_for_lora = self.kernel.shape
+
+        self.dora_kernel_a = self.add_weight(
+            name="dora_kernel_a",
+            shape=(kernel_shape_for_lora[:-1] + (rank,)),
+            initializer=initializers.get(a_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+        self.dora_kernel_b = self.add_weight(
+            name="dora_kernel_b",
+            shape=(rank, kernel_shape_for_lora[-1]),
+            initializer=initializers.get(b_initializer),
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        # Initialize Magnitude Vector
+        # We reduce all axes except the last one
+        axis = tuple(range(len(self.kernel.shape) - 1))
+        initial_magnitude = ops.stop_gradient(
+            ops.sqrt(ops.sum(ops.square(self.kernel), axis=axis))
+        )
+        self.dora_magnitude = self.add_weight(
+            name="dora_magnitude",
+            shape=(kernel_shape_for_lora[-1],),
+            initializer=lambda *a, **kw: initial_magnitude,
+            dtype="float32",
+            regularizer=self.kernel_regularizer,
+        )
+
+        self._kernel.trainable = False
+        self._tracker.lock()
+        self.dora_enabled = True
+        self.dora_rank = rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else rank
+
     def save_own_variables(self, store):
         # Do nothing if the layer isn't yet built
         if not self.built:
@@ -384,24 +489,6 @@ class EinsumDense(Layer):
         mode = self.quantization_mode
         if mode not in self.variable_serialization_spec:
             raise self._quantization_mode_error(mode)
-
-        # GPTQ/AWQ layers are only serializable after calibration. Before
-        # calibration, the quantized variables hold uninitialized values
-        # while the real weights live in the float `_kernel`, which has no
-        # slot in the serialization spec, so saving would silently drop the
-        # actual weights and produce a corrupted model on reload.
-        if (
-            mode == "gptq" and not getattr(self, "is_gptq_calibrated", False)
-        ) or (mode == "awq" and not getattr(self, "is_awq_calibrated", False)):
-            raise ValueError(
-                f"Cannot save layer '{self.name}' because it is quantized "
-                f"with mode '{mode}' but has never been calibrated. Its "
-                "quantized weights are uninitialized, so saving would "
-                "produce a corrupted model. Run calibration first, e.g. via "
-                "`model.quantize(...)` with a quantization layer structure "
-                "that covers this layer, or exclude the layer from "
-                "quantization with `filters`."
-            )
 
         # Kernel plus optional merged LoRA-aware scale/zero (returns
         # (kernel, None, None) for None/gptq)
@@ -414,11 +501,9 @@ class EinsumDense(Layer):
                 store[str(idx)] = kernel_value
             elif name == "bias" and self.bias is None:
                 continue
-            elif name == "kernel_zero" and mode == "int4":
-                # For int4, the (LoRA-merged) zero point comes from
-                # `_get_kernel_with_merged_lora()` and only exists for
-                # sub-channel quantization.
+            elif name == "kernel_zero":
                 if merged_kernel_zero is None:
+                    # kernel_zero only exists for sub-channel int4 quantization
                     continue
                 store[str(idx)] = merged_kernel_zero
             elif name == "g_idx":
@@ -435,8 +520,9 @@ class EinsumDense(Layer):
             idx += 1
 
     def load_own_variables(self, store):
-        if not self.lora_enabled:
+        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
             self._check_load_own_variables(store)
+
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
@@ -466,6 +552,18 @@ class EinsumDense(Layer):
         if self.lora_enabled:
             self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
             self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))
+        if self.dora_enabled:
+            self.dora_kernel_a.assign(ops.zeros(self.dora_kernel_a.shape))
+            self.dora_kernel_b.assign(ops.zeros(self.dora_kernel_b.shape))
+            # Temporarily disable to get base kernel
+            self.dora_enabled = False
+            base_kernel = self.kernel
+            self.dora_enabled = True
+
+            axis = tuple(range(len(base_kernel.shape) - 1))
+            self.dora_magnitude.assign(
+                ops.sqrt(ops.sum(ops.square(base_kernel), axis=axis))
+            )
 
     def get_config(self):
         base_config = super().get_config()
@@ -494,6 +592,9 @@ class EinsumDense(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
             config["lora_alpha"] = self.lora_alpha
+        if self.dora_rank:
+            config["dora_rank"] = self.dora_rank
+            config["dora_alpha"] = self.dora_alpha
         if self.gptq_unpacked_column_size:
             config["gptq_unpacked_column_size"] = self.gptq_unpacked_column_size
         return {**base_config, **config}
@@ -1465,9 +1566,9 @@ class EinsumDense(Layer):
 
         kernel_zero = getattr(self, "kernel_zero", None)
 
-        # If quantized but LoRA is not enabled, return the original quantized
-        # kernel.
-        if not self.lora_enabled:
+        # If quantized but LoRA/DoRA is not enabled, return the original
+        # quantized kernel.
+        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
             return self._kernel, self.kernel_scale, kernel_zero
 
         # Dequantize, Merge, and Re-quantize
@@ -1506,11 +1607,24 @@ class EinsumDense(Layer):
                 f"Unsupported quantization mode: {self.quantization_mode}"
             )
 
-        # 2. Merge the LoRA update in the float domain
-        lora_update = (self.lora_alpha / self.lora_rank) * ops.matmul(
-            self.lora_kernel_a, self.lora_kernel_b
-        )
-        merged_kernel = ops.add(kernel_fp, lora_update)
+        # 2. Merge the LoRA/DoRA update in the float domain
+        if self.lora_enabled:
+            lora_update = (self.lora_alpha / self.lora_rank) * ops.matmul(
+                self.lora_kernel_a, self.lora_kernel_b
+            )
+            merged_kernel = ops.add(kernel_fp, lora_update)
+        elif self.dora_enabled:
+            lora_update = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_kernel_a, self.dora_kernel_b
+            )
+            W_combined = ops.add(kernel_fp, lora_update)
+            axis = tuple(range(len(W_combined.shape) - 1))
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=axis))
+            merged_kernel = self.dora_magnitude * ops.divide_no_nan(
+                W_combined, norm
+            )
+        else:
+            merged_kernel = kernel_fp
 
         # 3. Re-quantize the merged float kernel back to the target format
         if self.quantization_mode == "int4":

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -180,7 +180,6 @@ class EinsumDense(Layer):
         self.lora_enabled = False
         self.dora_enabled = False
         self.gptq_unpacked_column_size = gptq_unpacked_column_size
-
         self.quantization_config = quantization_config
 
     def _update_kernel_initializer(self, input_axes, output_axes):
@@ -373,7 +372,7 @@ class EinsumDense(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
-        if getattr(self, "dora_enabled", False):
+        if self.dora_enabled:
             raise ValueError("dora is already enabled. Cannot enable LoRA.")
         if self.quantization_mode == "gptq":
             raise NotImplementedError(
@@ -490,6 +489,24 @@ class EinsumDense(Layer):
         if mode not in self.variable_serialization_spec:
             raise self._quantization_mode_error(mode)
 
+        # GPTQ/AWQ layers are only serializable after calibration. Before
+        # calibration, the quantized variables hold uninitialized values
+        # while the real weights live in the float `_kernel`, which has no
+        # slot in the serialization spec, so saving would silently drop the
+        # actual weights and produce a corrupted model on reload.
+        if (
+            mode == "gptq" and not getattr(self, "is_gptq_calibrated", False)
+        ) or (mode == "awq" and not getattr(self, "is_awq_calibrated", False)):
+            raise ValueError(
+                f"Cannot save layer '{self.name}' because it is quantized "
+                f"with mode '{mode}' but has never been calibrated. Its "
+                "quantized weights are uninitialized, so saving would "
+                "produce a corrupted model. Run calibration first, e.g. via "
+                "`model.quantize(...)` with a quantization layer structure "
+                "that covers this layer, or exclude the layer from "
+                "quantization with `filters`."
+            )
+
         # Kernel plus optional merged LoRA-aware scale/zero (returns
         # (kernel, None, None) for None/gptq)
         kernel_value, merged_kernel_scale, merged_kernel_zero = (
@@ -501,9 +518,11 @@ class EinsumDense(Layer):
                 store[str(idx)] = kernel_value
             elif name == "bias" and self.bias is None:
                 continue
-            elif name == "kernel_zero":
+            elif name == "kernel_zero" and mode == "int4":
+                # For int4, the (LoRA-merged) zero point comes from
+                # `_get_kernel_with_merged_lora()` and only exists for
+                # sub-channel quantization.
                 if merged_kernel_zero is None:
-                    # kernel_zero only exists for sub-channel int4 quantization
                     continue
                 store[str(idx)] = merged_kernel_zero
             elif name == "g_idx":
@@ -520,9 +539,8 @@ class EinsumDense(Layer):
             idx += 1
 
     def load_own_variables(self, store):
-        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
+        if not self.lora_enabled and not self.dora_enabled:
             self._check_load_own_variables(store)
-
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
@@ -1568,7 +1586,7 @@ class EinsumDense(Layer):
 
         # If quantized but LoRA/DoRA is not enabled, return the original
         # quantized kernel.
-        if not self.lora_enabled and not getattr(self, "dora_enabled", False):
+        if not self.lora_enabled and not self.dora_enabled:
             return self._kernel, self.kernel_scale, kernel_zero
 
         # Dequantize, Merge, and Re-quantize

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -721,7 +721,7 @@ class EinsumDenseTest(testing.TestCase):
         )
         with self.assertRaisesRegex(
             NotImplementedError,
-            "dora is not currently supported with GPTQ quantization",
+            "DoRA is not currently supported with quantized layers.",
         ):
             layer.enable_dora(rank=2)
 
@@ -733,8 +733,11 @@ class EinsumDenseTest(testing.TestCase):
         layer.build((None, 3))
         # original_kernel_shape should be (3, 2, 4)
         layer.quantize("int4")
-        layer.enable_dora(rank=2)
-        self.assertEqual(layer.dora_kernel_a.shape, (3, 2, 2))
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "DoRA is not currently supported with quantized layers.",
+        ):
+            layer.enable_dora(rank=2)
 
     def test_dora_lora_mutual_exclusivity(self):
         layer = layers.EinsumDense(

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -550,6 +550,217 @@ class EinsumDenseTest(testing.TestCase):
             supports_masking=False,
         )
 
+    @pytest.mark.requires_trainable_backend
+    def test_enable_dora(self):
+        layer = layers.EinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes=None,
+        )
+        layer.build((None, 3))
+        layer.enable_dora(2)
+        self.assertLen(layer.trainable_weights, 3)
+        self.assertLen(layer.non_trainable_weights, 1)
+        if backend.backend() == "torch":
+            self.assertLen(layer.torch_params, 4)
+        self.assertDType(layer.dora_kernel_a, "float32")
+        self.assertDType(layer.dora_kernel_b, "float32")
+        self.assertDType(layer.dora_magnitude, "float32")
+
+        # Try eager call
+        x = np.random.random((64, 3))
+        y = np.random.random((64, 8, 32))
+        _ = layer(x[:2])
+
+        init_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        init_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        init_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        # Try calling fit()
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y, epochs=2)
+
+        final_dora_a_kernel_value = layer.dora_kernel_a.numpy()
+        final_dora_b_kernel_value = layer.dora_kernel_b.numpy()
+        final_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        diff_a = np.max(
+            np.abs(init_dora_a_kernel_value - final_dora_a_kernel_value)
+        )
+        diff_b = np.max(
+            np.abs(init_dora_b_kernel_value - final_dora_b_kernel_value)
+        )
+        diff_m = np.max(
+            np.abs(init_dora_magnitude_value - final_dora_magnitude_value)
+        )
+
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+        self.assertGreater(diff_m, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].dora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        new_model = models.Sequential(
+            [
+                layers.EinsumDense(
+                    equation="ab,bcd->acd",
+                    output_shape=(8, 32),
+                    bias_axes=None,
+                ),
+            ]
+        )
+        new_model.build((None, 3))
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    def test_enable_dora_with_alpha(self):
+        equation = "ab,bc->ac"
+        output_shape = 3
+        bias_axes = None
+
+        layer = layers.EinsumDense(
+            equation=equation, output_shape=output_shape, bias_axes=bias_axes
+        )
+        layer.build((None, 2))
+
+        base_kernel = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32
+        )
+        layer._kernel.assign(base_kernel)
+
+        layer.enable_dora(rank=2, dora_alpha=3.0)
+        self.assertEqual(layer.dora_rank, 2)
+        self.assertEqual(layer.dora_alpha, 3.0)
+
+        a_val = np.array([[0.1, 0.2], [0.3, 0.4]], dtype=np.float32)
+        b_val = np.array([[0.5, 0.6, 0.7], [0.8, 0.9, 1.0]], dtype=np.float32)
+        layer.dora_kernel_a.assign(a_val)
+        layer.dora_kernel_b.assign(b_val)
+
+        # Manually compute expected effective kernel.
+        expected_delta = 1.5 * np.matmul(a_val, b_val)
+        W_combined = base_kernel + expected_delta
+        norm = np.sqrt(np.sum(np.square(W_combined), axis=0))
+        expected_kernel = ops.convert_to_numpy(layer.dora_magnitude) * (
+            W_combined / norm
+        )
+
+        actual_kernel = ops.convert_to_numpy(layer.kernel)
+        self.assertAllClose(
+            actual_kernel, expected_kernel, tpu_atol=1e-3, tpu_rtol=1e-3
+        )
+
+    def test_dora_rank_argument(self):
+        self.run_layer_test(
+            layers.EinsumDense,
+            init_kwargs={
+                "equation": "ab,bcd->acd",
+                "output_shape": (8, 32),
+                "bias_axes": None,
+                "dora_rank": 2,
+            },
+            input_shape=(2, 3),
+            expected_output_shape=(2, 8, 32),
+            expected_num_trainable_weights=3,
+            expected_num_non_trainable_weights=1,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
+    def test_enable_dora_with_kernel_constraint(self):
+        layer = layers.EinsumDense(
+            "ab,bc->ac", output_shape=4, kernel_constraint="max_norm"
+        )
+        with self.assertRaisesRegex(
+            ValueError, "DoRA is incompatible with kernel constraints"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_on_unbuilt_layer(self):
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=4)
+        with self.assertRaisesRegex(
+            ValueError, "Cannot enable dora on a layer that isn't yet built"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_when_already_enabled(self):
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=4)
+        layer.build((None, 2))
+        layer.enable_dora(rank=2)
+        with self.assertRaisesRegex(ValueError, "dora is already enabled"):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_with_gptq_quantization(self):
+        layer = layers.EinsumDense("ab,bc->ac", output_shape=4)
+        layer.build((None, 2))
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=2
+            ),
+        )
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "dora is not currently supported with GPTQ quantization",
+        ):
+            layer.enable_dora(rank=2)
+
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_enable_dora_int4_kernel_shape(self):
+        layer = layers.EinsumDense("ab,bcd->acd", output_shape=(2, 4))
+        layer.build((None, 3))
+        # original_kernel_shape should be (3, 2, 4)
+        layer.quantize("int4")
+        layer.enable_dora(rank=2)
+        self.assertEqual(layer.dora_kernel_a.shape, (3, 2, 2))
+
+    def test_dora_lora_mutual_exclusivity(self):
+        layer = layers.EinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes=None,
+        )
+        layer.build((None, 3))
+        layer.enable_lora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "LoRA is already enabled. Cannot enable DoRA."
+        ):
+            layer.enable_dora(rank=2)
+
+        layer2 = layers.EinsumDense(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes=None,
+        )
+        layer2.build((None, 3))
+        layer2.enable_dora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "dora is already enabled. Cannot enable LoRA."
+        ):
+            layer2.enable_lora(rank=2)
+
     # Test quantization-related methods.
 
     @parameterized.named_parameters(
@@ -1183,42 +1394,6 @@ class EinsumDenseTest(testing.TestCase):
         new_layer = layers.EinsumDense.from_config(layer_config)
         new_layer.build((None, 3))
         self.assertEqual(new_layer.quantization_mode, "awq")
-
-    def test_gptq_uncalibrated_save_raises(self):
-        """Saving a GPTQ layer that was never calibrated must raise."""
-        config = dict(
-            equation="ab,bcd->acd",
-            output_shape=(8, 32),
-            bias_axes="d",
-        )
-        layer = layers.EinsumDense(**config)
-        layer.build((None, 3))
-        layer.quantize(
-            "gptq",
-            config=GPTQConfig(
-                dataset=None, tokenizer=None, weight_bits=4, group_size=8
-            ),
-        )
-        with self.assertRaisesRegex(ValueError, "never been calibrated"):
-            layer.save_own_variables({})
-
-    def test_awq_uncalibrated_save_raises(self):
-        """Saving an AWQ layer that was never calibrated must raise."""
-        config = dict(
-            equation="ab,bcd->acd",
-            output_shape=(8, 32),
-            bias_axes="d",
-        )
-        layer = layers.EinsumDense(**config)
-        layer.build((None, 3))
-        layer.quantize(
-            "awq",
-            config=AWQConfig(
-                dataset=None, tokenizer=None, group_size=8, num_grid_points=10
-            ),
-        )
-        with self.assertRaisesRegex(ValueError, "never been calibrated"):
-            layer.save_own_variables({})
 
     def test_int4_kernel_returns_unpacked_form(self):
         """Test that the `kernel` property returns the unpacked int4 kernel."""

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1395,6 +1395,42 @@ class EinsumDenseTest(testing.TestCase):
         new_layer.build((None, 3))
         self.assertEqual(new_layer.quantization_mode, "awq")
 
+    def test_gptq_uncalibrated_save_raises(self):
+        """Saving a GPTQ layer that was never calibrated must raise."""
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+        layer.quantize(
+            "gptq",
+            config=GPTQConfig(
+                dataset=None, tokenizer=None, weight_bits=4, group_size=8
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "never been calibrated"):
+            layer.save_own_variables({})
+
+    def test_awq_uncalibrated_save_raises(self):
+        """Saving an AWQ layer that was never calibrated must raise."""
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+        layer.quantize(
+            "awq",
+            config=AWQConfig(
+                dataset=None, tokenizer=None, group_size=8, num_grid_points=10
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "never been calibrated"):
+            layer.save_own_variables({})
+
     def test_int4_kernel_returns_unpacked_form(self):
         """Test that the `kernel` property returns the unpacked int4 kernel."""
         layer = layers.EinsumDense(


### PR DESCRIPTION
## Description
Adds DoRA support to the EinsumDense layer. This is particularly useful for fine-tuning Transformer-based architectures that use EinsumDense for projections.


   - Implements weight decomposition compatible with EinsumDense kernel shapes.
   - Updates MultiHeadAttention tests to ensure seamless integration with attention mechanisms.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
