### PR TITLE
[DoRA] Implement DoRA for Embedding layer

### DIFF
--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -200,25 +200,29 @@ class Embedding(Layer):
                 embeddings, self._orig_output_dim, axis=-1
             )
         if self.lora_enabled:
+            lora_delta = ops.matmul(
+                ops.reshape(self.lora_embeddings_a, (-1, self.lora_rank)),
+                self.lora_embeddings_b,
+            )
+            lora_delta = ops.reshape(lora_delta, embeddings.shape)
             embeddings = ops.cast(
                 ops.add(
                     embeddings,
-                    (self.lora_alpha / self.lora_rank)
-                    * ops.matmul(
-                        self.lora_embeddings_a, self.lora_embeddings_b
-                    ),
+                    (self.lora_alpha / self.lora_rank) * lora_delta,
                 ),
                 dtype=self.compute_dtype,
             )
         elif self.dora_enabled:
-            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
-                self.dora_embeddings_a, self.dora_embeddings_b
+            dora_delta = ops.matmul(
+                ops.reshape(self.dora_embeddings_a, (-1, self.dora_rank)),
+                self.dora_embeddings_b,
             )
-            W_combined = ops.add(embeddings, lora_delta)
+            dora_delta = ops.reshape(dora_delta, embeddings.shape)
+            W_combined = ops.add(
+                embeddings, (self.dora_alpha / self.dora_rank) * dora_delta
+            )
             # Normalize along input dimension (axis 0)
-            norm = ops.stop_gradient(
-                ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
-            )
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
             embeddings = self.dora_magnitude * ops.divide_no_nan(
                 W_combined, norm
             )
@@ -318,10 +322,6 @@ class Embedding(Layer):
         if self.dora_enabled:
             raise ValueError(
                 "dora is already enabled. This can only be done once per layer."
-            )
-        if self.quantization_mode is not None:
-            raise NotImplementedError(
-                "DoRA is not currently supported with quantized layers."
             )
         self._tracker.unlock()
 
@@ -451,7 +451,10 @@ class Embedding(Layer):
             self.dora_enabled = True
 
             self.dora_magnitude.assign(
-                ops.sqrt(ops.sum(ops.square(base_embeddings), axis=0))
+                ops.cast(
+                    ops.sqrt(ops.sum(ops.square(base_embeddings), axis=0)),
+                    dtype=self.dora_magnitude.dtype,
+                )
             )
 
     def get_config(self):
@@ -631,6 +634,16 @@ class Embedding(Layer):
                 outputs, (self.lora_alpha / self.lora_rank) * lora_outputs
             )
             outputs = ops.cast(outputs, dtype=self.compute_dtype)
+        elif self.dora_enabled:
+            outputs = ops.cast(outputs, dtype=self.compute_dtype)
+            dora_outputs = ops.take(self.dora_embeddings_a, inputs, axis=0)
+            dora_outputs = ops.matmul(dora_outputs, self.dora_embeddings_b)
+            W_combined = ops.add(
+                outputs, (self.dora_alpha / self.dora_rank) * dora_outputs
+            )
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            outputs = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
+            outputs = ops.cast(outputs, dtype=self.compute_dtype)
         return outputs
 
     def _int4_call(self, inputs, training=None):
@@ -673,12 +686,23 @@ class Embedding(Layer):
                 outputs, (self.lora_alpha / self.lora_rank) * lora_outputs
             )
             outputs = ops.cast(outputs, dtype=self.compute_dtype)
+        elif self.dora_enabled:
+            outputs = ops.cast(outputs, dtype=self.compute_dtype)
+            dora_outputs = ops.take(self.dora_embeddings_a, inputs, axis=0)
+            dora_outputs = ops.matmul(dora_outputs, self.dora_embeddings_b)
+            W_combined = ops.add(
+                outputs, (self.dora_alpha / self.dora_rank) * dora_outputs
+            )
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            outputs = self.dora_magnitude * ops.divide_no_nan(W_combined, norm)
+            outputs = ops.cast(outputs, dtype=self.compute_dtype)
         return outputs
 
     def quantize(self, mode=None, type_check=True, config=None):
         # Prevent quantization of the subclasses.
         if type_check and (type(self) is not Embedding):
             raise self._not_implemented_error(self.quantize)
