### PR TITLE
Introduce Model Parallel infrastructure and DTensor support for Keras Variables in torch core.py

### DIFF
--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -6,6 +6,8 @@ import os
 import ml_dtypes
 import numpy as np
 import torch
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import Replicate
 
 from keras.src import tree
 from keras.src.backend.common import KerasVariable
@@ -24,6 +26,8 @@ SUPPORTS_SPARSE_TENSORS = False
 SUPPORTS_RAGGED_TENSORS = False
 SUPPORTS_COMPLEX_DTYPES = True
 IS_THREAD_SAFE = True
+_GLOBAL_DTENSOR_PROMOTION_MODE = None
+
 
 # Some operators such as 'aten::_foreach_mul_.Scalar'
 # are not currently implemented for the MPS device.
@@ -107,8 +111,115 @@ def to_torch_dtype(dtype):
     return standardized_dtype
 
 
+def _promote_tensor_args(args, kwargs, dtensor_arg):
+    """Promotes plain tensors to DTensors using the mesh of dtensor_arg."""
+    mesh = dtensor_arg.device_mesh
+    placements = [Replicate()] * len(mesh.shape)
+
+    def maybe_promote(value):
+        if isinstance(value, torch.Tensor) and not isinstance(value, DTensor):
+            if value.device.type != mesh.device_type:
+                value = value.to(mesh.device_type)
+            return DTensor.from_local(
+                value, device_mesh=mesh, placements=placements
+            )
+        return value
+
+    return tree.map_structure(maybe_promote, (args, kwargs))
+
+
+class KerasDTensorPromotionMode(torch.utils._python_dispatch.TorchDispatchMode):
+    """Dispatch mode that promotes mixed Tensor/DTensor arguments.
+
+    This mode prevents "mixed tensor" errors by intercepting operations where
+    plain tensors and DTensors collide, automatically promoting the plain
+    tensor to a Replicated DTensor.
+    """
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+
+        flat_args = tree.flatten((args, kwargs))
+        dtensor_arg = None
+        has_plain_tensor = False
+
+        for arg in flat_args:
+            if isinstance(arg, DTensor):
+                if dtensor_arg is None:
+                    dtensor_arg = arg
+            elif isinstance(arg, torch.Tensor):
+                has_plain_tensor = True
+
+            if dtensor_arg is not None and has_plain_tensor:
+                break
+
+        if dtensor_arg is not None and has_plain_tensor:
+            args, kwargs = _promote_tensor_args(args, kwargs, dtensor_arg)
+
+        return func(*args, **kwargs)
+
+
 class Variable(KerasVariable):
+    def _initialize_distributed(self, initializer):
+        from keras.src.distribution.distribution_lib import distribution
+
+        dist = distribution()
+        if dist is None:
+            return None
+
+        from keras.src.distribution.distribution_lib import DataParallel
+
+        if isinstance(dist, DataParallel):
+            return None
+
+        from keras.src.backend.torch import distribution_lib
+
+        if self._layout is None:
+            self._layout = dist.get_variable_layout(self)
+
+        if self._layout is None:
+            return None
+
+        from keras.src.distribution.distribution_lib import TensorLayout
+
+        if isinstance(self._layout, TensorLayout):
+            self._layout = self._layout.backend_layout
+
+        if callable(initializer):
+            value = initializer(self._shape, dtype=self._dtype)
+        else:
+            value = initializer
+
+        if isinstance(value, torch.nn.Parameter):
+            value = value.data
+        if isinstance(value, torch.Tensor) and (
+            value.requires_grad or value.grad_fn is not None
+        ):
+            value = value.detach()
+
+        if isinstance(value, torch.Tensor):
+            if value.device.type != self._layout.device_mesh.device_type:
+                value = value.to(self._layout.device_mesh.device_type)
+
+        dtensor = distribution_lib.distribute_tensor(value, self._layout)
+
+        return torch.nn.Parameter(dtensor, requires_grad=self.trainable)
+
+    def _initialize_with_initializer(self, initializer):
+        value = self._initialize_distributed(initializer)
+        if value is not None:
+            self._value = value
+        else:
+            super()._initialize_with_initializer(initializer)
+
     def _initialize(self, value):
+        self._shape = self._validate_shape(value.shape)
+        new_value = self._initialize_distributed(value)
+        if new_value is not None:
+            self._value = new_value
+            return
+
         if isinstance(value, torch.nn.Parameter):
             # Reuse same parameter
             self._value = value
