### PR TITLE
Fix rsqrt overflow for small float64 values using pow

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -288,7 +288,7 @@ def istft(
 
 def rsqrt(x):
     x = convert_to_tensor(x)
-    return jax.lax.rsqrt(x)
+    return jax.lax.pow(x, -0.5)
 
 
 def erf(x):

--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -288,7 +288,7 @@ def istft(
 
 def rsqrt(x):
     x = convert_to_tensor(x)
-    return jax.lax.pow(x, -0.5)
+    return jax.lax.pow(x, jax.lax.full(x.shape, -0.5, dtype=x.dtype))
 
 
 def erf(x):

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -317,7 +317,7 @@ def istft(
 
 def rsqrt(x):
     dtype = dtypes.result_type(x.dtype)
-    return (1.0 / np.sqrt(x)).astype(dtype)
+    return np.power(x, -0.5).astype(dtype)
 
 
 def erf(x):

--- a/keras/src/backend/openvino/math.py
+++ b/keras/src/backend/openvino/math.py
@@ -923,9 +923,7 @@ def istft(
 
 def rsqrt(x):
     x = get_ov_output(x)
-    const_one = ov_opset.constant(1, x.get_element_type()).output(0)
-    sqrt = ov_opset.sqrt(x).output(0)
-    return OpenVINOKerasTensor(ov_opset.divide(const_one, sqrt).output(0))
+    return OpenVINOKerasTensor(ov_opset.power(x, ov_opset.constant(-0.5, x.get_element_type())).output(0))
 
 
 def erf(x):

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -301,7 +301,7 @@ def istft(
 
 def rsqrt(x):
     x = convert_to_tensor(x)
-    return tf.math.rsqrt(x)
+    return tf.math.pow(x, -0.5)
 
 
 def erf(x):

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -410,7 +410,7 @@ def istft(
 
 def rsqrt(x):
     x = convert_to_tensor(x)
-    return torch.rsqrt(x)
+    return torch.pow(x, -0.5)
 
 
 def erf(x):

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -1171,7 +1171,7 @@ def rsqrt(x):
     """
     if any_symbolic_tensors((x,)):
         return Rsqrt().symbolic_call(x)
-    return backend.math.pow(x, -0.5)
+    return backend.math.rsqrt(x)
 
 
 class Erf(Operation):

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -1171,7 +1171,7 @@ def rsqrt(x):
     """
     if any_symbolic_tensors((x,)):
         return Rsqrt().symbolic_call(x)
-    return backend.math.rsqrt(x)
+    return backend.math.pow(x, -0.5)
 
 
 class Erf(Operation):


### PR DESCRIPTION
Fixes #23401

Changed `backend.math.rsqrt` to `backend.math.pow(x, -0.5)` to prevent overflow for very small float64 values like 5e-324.