+
         if mode not in ("int8", "int4"):
             raise self._quantization_mode_error(mode)
 

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -76,6 +76,17 @@ class Embedding(Layer):
             trainable matrices) during the forward pass. The delta is scaled by
             `lora_alpha / lora_rank`, allowing you to fine-tune the strength of
             the LoRA adjustment independently of `lora_rank`.
+        dora_rank: Optional integer. If set, the layer's forward pass
+            will implement DoRA (Weight-Decomposed Low-Rank Adaptation)
+            with the provided rank. DoRA decomposes the layer's embeddings
+            into magnitude and direction components and applies LoRA
+            to the direction component. This can improve the learning
+            capacity of LoRA. You can also enable DoRA on an existing
+            `Embedding` layer by calling `layer.enable_dora(rank)`.
+        dora_alpha: Optional integer. If set, this parameter scales the
+            low-rank adaptation delta during the forward pass. The delta
+            is scaled by `dora_alpha / dora_rank`, allowing you to fine-tune
+            the strength of the DoRA adjustment independently of `dora_rank`.
 
     Input shape:
         2D tensor with shape: `(batch_size, input_length)`.
@@ -95,6 +106,8 @@ class Embedding(Layer):
         weights=None,
         lora_rank=None,
         lora_alpha=None,
+        dora_rank=None,
+        dora_alpha=None,
         quantization_config=None,
         **kwargs,
     ):
@@ -134,7 +147,14 @@ class Embedding(Layer):
         self.autocast = False
         self.lora_rank = lora_rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else lora_rank
+        self.dora_rank = dora_rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else dora_rank
+        if self.lora_rank and self.dora_rank:
+            raise ValueError(
+                "Only one of `lora_rank` or `dora_rank` can be set."
+            )
         self.lora_enabled = False
+        self.dora_enabled = False
         self.quantization_config = quantization_config
 
         if weights is not None:
@@ -165,6 +185,8 @@ class Embedding(Layer):
         self.built = True
         if self.lora_rank:
             self.enable_lora(self.lora_rank)
+        if self.dora_rank:
+            self.enable_dora(self.dora_rank, dora_alpha=self.dora_alpha)
 
     @property
     def embeddings(self):
@@ -188,6 +210,20 @@ class Embedding(Layer):
                 ),
                 dtype=self.compute_dtype,
             )
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_embeddings_a, self.dora_embeddings_b
+            )
+            W_combined = ops.add(embeddings, lora_delta)
+            # Normalize along input dimension (axis 0)
+            norm = ops.stop_gradient(
+                ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            )
+            embeddings = self.dora_magnitude * ops.divide_no_nan(
+                W_combined, norm
+            )
+            embeddings = ops.cast(embeddings, dtype=self.compute_dtype)
+
         return embeddings
 
     def call(self, inputs):
@@ -232,6 +268,8 @@ class Embedding(Layer):
             raise ValueError(
                 "lora is already enabled. This can only be done once per layer."
             )
+        if self.dora_enabled:
+            raise ValueError("dora is already enabled. Cannot enable LoRA.")
         self._tracker.unlock()
 
         # LoRA weights should be float32 to avoid the risk of underflow or
@@ -257,6 +295,68 @@ class Embedding(Layer):
         self.lora_enabled = True
         self.lora_rank = rank
         self.lora_alpha = lora_alpha if lora_alpha is not None else rank
