### PR TITLE
Enabled Async Next Batch Fetch in JAX backend with Distribution

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -1091,13 +1091,16 @@ class JAXEpochIterator(EpochIterator):
     def _get_iterator(self):
         distribution = distribution_lib.distribution()
         if distribution is not None:
-            return self._get_distributed_iterator(distribution)
+            iterator = self._get_distributed_iterator(distribution)
         else:
-            iterator = self.data_adapter.get_jax_iterator()
-            # No benefit from look-ahead on CPU — avoid the overhead
-            if jax.default_backend() == "cpu":
-                return iterator
-            return self._one_batch_ahead_iterator(iterator)
+            iterator = (
+                _distribute_data(batch)
+                for batch in self.data_adapter.get_jax_iterator()
+            )
+        # No benefit from look-ahead on CPU — avoid the overhead
+        if jax.default_backend() == "cpu":
+            return iterator
+        return self._one_batch_ahead_iterator(iterator)
 
     def _get_distributed_iterator(self, distribution):
         """Lazily compute layouts to reduce host to device transfer latency."""
@@ -1113,17 +1116,22 @@ class JAXEpochIterator(EpochIterator):
                 layouts = tree.map_structure(get_layout, data)
             yield _distribute_data(data, layouts)
 
-    def _one_batch_ahead_iterator(self, numpy_iterator):
+    def _one_batch_ahead_iterator(self, iterator):
         """Initiate transfers to the device one batch ahead.
 
         This utility takes an iterator and returns a new iterator which
         initiates the transfer to device one step ahead. This can improve the
         performance of training loops significantly by overlapping compute and
         data transfer.
+
+        Args:
+            iterator: Source data iterator yielding batches.
+
+        Yields:
+            Batches one step ahead of the source iterator.
         """
         next_batch = None
-        for batch in numpy_iterator:
-            batch = _distribute_data(batch)
+        for batch in iterator:
             if next_batch is None:
                 next_batch = batch
             else:


### PR DESCRIPTION
## Description
### Overview / Summary

This PR enables asynchronous one-batch-ahead device prefetching in `JAXEpochIterator` during distributed training (`keras.distribution.DataParallel` / `keras.distribution.ModelParallel`).

### Problem Statement

Previously in `JAXEpochIterator._get_iterator()`:
1. When a distribution strategy was active (`distribution is not None`), `_get_iterator()` returned `_get_distributed_iterator(distribution)` directly without wrapping it in `_one_batch_ahead_iterator()`.
2. As a result, distributed training on accelerators (TPUs and GPUs) suffered from noticeable step-to-step host transfer stalls: the accelerator had to wait synchronously at every step boundary for host-side data preparation, sharding, and device transfer (`_distribute_data`).
3. Furthermore, `_one_batch_ahead_iterator` was hardcoded to call `_distribute_data` inside its internal loop, assuming it only ever received a raw NumPy iterator.

### Proposed Changes

1. **Enable Look-Ahead Prefetching in Distributed Mode**: 
   - `JAXEpochIterator._get_iterator()` now passes both distributed and non-distributed iterators through `self._one_batch_ahead_iterator(iterator)` on non-CPU backends (preserving the CPU bypass).
2. **Decouple Data Placement from Look-Ahead Buffering**: 
   - Data distribution/placement is performed at iterator creation time (`_get_distributed_iterator` or `_distribute_data(batch) for batch in ...`).
   - `_one_batch_ahead_iterator` now takes any generic device-bound `iterator`, buffering the next batch to trigger asynchronous host-to-device transfers in the background while the previous batch executes on device.

### Performance Impact

- **Compute/Transfer Overlap**: Overlaps host-to-device data transfers (such as layout computations and sharded device placements) with accelerator compute.
- **Latency Reduction**: Eliminates the inter-step data staging bubble during distributed training on multi-device and multi-host TPU/GPU topologies.

### Testing & Verification

- Tested with `pytest keras/src/backend/jax/trainer_test.py` with multi-device simulation (`XLA_FLAGS="--xla_force_host_platform_device_count=8"`).
- All 8 unit tests in `trainer_test.py` (`DataParallel`, `ModelParallel`, `test_train_on_batch`, etc.) passed.


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
