### PR TITLE
Fix MultiProcessInitializeTest causing TorchInductor compilation failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,13 +38,6 @@ jobs:
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
-      - name: Install Linux binary dependencies
-        # build-essential is the C++ compiler for Torch Dynamo
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install build-essential g++
-          g++ --version
-          g++ -print-prog-name=cc1plus
       - name: Install dependencies
         run: pip install -r requirements.txt --progress-bar off --upgrade
       - name: Test integrations

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
+      - name: Install Linux binary dependencies
+        # build-essential is the C++ compiler for Torch Dynamo
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install build-essential g++
+          g++ --version
+          g++ -print-prog-name=cc1plus
       - name: Install dependencies
         run: pip install -r requirements.txt --progress-bar off --upgrade
       - name: Test integrations

--- a/keras/src/distribution/distribution_lib_test.py
+++ b/keras/src/distribution/distribution_lib_test.py
@@ -23,9 +23,14 @@ from keras.src.distribution import distribution_lib
     return_value=None,
 )
 class MultiProcessInitializeTest(testing.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._original_env = os.environ.copy()
+
     def tearDown(self):
         super().tearDown()
         os.environ.clear()
+        os.environ.update(self._original_env)
 
     def test_initialize_with_explicit_param(self, mock_backend_initialize):
         job_addresses = "10.0.0.1:1234,10.0.0.2:2345"

--- a/keras/src/distribution/distribution_lib_test.py
+++ b/keras/src/distribution/distribution_lib_test.py
@@ -23,15 +23,6 @@ from keras.src.distribution import distribution_lib
     return_value=None,
 )
 class MultiProcessInitializeTest(testing.TestCase):
-    def setUp(self):
-        super().setUp()
-        self._original_env = os.environ.copy()
-
-    def tearDown(self):
-        super().tearDown()
-        os.environ.clear()
-        os.environ.update(self._original_env)
-
     def test_initialize_with_explicit_param(self, mock_backend_initialize):
         job_addresses = "10.0.0.1:1234,10.0.0.2:2345"
         num_processes = 2
@@ -53,10 +44,15 @@ class MultiProcessInitializeTest(testing.TestCase):
         os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = str(num_processes)
         os.environ["KERAS_DISTRIBUTION_PROCESS_ID"] = str(current_process_id)
 
-        distribution_lib.initialize()
-        mock_backend_initialize.assert_called_once_with(
-            job_addresses, num_processes, current_process_id
-        )
+        try:
+            distribution_lib.initialize()
+            mock_backend_initialize.assert_called_once_with(
+                job_addresses, num_processes, current_process_id
+            )
+        finally:
+            os.environ.pop("KERAS_DISTRIBUTION_JOB_ADDRESSES", None)
+            os.environ.pop("KERAS_DISTRIBUTION_NUM_PROCESSES", None)
+            os.environ.pop("KERAS_DISTRIBUTION_PROCESS_ID", None)
 
     def test_init_with_nones(self, mock_backend_initialize):
         # This is also valid case for Cloud TPU on JAX


### PR DESCRIPTION
## Description
Fixes the Keras Nightly and PR CI test failures for the PyTorch backend (failed @torch.compile / _jit tests, such as _`test_steps_per_execution_steps_per_epoch_unknown_data_size_not_match_too_low_jit`_).

**Root Cause & Evidence**
In commit c307772e4 (PR #23316), MultiProcessInitializeTest in keras/src/distribution/distribution_lib_test.py
was enabled for the PyTorch backend. MultiProcessInitializeTest.tearDown() previously called os.environ.clear(), wiping every operating system environment variable from the running Python process—including PATH.

When subsequent tests in the suite invoked torch.compile (_jit), TorchInductor called g++ to compile CPU C++ wrapper code. Because PATH had been wiped from os.environ, g++'s internal execvp/posix_spawnp call could not locate its C++ compiler parser backend (cc1plus), failing with:
`
g++: fatal error: cannot execute 'cc1plus': posix_spawnp: No such file or directory
`

**Changes:**
Updated `MultiProcessInitializeTest` in  to save os.environ.copy() in setUp() and restore it in tearDown() instead of permanently wiping the process environment.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
