### PR TITLE
Optimize array unstacking in Numpy and JAX backends

### DIFF
--- a/keras/src/backend/jax/core.py
+++ b/keras/src/backend/jax/core.py
@@ -610,10 +610,7 @@ def stop_gradient(variable):
 
 
 def unstack(x, num=None, axis=0):
-    return [
-        jax.lax.index_in_dim(x, i, axis, keepdims=False)
-        for i in range(x.shape[axis])
-    ]
+    return list(jnp.moveaxis(x, axis, 0))
 
 
 def random_seed_dtype():

--- a/keras/src/backend/jax/rnn.py
+++ b/keras/src/backend/jax/rnn.py
@@ -534,7 +534,4 @@ def gru(
 
 
 def unstack(x, axis=0):
-    return [
-        lax.index_in_dim(x, i, axis, keepdims=False)
-        for i in range(x.shape[axis])
-    ]
+    return list(jnp.moveaxis(x, axis, 0))

--- a/keras/src/backend/numpy/core.py
+++ b/keras/src/backend/numpy/core.py
@@ -433,8 +433,7 @@ def stop_gradient(variable):
 
 
 def unstack(x, num=None, axis=0):
-    x = np.moveaxis(x, axis, 0)
-    return [x[i] for i in range(x.shape[0])]
+    return list(np.moveaxis(x, axis, 0))
 
 
 def random_seed_dtype():

--- a/keras/src/backend/numpy/rnn.py
+++ b/keras/src/backend/numpy/rnn.py
@@ -213,7 +213,7 @@ def bidirectional_lstm(*args, **kwargs):
 
 
 def unstack(x, axis=0):
-    return [x.take(i, axis) for i in range(x.shape[axis])]
+    return list(np.moveaxis(x, axis, 0))
 
 
 def numpy_scan(f, init, xs, reverse=False, mask=None):


### PR DESCRIPTION

## Description
<!-- Describe your changes here -->
Replaced explicit list comprehensions for unstacking arrays with `list(backend.moveaxis(x, axis, 0))` in Numpy and JAX backends to significantly improve tracing and execution performance.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
