### PR TITLE
Fix RematScope(mode=None) truthy bug in get_current_remat_mode

### DIFF
--- a/keras/src/backend/common/remat.py
+++ b/keras/src/backend/common/remat.py
@@ -127,6 +127,8 @@ def get_current_remat_mode():
     if not remat_scope_stack:
         return None
     active_scope = remat_scope_stack[-1]
+    if active_scope.mode is None:
+        return None
     return RematMode(
         active_scope.mode,
         active_scope.output_size_threshold,

--- a/keras/src/backend/common/remat_test.py
+++ b/keras/src/backend/common/remat_test.py
@@ -26,6 +26,11 @@ class TestRematScope(testing.TestCase):
             get_current_remat_mode()
         )  # Mode is restored to None after scope ends
 
+        with RematScope(mode=None):
+            self.assertIsNone(
+                get_current_remat_mode()
+            )  # Mode is None when explicitly disabled
+
     def test_remat_scope_nested(self):
         """Test nested scopes with different rematerialization modes."""
         with RematScope(mode="full"):


### PR DESCRIPTION
### Summary of Changes

Fixes an issue where `RematScope(mode=None)` was incorrectly evaluated as truthy when calling `get_current_remat_mode()`.

#### Root Cause
`RematScope` accepts `mode=None` to explicitly disable rematerialization within a context block. Previously, `get_current_remat_mode()` returned a `RematMode` namedtuple (`RematMode(mode=None, ...)`), which evaluates to `True` in boolean context checks (`if get_current_remat_mode():`). Consequently, downstream code treated rematerialization as enabled even when `mode=None` was specified.

#### Solution
- Updated `get_current_remat_mode()` in `keras/src/backend/common/remat.py` to return `None` when `active_scope.mode is None`.
- Added a test assertion in `TestRematScope.test_remat_scope_activation` in `keras/src/backend/common/remat_test.py` verifying that `get_current_remat_mode()` returns `None` inside `with RematScope(mode=None):`.

### Testing
- Ran all tests in `keras/src/backend/common/remat_test.py` (6/6 passed).

### Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
