### PR TITLE
Extract _unscale_grads helper in LossScaleOptimizer

### DIFF
--- a/keras/src/optimizers/loss_scale_optimizer.py
+++ b/keras/src/optimizers/loss_scale_optimizer.py
@@ -141,6 +141,17 @@ class LossScaleOptimizer(optimizer.Optimizer):
             ),
         )
 
+    def _unscale_grads(self, grads, variables):
+        # Divide gradients by the loss scale, keeping any gradient that
+        # overwrites its variable untouched.
+        scale = self.dynamic_scale
+        return [
+            g
+            if g is None or self._overwrite_variable_with_gradient(v)
+            else ops.divide(g, scale)
+            for g, v in zip(grads, variables)
+        ]
+
     def _stateless_handle_finite_grads(
         self, optimizer_variables, grads, trainable_variables
     ):
@@ -166,14 +177,9 @@ class LossScaleOptimizer(optimizer.Optimizer):
                 increment,
             )
 
-            # Unscale gradients.
-            scale = self.dynamic_scale
-            unscaled_grads = [
-                g
-                if g is None or self._overwrite_variable_with_gradient(v)
-                else ops.divide(g, scale)
-                for g, v in zip(grads, self._trainable_variables)
-            ]
+            unscaled_grads = self._unscale_grads(
+                grads, self._trainable_variables
+            )
             (
                 new_trainable_variables,
                 new_inner_variables,
@@ -211,15 +217,8 @@ class LossScaleOptimizer(optimizer.Optimizer):
             self._common_apply(grads, trainable_variables)
 
     def _stateful_handle_finite_grads(self, grads, trainable_variables):
-        scale = self.dynamic_scale
-        # Unscale gradients.
         tvs = trainable_variables or self._trainable_variables
-        unscaled_grads = [
-            g
-            if g is None or self._overwrite_variable_with_gradient(v)
-            else ops.divide(g, scale)
-            for g, v in zip(grads, tvs)
-        ]
+        unscaled_grads = self._unscale_grads(grads, tvs)
         self.inner_optimizer.apply(
             unscaled_grads, trainable_variables=trainable_variables
         )

--- a/keras/src/optimizers/loss_scale_optimizer.py
+++ b/keras/src/optimizers/loss_scale_optimizer.py
@@ -144,11 +144,10 @@ class LossScaleOptimizer(optimizer.Optimizer):
     def _unscale_grads(self, grads, variables):
         # Divide gradients by the loss scale, keeping any gradient that
         # overwrites its variable untouched.
-        scale = self.dynamic_scale
         return [
             g
             if g is None or self._overwrite_variable_with_gradient(v)
-            else ops.divide(g, scale)
+            else ops.divide(g, self.dynamic_scale)
             for g, v in zip(grads, variables)
         ]
 


### PR DESCRIPTION
## Description

`LossScaleOptimizer` unscales gradients in two places, `_stateless_handle_finite_grads` and `_stateful_handle_finite_grads`, and both use the same list comprehension to divide by the loss scale while leaving untouched any gradient that overwrites its variable. This pulls that block into a `_unscale_grads` helper so the rule lives in one place and the two paths cannot drift apart.

There is no behavior change, the two comprehensions were already identical. The helper reads `self.dynamic_scale` itself rather than taking it as an argument, since both call sites were computing that local only to pass it straight through, and in the stateless path the read still happens inside the same `StatelessScope` as before.

Splitting this out of #23076, where @hertschuh noted that the refactor is good but unrelated to MLX and asked for it as a separate PR against master.

Tested with `keras/src/optimizers/loss_scale_optimizer_test.py` on the jax, tensorflow and torch backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
