### PR TITLE
Fix test_cross and numpy backend cross() for NumPy>=2.5.0

### DIFF
--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -551,14 +551,41 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     dtype = dtypes.result_type(x1.dtype, x2.dtype)
     x1 = x1.astype(dtype)
     x2 = x2.astype(dtype)
-    return np.cross(
-        x1,
-        x2,
-        axisa=axisa,
-        axisb=axisb,
-        axisc=axisc,
-        axis=axis,
-    )
+
+    if axis is not None:
+        axisa = axis
+        axisb = axis
+        axisc = axis
+    x1 = np.moveaxis(x1, axisa, -1)
+    x2 = np.moveaxis(x2, axisb, -1)
+
+    x1_dim = x1.shape[-1]
+    x2_dim = x2.shape[-1]
+    if x1_dim not in (2, 3) or x2_dim not in (2, 3):
+        raise ValueError(
+            "Both input arrays must be (arrays of) 2 or 3-dimensional "
+            f"vectors, but they are {x1_dim} and {x2_dim} dimensional "
+            "instead."
+        )
+
+    # NumPy>=2.5 removed support for 2-dimensional vectors in `np.cross`
+    # (https://numpy.org/doc/stable/release/2.5.0-notes.html), so pad them
+    # to 3 dimensions ourselves (with an implicit zero z-component) before
+    # delegating the cross product of the resulting 3-dimensional vectors
+    # to `np.cross`.
+    def maybe_pad_zero(x, size_of_last_dim):
+        if size_of_last_dim == 2:
+            return np.pad(x, [(0, 0)] * (x.ndim - 1) + [(0, 1)])
+        return x
+
+    x1 = maybe_pad_zero(x1, x1_dim)
+    x2 = maybe_pad_zero(x2, x2_dim)
+
+    c = np.cross(x1, x2)
+
+    if x1_dim == 2 and x2_dim == 2:
+        return c[..., 2]
+    return np.moveaxis(c, -1, axisc)
 
 
 def cumprod(x, axis=None, dtype=None):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -573,13 +573,13 @@ def cross(x1, x2, axisa=-1, axisb=-1, axisc=-1, axis=None):
     # to 3 dimensions ourselves (with an implicit zero z-component) before
     # delegating the cross product of the resulting 3-dimensional vectors
     # to `np.cross`.
-    def maybe_pad_zero(x, size_of_last_dim):
-        if size_of_last_dim == 2:
+    def _pad_2d_vector_to_3d(x):
+        if x.shape[-1] == 2:
             return np.pad(x, [(0, 0)] * (x.ndim - 1) + [(0, 1)])
         return x
 
-    x1 = maybe_pad_zero(x1, x1_dim)
-    x2 = maybe_pad_zero(x2, x2_dim)
+    x1 = _pad_2d_vector_to_3d(x1)
+    x2 = _pad_2d_vector_to_3d(x2)
 
     c = np.cross(x1, x2)
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3717,9 +3717,7 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
             # `a` holds 3D vectors, `b` holds 2D vectors (implicit z=0).
             a0, a1, a2 = a[..., 0], a[..., 1], a[..., 2]
             b0, b1 = b[..., 0], b[..., 1]
-            return np.stack(
-                [-a2 * b1, a2 * b0, a0 * b1 - a1 * b0], axis=-1
-            )
+            return np.stack([-a2 * b1, a2 * b0, a0 * b1 - a1 * b0], axis=-1)
 
         def cross_2d_2d(a, b):
             a0, a1 = a[..., 0], a[..., 1]

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -3713,6 +3713,19 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
     # right_shift is same as bitwise_right_shift
 
     def test_cross(self):
+        def cross_3d_2d(a, b):
+            # `a` holds 3D vectors, `b` holds 2D vectors (implicit z=0).
+            a0, a1, a2 = a[..., 0], a[..., 1], a[..., 2]
+            b0, b1 = b[..., 0], b[..., 1]
+            return np.stack(
+                [-a2 * b1, a2 * b0, a0 * b1 - a1 * b0], axis=-1
+            )
+
+        def cross_2d_2d(a, b):
+            a0, a1 = a[..., 0], a[..., 1]
+            b0, b1 = b[..., 0], b[..., 1]
+            return a0 * b1 - a1 * b0
+
         x1 = np.ones([2, 1, 4, 3])
         x2 = np.ones([2, 1, 4, 2])
         y1 = np.ones([2, 1, 4, 3])
@@ -3723,16 +3736,16 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         if backend.backend() != "torch":
             # API divergence between `torch.cross` and `np.cross`
             # `torch.cross` only allows dim 3, `np.cross` allows dim 2 or 3
-            self.assertAllClose(knp.cross(x1, y3), np.cross(x1, y3))
-            self.assertAllClose(knp.cross(x2, y3), np.cross(x2, y3))
+            self.assertAllClose(knp.cross(x1, y3), cross_3d_2d(x1, y3))
+            self.assertAllClose(knp.cross(x2, y3), cross_2d_2d(x2, y3))
 
         self.assertAllClose(knp.Cross()(x1, y1), np.cross(x1, y1))
         self.assertAllClose(knp.Cross()(x1, y2), np.cross(x1, y2))
         if backend.backend() != "torch":
             # API divergence between `torch.cross` and `np.cross`
             # `torch.cross` only allows dim 3, `np.cross` allows dim 2 or 3
-            self.assertAllClose(knp.Cross()(x1, y3), np.cross(x1, y3))
-            self.assertAllClose(knp.Cross()(x2, y3), np.cross(x2, y3))
+            self.assertAllClose(knp.Cross()(x1, y3), cross_3d_2d(x1, y3))
+            self.assertAllClose(knp.Cross()(x2, y3), cross_2d_2d(x2, y3))
 
         # Test axis is not None
         self.assertAllClose(


### PR DESCRIPTION
## Description
NumPy's [2.5.0 release notes](https://numpy.org/doc/stable/release/2.5.0-notes.html) confirm 2D-vector support in np.cross() (deprecated since 2.0) is now fully removed:
numpy.cross no longer supports 2-dimensional vectors. (Deprecated since 2.0) ([gh-30461](https://github.com/numpy/numpy/pull/30461))

This breaks test_cross, which uses np.cross() as its oracle for 2D inputs. This PR fixes it by computing the expected 2D cross product directly instead.

It also breaks the numpy backend's cross() itsel, which delegated straight to np.cross(). This PR fixes it by padding 2D vectors to 3D (implicit zero z-component) before computing, matching the approach the tensorflow backend already uses. Other backends (tensorflow, torch, openvino, jax) are unaffected.

It does not fail in CI yet, probably because CI here uses 2.4.6 version, but it fails on keras-openvino, which uses 2.5.1.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [X] I am a human, and not a bot.
- [X] I will be responsible for responding to review comments in a timely manner.
- [X] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
