### PR TITLE
Fix unpack_ternary decoding for signed int8 packed tensors

### DIFF
--- a/keras/src/quantizers/quantizers.py
+++ b/keras/src/quantizers/quantizers.py
@@ -1026,6 +1026,7 @@ def unpack_ternary(packed, orig_len, axis=0):
     # Fast path: axis=0 on a rank-2 tensor — no transposes needed.
     if axis == 0 and rank == 2:
         codes = ops.cast(packed, "int32")
+        codes = ops.where(codes < 0, codes + 256, codes)
         digits = []
         for place in (1, 3, 9, 27, 81):
             digit = ops.mod(ops.floor_divide(codes, place), 3)
@@ -1040,6 +1041,7 @@ def unpack_ternary(packed, orig_len, axis=0):
     inv_perm = [perm.index(i) for i in range(rank)]
     transposed = ops.transpose(packed, perm)
     codes = ops.cast(transposed, "int32")
+    codes = ops.where(codes < 0, codes + 256, codes)
 
     digits = []
     for place in (1, 3, 9, 27, 81):


### PR DESCRIPTION
## Description
"pack_ternary" outputs a uint8 tensor, but if it gets cast to int8 during save/load, values >= 128 overflow to negative numbers and break decoding.  #23374 

**Fix:**
This PR patches unpack_ternary to properly handle signed int8 inputs by remapping any negative values back to their original unsigned counterparts (adding 256 via ops.where) immediately after casting to int32. This ensures a lossless round trip for base-3 ternary values across all backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [X] I am a human, and not a bot.
- [X] I will be responsible for responding to review comments in a timely manner.
- [X] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
