### PR TITLE
Fix zizmor warning with `dorny/path-filter`.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
 
       - name: Check for changes in keras/src/applications
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |


### PR DESCRIPTION
The exact version is `4.0.2`.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