@@ -119,6 +230,17 @@ class Variable(KerasVariable):
             ).to(get_device())
 
     def _direct_assign(self, value):
+        if isinstance(self.value.data, DTensor):
+            from keras.src.backend.torch import distribution_lib
+            from keras.src.distribution.distribution_lib import TensorLayout
+
+            layout = self._layout
+            if isinstance(layout, TensorLayout):
+                layout = layout.backend_layout
+            if value.device.type != layout.device_mesh.device_type:
+                value = value.to(layout.device_mesh.device_type)
+            value = distribution_lib.distribute_tensor(value, layout)
+
         with torch.no_grad():
             self.value.copy_(value)
 
@@ -203,12 +325,18 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
     if isinstance(x, Variable) or is_tensor(x):
         if isinstance(x, Variable):
             x = x.value
-        device = get_device()
-        if x.device != device:
-            if x.is_meta:
-                x = torch.empty_like(x, device=device)
-            else:
-                x = x.to(device)
+        if isinstance(x, DTensor):
+            global _GLOBAL_DTENSOR_PROMOTION_MODE
+            if _GLOBAL_DTENSOR_PROMOTION_MODE is None:
+                _GLOBAL_DTENSOR_PROMOTION_MODE = KerasDTensorPromotionMode()
+                _GLOBAL_DTENSOR_PROMOTION_MODE.__enter__()
+        else:
+            device = get_device()
+            if x.device != device:
+                if x.is_meta:
+                    x = torch.empty_like(x, device=device)
+                else:
+                    x = x.to(device)
         if dtype is not None:
             x = x.to(to_torch_dtype(dtype))
         return x
@@ -266,7 +394,11 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
 
 def convert_to_numpy(x):
     def transform(x):
+        if isinstance(x, Variable):
+            x = x.value
         if is_tensor(x):
+            if isinstance(x, DTensor):
+                x = x.to_local()
             if x.requires_grad:
                 x = x.detach()
             # Tensor has to be moved to CPU before converting to numpy.

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -6,6 +6,8 @@ import os
 import ml_dtypes
 import numpy as np
 import torch
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import Replicate
 
 from keras.src import tree
 from keras.src.backend.common import KerasVariable
@@ -24,6 +26,26 @@ SUPPORTS_SPARSE_TENSORS = False
 SUPPORTS_RAGGED_TENSORS = False
 SUPPORTS_COMPLEX_DTYPES = True
 IS_THREAD_SAFE = True
+_GLOBAL_DTENSOR_PROMOTION_MODE = None
+_DTENSOR_PROMOTION_ACTIVE = False
+
+
+def activate_dtensor_promotion():
+    global _GLOBAL_DTENSOR_PROMOTION_MODE, _DTENSOR_PROMOTION_ACTIVE
+    if _GLOBAL_DTENSOR_PROMOTION_MODE is None:
+        _GLOBAL_DTENSOR_PROMOTION_MODE = KerasDTensorPromotionMode()
+    if not _DTENSOR_PROMOTION_ACTIVE:
+        _GLOBAL_DTENSOR_PROMOTION_MODE.__enter__()
+        _DTENSOR_PROMOTION_ACTIVE = True
+
+
+def deactivate_dtensor_promotion():
+    global _GLOBAL_DTENSOR_PROMOTION_MODE, _DTENSOR_PROMOTION_ACTIVE
+    if _DTENSOR_PROMOTION_ACTIVE:
+        _GLOBAL_DTENSOR_PROMOTION_MODE.__exit__(None, None, None)
+        _DTENSOR_PROMOTION_ACTIVE = False
+    _GLOBAL_DTENSOR_PROMOTION_MODE = None
+
 
 # Some operators such as 'aten::_foreach_mul_.Scalar'
 # are not currently implemented for the MPS device.
@@ -107,8 +129,112 @@ def to_torch_dtype(dtype):
     return standardized_dtype
 
 