+
+    def enable_dora(
+        self,
+        rank,
+        dora_alpha=None,
+        a_initializer="he_uniform",
+        b_initializer="zeros",
+    ):
+        if self.embeddings_constraint:
+            raise ValueError(
+                "DoRA is incompatible with embedding constraints. "
+                "In order to enable dora on this layer, remove the "
+                "`embeddings_constraint` argument."
+            )
+        if not self.built:
+            raise ValueError(
+                "Cannot enable dora on a layer that isn't yet built."
+            )
+        if self.lora_enabled:
+            raise ValueError("LoRA is already enabled. Cannot enable DoRA.")
+        if self.dora_enabled:
+            raise ValueError(
+                "dora is already enabled. This can only be done once per layer."
+            )
+        if self.quantization_mode is not None:
+            raise NotImplementedError(
+                "DoRA is not currently supported with quantized layers."
+            )
+        self._tracker.unlock()
+
+        self.dora_embeddings_a = self.add_weight(
+            name="dora_embeddings_a",
+            shape=(self.input_dim, rank),
+            initializer=initializers.get(a_initializer),
+            dtype="float32",
+            regularizer=self.embeddings_regularizer,
+        )
+        self.dora_embeddings_b = self.add_weight(
+            name="dora_embeddings_b",
+            shape=(rank, self.output_dim),
+            initializer=initializers.get(b_initializer),
+            dtype="float32",
+            regularizer=self.embeddings_regularizer,
+        )
+
+        # Initialize Magnitude Vector
+        # We reduce all axes except the last one (output_dim)
+        initial_magnitude = ops.sqrt(
+            ops.sum(ops.square(self.embeddings), axis=0)
+        )
+        self.dora_magnitude = self.add_weight(
+            name="dora_magnitude",
+            shape=(self.output_dim,),
+            initializer=initializers.Constant(initial_magnitude),
+            dtype="float32",
+        )
+
+        self._embeddings.trainable = False
+        self._tracker.lock()
+        self.dora_enabled = True
+        self.dora_rank = rank
+        self.dora_alpha = dora_alpha if dora_alpha is not None else rank
 
     def save_own_variables(self, store):
         # Do nothing if the layer isn't yet built
@@ -301,7 +401,7 @@ class Embedding(Layer):
             idx += 1
 
     def load_own_variables(self, store):
-        if not self.lora_enabled:
+        if not self.lora_enabled and not self.dora_enabled:
             self._check_load_own_variables(store)
         # Do nothing if the layer isn't yet built
         if not self.built:
@@ -338,6 +438,21 @@ class Embedding(Layer):
             self.lora_embeddings_b.assign(
                 ops.zeros(self.lora_embeddings_b.shape)
             )
+        if self.dora_enabled:
+            self.dora_embeddings_a.assign(
+                ops.zeros(self.dora_embeddings_a.shape)
+            )
+            self.dora_embeddings_b.assign(
+                ops.zeros(self.dora_embeddings_b.shape)
+            )
+            # Temporarily disable to get base kernel
+            self.dora_enabled = False
+            base_embeddings = self.embeddings
+            self.dora_enabled = True
+
+            self.dora_magnitude.assign(
+                ops.sqrt(ops.sum(ops.square(base_embeddings), axis=0))
+            )
 
     def get_config(self):
         base_config = super().get_config()
@@ -364,6 +479,9 @@ class Embedding(Layer):
         if self.lora_rank:
             config["lora_rank"] = self.lora_rank
             config["lora_alpha"] = self.lora_alpha
+        if self.dora_rank:
+            config["dora_rank"] = self.dora_rank
+            config["dora_alpha"] = self.dora_alpha
         return {**base_config, **config}
 
     @classmethod
@@ -734,10 +852,22 @@ class Embedding(Layer):
             )
 
         # Merge LoRA weights in float domain.
-        lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
-            self.lora_embeddings_a, self.lora_embeddings_b
-        )
-        merged_float_embeddings = ops.add(float_embeddings, lora_delta)
+        if self.lora_enabled:
+            lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
+                self.lora_embeddings_a, self.lora_embeddings_b
+            )
+            merged_float_embeddings = ops.add(float_embeddings, lora_delta)
+        elif self.dora_enabled:
+            lora_delta = (self.dora_alpha / self.dora_rank) * ops.matmul(
+                self.dora_embeddings_a, self.dora_embeddings_b
+            )
+            W_combined = ops.add(float_embeddings, lora_delta)
+            norm = ops.sqrt(ops.sum(ops.square(W_combined), axis=0))
+            merged_float_embeddings = self.dora_magnitude * ops.divide_no_nan(
+                W_combined, norm
+            )
+        else:
+            merged_float_embeddings = float_embeddings
 
         # Requantize.
         if self.quantization_mode == "int4":

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -981,11 +981,24 @@ class EmbeddingTest(test_case.TestCase):
         layer.quantize("int4", config=config)
         layer.enable_dora(rank=4)
 
