### PR TITLE
Fix Embedding.enable_lora freezing the wrong tensor after int4 quantization

### DIFF
--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -252,7 +252,9 @@ class Embedding(Layer):
             dtype="float32",
             regularizer=self.embeddings_regularizer,
         )
-        self.embeddings.trainable = False
+        # Freeze the underlying variable, not the `embeddings` property, which
+        # returns a throwaway unpacked tensor in int4 mode.
+        self._embeddings.trainable = False
         self._tracker.lock()
         self.lora_enabled = True
         self.lora_rank = rank

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -343,6 +343,17 @@ class EmbeddingTest(test_case.TestCase):
         with self.assertRaisesRegex(ValueError, "lora is already enabled"):
             layer.enable_lora(rank=2)
 
+    def test_enable_lora_after_int4_quantization_freezes_variable(self):
+        # In int4 mode the `embeddings` property returns a freshly unpacked
+        # tensor rather than the variable, so freezing must go through
+        # `_embeddings`. Backends whose tensors reject attribute assignment
+        # raise `AttributeError` here otherwise.
+        layer = layers.Embedding(input_dim=10, output_dim=16)
+        layer.build()
+        layer.quantize("int4")
+        layer.enable_lora(rank=2)
+        self.assertFalse(layer._embeddings.trainable)
+
     # Test quantization-related methods.
 
     @parameterized.named_parameters(


### PR DESCRIPTION
## Description

`Embedding.enable_lora()` raises `AttributeError` on the numpy backend when the layer has already been quantized to `int4`. The `embeddings` property normally returns the `_embeddings` variable, but in `int4` mode it returns a freshly unpacked tensor from `quantizers.unpack_int4(...)`. `enable_lora` does `self.embeddings.trainable = False`, so it sets an attribute on that throwaway tensor rather than on the variable it means to freeze.

The reason this has gone unnoticed is test coverage rather than rarity. The two existing tests that combine `int4` with LoRA, `test_int4_block_size_with_lora` and `test_quantize_lora_integration_int4`, both call `fit()` and so carry `@pytest.mark.requires_trainable_backend`, which skips them on numpy and openvino with "Trainer not implemented for NumPy and OpenVINO backend". No test reached `enable_lora` after `int4` quantization on a backend where the bug is observable. The test added here stops short of `fit()` so it runs everywhere, and it fails on master with the traceback above.

I came across this while working on the MLX backend in #23076, where `mlx.core.array` rejects attribute assignment in the same way `numpy.ndarray` does. Splitting it out since it is a pre-existing bug on master and independent of that work.


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