+def _promote_tensor_args(args, kwargs, dtensor_arg):
+    """Promotes plain tensors to DTensors using the mesh of dtensor_arg."""
+    mesh = dtensor_arg.device_mesh
+    placements = [Replicate()] * len(mesh.shape)
+
+    def maybe_promote(value):
+        if isinstance(value, torch.Tensor) and not isinstance(value, DTensor):
+            if value.device.type != mesh.device_type:
+                value = value.to(mesh.device_type)
+            return DTensor.from_local(
+                value, device_mesh=mesh, placements=placements
+            )
+        return value
+
+    return tree.map_structure(maybe_promote, (args, kwargs))
+
+
+class KerasDTensorPromotionMode(torch.utils._python_dispatch.TorchDispatchMode):
+    """Dispatch mode that promotes mixed Tensor/DTensor arguments.
+
+    This mode prevents "mixed tensor" errors by intercepting operations where
+    plain tensors and DTensors collide, automatically promoting the plain
+    tensor to a Replicated DTensor.
+    """
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+
+        flat_args = tree.flatten((args, kwargs))
+        dtensor_arg = None
+        has_plain_tensor = False
+
+        for arg in flat_args:
+            if isinstance(arg, DTensor):
+                if dtensor_arg is None:
+                    dtensor_arg = arg
+            elif isinstance(arg, torch.Tensor):
+                has_plain_tensor = True
+
+            if dtensor_arg is not None and has_plain_tensor:
+                break
+
+        if dtensor_arg is not None and has_plain_tensor:
+            args, kwargs = _promote_tensor_args(args, kwargs, dtensor_arg)
+
+        return func(*args, **kwargs)
+
+
 class Variable(KerasVariable):
+    def _initialize_distributed(self, initializer):
+        from keras.src.distribution.distribution_lib import distribution
+
+        dist = distribution()
+        if dist is None:
+            return None
+
+        from keras.src.backend.torch import distribution_lib
+
+        if self._layout is None:
+            self._layout = dist.get_variable_layout(self)
+
+        if self._layout is None:
+            return None
+
+        from keras.src.distribution.distribution_lib import TensorLayout
+
+        if isinstance(self._layout, TensorLayout):
+            if all(axis is None for axis in self._layout.axes):
+                return None
+            self._layout = self._layout.backend_layout
+
+        if callable(initializer):
+            value = initializer(self._shape, dtype=self._dtype)
+        else:
+            value = initializer
+
+        if isinstance(value, torch.nn.Parameter):
+            value = value.data
+        if isinstance(value, torch.Tensor) and (
+            value.requires_grad or value.grad_fn is not None
+        ):
+            value = value.detach()
+
+        if isinstance(value, torch.Tensor):
+            if value.device.type != self._layout.device_mesh.device_type:
+                value = value.to(self._layout.device_mesh.device_type)
+
+        dtensor = distribution_lib.distribute_tensor(value, self._layout)
+
+        return torch.nn.Parameter(dtensor, requires_grad=self.trainable)
+
+    def _initialize_with_initializer(self, initializer):
+        value = self._initialize_distributed(initializer)
+        if value is not None:
+            self._value = value
+        else:
+            super()._initialize_with_initializer(initializer)
+
     def _initialize(self, value):
+        self._shape = self._validate_shape(value.shape)
+        new_value = self._initialize_distributed(value)
+        if new_value is not None:
+            self._value = new_value
+            return
+
         if isinstance(value, torch.nn.Parameter):
             # Reuse same parameter
             self._value = value
@@ -119,6 +245,17 @@ class Variable(KerasVariable):
             ).to(get_device())
 
     def _direct_assign(self, value):
+        if isinstance(self.value.data, DTensor):
+            from keras.src.backend.torch import distribution_lib
+            from keras.src.distribution.distribution_lib import TensorLayout
+
+            layout = self._layout
+            if isinstance(layout, TensorLayout):
+                layout = layout.backend_layout
+            if value.device.type != layout.device_mesh.device_type:
+                value = value.to(layout.device_mesh.device_type)
+            value = distribution_lib.distribute_tensor(value, layout)
+
         with torch.no_grad():
             self.value.copy_(value)
 
@@ -265,7 +402,11 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
 
 def convert_to_numpy(x):
     def transform(x):
+        if isinstance(x, Variable):
+            x = x.value
         if is_tensor(x):
+            if isinstance(x, DTensor):
+                x = x.to_local()
             if x.requires_grad:
                 x = x.detach()
             # Tensor has to be moved to CPU before converting to numpy.

--- a/keras/src/backend/torch/core_test.py
+++ b/keras/src/backend/torch/core_test.py
@@ -1,12 +1,27 @@
 """Tests for PyTorch backend core utilities."""
 
+import os
+
+import numpy as np
 import pytest
 import torch