+        a_val = np.random.random(layer.dora_embeddings_a.shape).astype(
+            "float32"
+        )
+        b_val = np.random.random(layer.dora_embeddings_b.shape).astype(
+            "float32"
+        )
+        layer.dora_embeddings_a.assign(a_val)
+        layer.dora_embeddings_b.assign(b_val)
+
         x = np.random.randint(0, input_dim, size=(4, 8))
 
-        # Should run without error
         y = layer(x)
         self.assertEqual(y.shape, (4, 8, output_dim))
+
+        layer.dora_enabled = False
+        y_base = layer(x)
+        layer.dora_enabled = True
+        self.assertNotAllClose(y, y_base)
 
     def test_int4_grouped_vs_perchannel_scale_shapes(self):
         """Test that grouped and per-channel have different scale shapes."""

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -343,6 +343,167 @@ class EmbeddingTest(test_case.TestCase):
         with self.assertRaisesRegex(ValueError, "lora is already enabled"):
             layer.enable_lora(rank=2)
 
+    @pytest.mark.requires_trainable_backend
+    def test_enable_dora(self):
+        layer = layers.Embedding(10, 16)
+        layer.build()
+        layer.enable_dora(4)
+        self.assertLen(layer.trainable_weights, 3)
+        self.assertLen(layer.non_trainable_weights, 1)
+        if backend.backend() == "torch":
+            self.assertLen(layer.torch_params, 4)
+        self.assertDType(layer.dora_embeddings_a, "float32")
+        self.assertDType(layer.dora_embeddings_b, "float32")
+        self.assertDType(layer.dora_magnitude, "float32")
+
+        # Try eager call
+        x = np.random.randint(0, 9, size=(64, 3))
+        y = np.random.random((64, 3, 16))
+        _ = layer(x[:2])
+
+        init_dora_a_embeddings_value = layer.dora_embeddings_a.numpy()
+        init_dora_b_embeddings_value = layer.dora_embeddings_b.numpy()
+        init_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        # Try calling fit()
+        model = models.Sequential([layer])
+        model.compile(optimizer="sgd", loss="mse")
+        model.fit(x, y)
+
+        final_dora_a_embeddings_value = layer.dora_embeddings_a.numpy()
+        final_dora_b_embeddings_value = layer.dora_embeddings_b.numpy()
+        final_dora_magnitude_value = layer.dora_magnitude.numpy()
+
+        diff_a = np.max(
+            np.abs(init_dora_a_embeddings_value - final_dora_a_embeddings_value)
+        )
+        diff_b = np.max(
+            np.abs(init_dora_b_embeddings_value - final_dora_b_embeddings_value)
+        )
+        diff_m = np.max(
+            np.abs(init_dora_magnitude_value - final_dora_magnitude_value)
+        )
+
+        self.assertGreater(diff_a, 0.0)
+        self.assertGreater(diff_b, 0.0)
+        self.assertGreater(diff_m, 0.0)
+
+        # Try saving and reloading the model
+        temp_filepath = os.path.join(self.get_temp_dir(), "dora_model.keras")
+        model.save(temp_filepath)
+
+        new_model = saving.load_model(temp_filepath)
+        self.assertTrue(new_model.layers[0].dora_enabled)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try saving and reloading the model's weights only
+        temp_filepath = os.path.join(
+            self.get_temp_dir(), "dora_model.weights.h5"
+        )
+        model.save_weights(temp_filepath)
+
+        # Load the file into a fresh, non-dora model
+        new_model = models.Sequential(
+            [
+                layers.Input((3,), dtype="int32"),
+                layers.Embedding(10, 16),
+            ]
+        )
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+        # Try loading a normal checkpoint into a dora model
+        new_model.save_weights(temp_filepath)
+        model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    def test_enable_dora_with_alpha(self):
+        layer = layers.Embedding(input_dim=3, output_dim=2)
+        layer.build((None,))
+
+        base_emb = np.array(
+            [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float32
+        )
+        layer._embeddings.assign(base_emb)
+
+        layer.enable_dora(2, dora_alpha=3.0)
+        self.assertEqual(layer.dora_rank, 2)
+        self.assertEqual(layer.dora_alpha, 3.0)
+
+        a_val = np.array([[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]], dtype=np.float32)
+        b_val = np.array([[0.5, 0.5], [0.6, 0.6]], dtype=np.float32)
+        layer.dora_embeddings_a.assign(a_val)
+        layer.dora_embeddings_b.assign(b_val)
+
+        # Manually compute expected effective embeddings.
+        expected_delta = 1.5 * np.matmul(a_val, b_val)
+        W_combined = base_emb + expected_delta
+        norm = np.sqrt(np.sum(np.square(W_combined), axis=0))
+        expected_embeddings = ops.convert_to_numpy(layer.dora_magnitude) * (
+            W_combined / norm
+        )
+
+        actual_embeddings = ops.convert_to_numpy(layer.embeddings)
+        self.assertAllClose(
+            actual_embeddings, expected_embeddings, tpu_atol=1e-3, tpu_rtol=1e-3
+        )
+
+    def test_dora_rank_argument(self):
+        self.run_layer_test(
+            layers.Embedding,
+            init_kwargs={"input_dim": 5, "output_dim": 4, "dora_rank": 2},
+            input_shape=(2, 3),
+            input_dtype="int32",
+            expected_output_shape=(2, 3, 4),
+            expected_num_trainable_weights=3,
+            expected_num_non_trainable_weights=1,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
+
+    def test_dora_lora_mutual_exclusivity(self):
+        layer = layers.Embedding(input_dim=10, output_dim=16)
+        layer.build()
+        layer.enable_lora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "LoRA is already enabled. Cannot enable DoRA."
+        ):
+            layer.enable_dora(rank=2)
+
+        layer2 = layers.Embedding(input_dim=10, output_dim=16)
+        layer2.build()
+        layer2.enable_dora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "dora is already enabled. Cannot enable LoRA."
+        ):
+            layer2.enable_lora(rank=2)
+
+    def test_enable_dora_with_embeddings_constraint(self):
+        layer = layers.Embedding(
+            input_dim=10, output_dim=16, embeddings_constraint="max_norm"
+        )
+        with self.assertRaisesRegex(
+            ValueError, "DoRA is incompatible with embedding constraints"
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_on_unbuilt_layer(self):
+        layer = layers.Embedding(input_dim=10, output_dim=16)
+        with self.assertRaisesRegex(
+            ValueError, "Cannot enable dora on a layer that isn't yet built."
+        ):
+            layer.enable_dora(rank=2)
+
+    def test_enable_dora_when_already_enabled(self):
+        layer = layers.Embedding(input_dim=10, output_dim=16)
+        layer.build()
+        layer.enable_dora(rank=2)
+        with self.assertRaisesRegex(
+            ValueError, "dora is already enabled. This can only be done once"
+        ):
+            layer.enable_dora(rank=2)
+
     # Test quantization-related methods.
 
     @parameterized.named_parameters(
@@ -798,6 +959,27 @@ class EmbeddingTest(test_case.TestCase):
         config = Int4QuantizationConfig(block_size=block_size)
         layer.quantize("int4", config=config)
         layer.enable_lora(rank=4)
+
+        x = np.random.randint(0, input_dim, size=(4, 8))
+
+        # Should run without error
+        y = layer(x)
+        self.assertEqual(y.shape, (4, 8, output_dim))
+
+    @parameterized.named_parameters(
+        ("grouped_block_64", 64),
+        ("per_channel", None),
+    )
+    @pytest.mark.requires_trainable_backend
+    def test_int4_block_size_with_dora(self, block_size):
+        """Test int4 quantization with DoRA and different block_size."""
+        input_dim, output_dim = 50, 128
+        layer = layers.Embedding(input_dim=input_dim, output_dim=output_dim)
+        layer.build()
+
+        config = Int4QuantizationConfig(block_size=block_size)
+        layer.quantize("int4", config=config)
+        layer.enable_dora(rank=4)
 
         x = np.random.randint(0, input_dim, size=(4, 8))
 


### PR DESCRIPTION
## Description
Adapts the DoRA decomposition for the Embedding layer.


   - Decomposes embedding weights into magnitude and direction.
   - Allows fine-tuning of large embedding tables with significantly fewer parameters while maintaining better learning capacity than standard LoRA.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