+from absl.testing import parameterized
+from torch.distributed.device_mesh import DeviceMesh as TorchDeviceMesh
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import Replicate
 
 from keras.src import backend
 from keras.src import testing
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import distribution_lib
+from keras.src.backend.torch.core import KerasDTensorPromotionMode
+from keras.src.backend.torch.core import Variable
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import slice as torch_slice
+from keras.src.distribution.distribution_lib import DeviceMesh
+from keras.src.distribution.distribution_lib import LayoutMap
+from keras.src.distribution.distribution_lib import ModelParallel
+from keras.src.distribution.distribution_lib import set_distribution
 
 
 def _get_backed_symint(hint=2):
@@ -104,3 +119,185 @@ class TorchCoreTest(testing.TestCase):
         shape = [batch, 2, 2]
         result = torch_slice(x, start_indices, shape)
         self.assertEqual(tuple(result.shape), (2, 2, 2))
+
+
+@pytest.mark.skipif(
+    backend.backend() != "torch", reason="Requires torch backend"
+)
+class TorchCoreDistributedTest(testing.TestCase):
+    def set_env(self, key, value):
+        old = os.environ.get(key)
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+        self.addCleanup(
+            lambda: (
+                os.environ.update({key: old})
+                if old is not None
+                else os.environ.pop(key, None)
+            )
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+        from keras.src.backend.torch import core as torch_core
+
+        if (
+            getattr(torch_core, "_GLOBAL_DTENSOR_PROMOTION_MODE", None)
+            is not None
+        ):
+            torch_core._GLOBAL_DTENSOR_PROMOTION_MODE.__exit__(None, None, None)
+            torch_core._GLOBAL_DTENSOR_PROMOTION_MODE = None
+
+    def _ensure_distributed_initialized(self, port="29500"):
+        if not torch.distributed.is_initialized():
+            self.set_env("MASTER_ADDR", "localhost")
+            self.set_env("MASTER_PORT", port)
+            distribution_lib.initialize(num_processes=1, process_id=0)
+
+    def test_keras_dtensor_promotion_mode(self):
+        self._ensure_distributed_initialized(port="29501")
+
+        device_type = torch_core.get_device().split(":")[0]
+        mesh = TorchDeviceMesh(device_type, np.array([0]))
+        local_tensor = torch.ones((2, 2), device=device_type)
+        dtensor = DTensor.from_local(
+            local_tensor, device_mesh=mesh, placements=[Replicate()]
+        )
+
+        plain_tensor = torch.zeros((2, 2), device=device_type)
+
+        with KerasDTensorPromotionMode():
+            # Test simple addition
+            result = dtensor + plain_tensor
+            self.assertIsInstance(result, DTensor)
+            self.assertTrue(
+                torch.allclose(
+                    result.to_local(),
+                    torch.ones((2, 2), device=device_type),
+                )
+            )
+
+            # Test in-place
+            dtensor += plain_tensor
+            self.assertIsInstance(dtensor, DTensor)
+
+            # Test nested structures
+            result = torch.addcmul(dtensor, plain_tensor, dtensor, value=0.5)
+            self.assertIsInstance(result, DTensor)
+
+    def test_convert_to_tensor_pushes_dtensor_mode(self):
+        self._ensure_distributed_initialized(port="29502")
+
+        device_type = torch_core.get_device().split(":")[0]
+        mesh = TorchDeviceMesh(device_type, np.array([0]))
+        local_tensor = torch.ones((2, 2), device=device_type)
+        dtensor = DTensor.from_local(
+            local_tensor, device_mesh=mesh, placements=[Replicate()]
+        )
+
+        if torch_core._GLOBAL_DTENSOR_PROMOTION_MODE is not None:
+            torch_core._GLOBAL_DTENSOR_PROMOTION_MODE.__exit__(None, None, None)
+            torch_core._GLOBAL_DTENSOR_PROMOTION_MODE = None
+
+        convert_to_tensor(dtensor)
+
+        self.assertIsNotNone(torch_core._GLOBAL_DTENSOR_PROMOTION_MODE)
+
+        plain_tensor = torch.zeros((2, 2), device=device_type)
+        result = dtensor + plain_tensor
+        self.assertIsInstance(result, DTensor)
+        self.assertTrue(
+            torch.allclose(
+                result.to_local(), torch.ones((2, 2), device=device_type)
+            )
+        )
+
+        if torch_core._GLOBAL_DTENSOR_PROMOTION_MODE is not None:
+            torch_core._GLOBAL_DTENSOR_PROMOTION_MODE.__exit__(None, None, None)
+            torch_core._GLOBAL_DTENSOR_PROMOTION_MODE = None
+
+    def test_convert_to_numpy_dtensor(self):
+        self._ensure_distributed_initialized(port="29508")
+        device_type = torch_core.get_device().split(":")[0]
+        mesh = TorchDeviceMesh(device_type, np.array([0]))
+        dtensor = DTensor.from_local(
+            torch.ones((2, 2), device=device_type),
+            device_mesh=mesh,
+            placements=[Replicate()],
+        )
+
+        nv = torch_core.convert_to_numpy(dtensor)
+        self.assertIsInstance(nv, np.ndarray)
+        self.assertEqual(nv.shape, (2, 2))
+        self.assertTrue(np.allclose(nv, 1.0))
+
+    @parameterized.parameters(
+        ("callable",),
+        ("parameter",),
+        ("tensor_with_grad",),
+    )
+    def test_variable_initialize_distributed(self, init_type):
+        self._ensure_distributed_initialized()
+
+        mesh = DeviceMesh(
+            shape=(1,),
+            axis_names=["x"],
+            devices=np.array([distribution_lib.list_devices()[0]]),
+        )
+
+        layout_map = LayoutMap(mesh)
+        layout_map[".*"] = ("x", None)
+        dist = ModelParallel(layout_map=layout_map)
+
+        set_distribution(dist)
+
+        if init_type == "callable":
+
+            def initializer(shape, dtype):
+                return torch.ones(shape)
+
+            v = Variable(initializer, shape=(2, 2), dtype="float32")
+        elif init_type == "parameter":
+            v = Variable(torch.nn.Parameter(torch.ones((2, 2))))
+        elif init_type == "tensor_with_grad":
+            v = Variable(torch.ones((2, 2), requires_grad=True))
+
+        self.assertIsInstance(v.value, torch.nn.Parameter)
+        self.assertIsInstance(v.value.data, DTensor)
+        self.assertEqual(v.value.device.type, mesh.backend_mesh.device_type)
+
+    def test_variable_direct_assign(self):
+        self._ensure_distributed_initialized(port="29505")
+
+        mesh = DeviceMesh(
+            shape=(1,),
+            axis_names=["x"],
+            devices=np.array([distribution_lib.list_devices()[0]]),
+        )
+
+        layout_map = LayoutMap(mesh)
+        layout_map[".*"] = ("x", None)
+        dist = ModelParallel(layout_map=layout_map)
+
+        set_distribution(dist)
+
+        v = Variable(torch.ones((2, 2)))
+
+        self.assertIsInstance(v.value, torch.nn.Parameter)
+        self.assertIsInstance(v.value.data, DTensor)
+
+        new_val = torch.zeros((2, 2))
+        v._direct_assign(new_val)
+
+        self.assertIsInstance(v.value.data, DTensor)
+        self.assertTrue(
+            torch.allclose(
+                v.value.data.to_local(),
+                torch.zeros((2, 2), device=v.value.data.to_local().device),
+            )
+        )

--- a/keras/src/backend/torch/core_test.py
+++ b/keras/src/backend/torch/core_test.py
@@ -1,12 +1,27 @@
 """Tests for PyTorch backend core utilities."""
 
+import os
+
+import numpy as np
 import pytest
 import torch
+from absl.testing import parameterized
+from torch.distributed.device_mesh import DeviceMesh as TorchDeviceMesh
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import Replicate
 
 from keras.src import backend
 from keras.src import testing
+from keras.src.backend.torch import core as torch_core
+from keras.src.backend.torch import distribution_lib
+from keras.src.backend.torch.core import KerasDTensorPromotionMode
+from keras.src.backend.torch.core import Variable
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import slice as torch_slice
+from keras.src.distribution.distribution_lib import DeviceMesh
+from keras.src.distribution.distribution_lib import LayoutMap
+from keras.src.distribution.distribution_lib import ModelParallel
+from keras.src.distribution.distribution_lib import set_distribution
 
 
 def _get_backed_symint(hint=2):
@@ -104,3 +119,172 @@ class TorchCoreTest(testing.TestCase):
         shape = [batch, 2, 2]
         result = torch_slice(x, start_indices, shape)
         self.assertEqual(tuple(result.shape), (2, 2, 2))
+
+
+@pytest.mark.skipif(
+    backend.backend() != "torch", reason="Requires torch backend"
+)
+class TorchCoreDistributedTest(testing.TestCase):
+    def set_env(self, key, value):
+        old = os.environ.get(key)
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+        self.addCleanup(
+            lambda: (
+                os.environ.update({key: old})
+                if old is not None
+                else os.environ.pop(key, None)
+            )
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+        from keras.src.backend.torch import core as torch_core
+
+        torch_core.deactivate_dtensor_promotion()
+
+    def _ensure_distributed_initialized(self, port="29500"):
+        if not torch.distributed.is_initialized():
+            self.set_env("MASTER_ADDR", "localhost")
+            self.set_env("MASTER_PORT", port)
+            distribution_lib.initialize(num_processes=1, process_id=0)
+
+    def test_keras_dtensor_promotion_mode(self):
+        self._ensure_distributed_initialized(port="29501")
+
+        device_type = torch_core.get_device().split(":")[0]
+        mesh = TorchDeviceMesh(device_type, np.array([0]))
+        local_tensor = torch.ones((2, 2), device=device_type)
+        dtensor = DTensor.from_local(
+            local_tensor, device_mesh=mesh, placements=[Replicate()]
+        )
+
+        plain_tensor = torch.zeros((2, 2), device=device_type)
+
+        with KerasDTensorPromotionMode():
+            # Test simple addition
+            result = dtensor + plain_tensor
+            self.assertIsInstance(result, DTensor)
+            self.assertTrue(
+                torch.allclose(
+                    result.to_local(),
+                    torch.ones((2, 2), device=device_type),
+                )
+            )
+
+            # Test in-place
+            dtensor += plain_tensor
+            self.assertIsInstance(dtensor, DTensor)
+
+            # Test nested structures
+            result = torch.addcmul(dtensor, plain_tensor, dtensor, value=0.5)
+            self.assertIsInstance(result, DTensor)
+
+    def test_convert_to_tensor_pushes_dtensor_mode(self):
+        self._ensure_distributed_initialized(port="29502")
+
+        device_type = torch_core.get_device().split(":")[0]
+        mesh = TorchDeviceMesh(device_type, np.array([0]))
+        local_tensor = torch.ones((2, 2), device=device_type)
+        dtensor = DTensor.from_local(
+            local_tensor, device_mesh=mesh, placements=[Replicate()]
+        )
+
+        torch_core.activate_dtensor_promotion()
+
+        convert_to_tensor(dtensor)
+
+        plain_tensor = torch.zeros((2, 2), device=device_type)
+        result = dtensor + plain_tensor
+        self.assertIsInstance(result, DTensor)
+        self.assertTrue(
+            torch.allclose(
+                result.to_local(), torch.ones((2, 2), device=device_type)
+            )
+        )
+
+    def test_convert_to_numpy_dtensor(self):
+        self._ensure_distributed_initialized(port="29508")
+        device_type = torch_core.get_device().split(":")[0]
+        mesh = TorchDeviceMesh(device_type, np.array([0]))
+        dtensor = DTensor.from_local(
+            torch.ones((2, 2), device=device_type),
+            device_mesh=mesh,
+            placements=[Replicate()],
+        )
+
+        nv = torch_core.convert_to_numpy(dtensor)
+        self.assertIsInstance(nv, np.ndarray)
+        self.assertEqual(nv.shape, (2, 2))
+        self.assertTrue(np.allclose(nv, 1.0))
+
+    @parameterized.parameters(
+        ("callable",),
+        ("parameter",),
+        ("tensor_with_grad",),
+    )
+    def test_variable_initialize_distributed(self, init_type):
+        self._ensure_distributed_initialized()
+
+        mesh = DeviceMesh(
+            shape=(1,),
+            axis_names=["x"],
+            devices=np.array([distribution_lib.list_devices()[0]]),
+        )
+
+        layout_map = LayoutMap(mesh)
+        layout_map[".*"] = ("x", None)
+        dist = ModelParallel(layout_map=layout_map)
+
+        set_distribution(dist)
+
+        if init_type == "callable":
+
+            def initializer(shape, dtype):
+                return torch.ones(shape)
+
+            v = Variable(initializer, shape=(2, 2), dtype="float32")
+        elif init_type == "parameter":
+            v = Variable(torch.nn.Parameter(torch.ones((2, 2))))
+        elif init_type == "tensor_with_grad":
+            v = Variable(torch.ones((2, 2), requires_grad=True))
+
+        self.assertIsInstance(v.value, torch.nn.Parameter)
+        self.assertIsInstance(v.value.data, DTensor)
+        self.assertEqual(v.value.device.type, mesh.backend_mesh.device_type)
+
+    def test_variable_direct_assign(self):
+        self._ensure_distributed_initialized(port="29505")
+
+        mesh = DeviceMesh(
+            shape=(1,),
+            axis_names=["x"],
+            devices=np.array([distribution_lib.list_devices()[0]]),
+        )
+
+        layout_map = LayoutMap(mesh)
+        layout_map[".*"] = ("x", None)
+        dist = ModelParallel(layout_map=layout_map)
+
+        set_distribution(dist)
+
+        v = Variable(torch.ones((2, 2)))
+
+        self.assertIsInstance(v.value, torch.nn.Parameter)
+        self.assertIsInstance(v.value.data, DTensor)
+
+        new_val = torch.zeros((2, 2))
+        v._direct_assign(new_val)
+
+        self.assertIsInstance(v.value.data, DTensor)
+        self.assertTrue(
+            torch.allclose(
+                v.value.data.to_local(),
+                torch.zeros((2, 2), device=v.value.data.to_local().device),
+            )
+        )

--- a/keras/src/backend/torch/distribution_lib.py
+++ b/keras/src/backend/torch/distribution_lib.py
@@ -5,6 +5,7 @@ import torch
 import torch.distributed
 from torch.distributed import tensor as torch_distributed_tensor
 
+from keras.src.backend.torch import core as torch_core
 from keras.src.backend.torch.core import _parse_device_input
 from keras.src.backend.torch.core import convert_to_tensor
 from keras.src.backend.torch.core import get_device
@@ -126,6 +127,22 @@ def initialize(job_addresses=None, num_processes=None, process_id=None):
         torch.distributed.init_process_group(
             backend=backend, rank=rank, world_size=world_size
         )
+
+        if torch_core._GLOBAL_DTENSOR_PROMOTION_MODE is None:
+            torch_core._GLOBAL_DTENSOR_PROMOTION_MODE = (
+                torch_core.KerasDTensorPromotionMode()
+            )
+            # We don't automatically enter the mode globally anymore,
+            # to avoid interfering with torch.compile.
+            # Instead, it's entered in Distribution.scope().
+
+
+def activate_dtensor_promotion():
+    torch_core.activate_dtensor_promotion()
+
+
+def deactivate_dtensor_promotion():
+    torch_core.deactivate_dtensor_promotion()
 
 
 def num_processes():

--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -831,3 +831,9 @@ def set_distribution(value):
         value: a `Distribution` instance.
     """
     global_state.set_global_attribute(GLOBAL_ATTRIBUTE_NAME, value)
+    if value is not None:
+        if hasattr(distribution_lib, "activate_dtensor_promotion"):
+            distribution_lib.activate_dtensor_promotion()
+    else:
+        if hasattr(distribution_lib, "deactivate_dtensor_promotion"):
+            distribution_lib.deactivate_dtensor_promotion()


### PR DESCRIPTION
This PR implements distributed variable initialization and tensor promotion for the PyTorch backend using torch.distributed.tensor (DTensor). It enables ModelParallel distribution strategies to correctly shard variables and manage mixed-tensor operations.


  Key Changes:
   - Distributed Variable Initialization: Implemented _initialize_distributed in keras/src/backend/torch/core.py. This ensures that when a ModelParallel distribution is active, Variable objects are initialized as DTensors according to the specified layout.
   - DTensor Promotion Mode: Introduced KerasDTensorPromotionMode, a TorchDispatchMode that automatically promotes plain tensors to replicated DTensors when they interact with DTensors. This prevents "mixed tensor" errors during distributed execution.
   - Automatic Promotion Activation: convert_to_tensor now automatically enters the global KerasDTensorPromotionMode when it encounters a DTensor, ensuring seamless integration with standard Keras ops.
   - Updated _direct_assign to handle DTensor targets, ensuring that assigned values are correctly distributed before copying.
   - Updated convert_to_numpy to handle DTensors by first redistributing them to a replicated state and then converting the local data to NumPy.

## Description
<!-- Describe your changes here -->

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
