### PR TITLE
Add fallback implementation for the cbrt op

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1983,7 +1983,7 @@ def broadcast_to(x, shape):
 
 class Cbrt(Operation):
     def call(self, x):
-        return backend.numpy.cbrt(x)
+        return _cbrt(x)
 
     def compute_output_spec(self, x):
         dtype = backend.standardize_dtype(x.dtype)
@@ -2018,7 +2018,23 @@ def cbrt(x):
     """
     if any_symbolic_tensors((x,)):
         return Cbrt().symbolic_call(x)
-    return backend.numpy.cbrt(x)
+    return _cbrt(x)
+
+
+def _cbrt(x):
+    if hasattr(backend.numpy, "cbrt"):
+        return backend.numpy.cbrt(x)
+    x = backend.convert_to_tensor(x)
+    dtype = backend.standardize_dtype(x.dtype)
+    if dtype in ["bool", "int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+        dtype = backend.floatx()
+    elif dtype in ["int64", "uint64"]:
+        dtype = "float64"
+    x = backend.cast(x, dtype)
+    y = backend.numpy.sign(x) * backend.numpy.power(
+        backend.numpy.abs(x), 1.0 / 3.0
+    )
+    return backend.cast(y, dtype)
 
 
 class Ceil(Operation):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2028,11 +2028,11 @@ def _cbrt(x):
     dtype = backend.standardize_dtype(x.dtype)
     if dtype in ["bool", "int8", "int16", "int32", "uint8", "uint16", "uint32"]:
         dtype = backend.floatx()
-    elif dtype in ["int64", "uint64"]:
+    elif dtype == "int64":
         dtype = "float64"
     x = backend.cast(x, dtype)
     y = backend.numpy.sign(x) * backend.numpy.power(
-        backend.numpy.abs(x), 1.0 / 3.0
+        backend.numpy.absolute(x), 1.0 / 3.0
     )
     return backend.cast(y, dtype)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -8,6 +8,7 @@ from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.backend import KerasTensor
 from keras.src.backend import any_symbolic_tensors
+from keras.src.backend import config
 from keras.src.backend.common import dtypes
 from keras.src.backend.common.backend_utils import canonicalize_axes
 from keras.src.backend.common.backend_utils import canonicalize_axis
@@ -2022,7 +2023,9 @@ def cbrt(x):
 
 
 def _cbrt(x):
-    if hasattr(backend.numpy, "cbrt"):
+    if not config._use_backend_agnostic_ops() and hasattr(
+        backend.numpy, "cbrt"
+    ):
         return backend.numpy.cbrt(x)
     x = backend.convert_to_tensor(x)
     dtype = backend.standardize_dtype(x.dtype)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2029,7 +2029,7 @@ def _cbrt(x):
         return backend.numpy.cbrt(x)
     x = backend.convert_to_tensor(x)
     dtype = backend.standardize_dtype(x.dtype)
-    if dtype in ["bool", "int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+    if dtype in ("bool", "int8", "int16", "int32", "uint8", "uint16", "uint32"):
         dtype = backend.floatx()
     elif dtype == "int64":
         dtype = "float64"


### PR DESCRIPTION
## Description
This PR adds a backend-agnostic implementation for the `cbrt` op that can be used as a fallback for backends that don't implement this op.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ x] I am a human, and not a bot.
- [ x] I will be responsible for responding to review comments in a timely manner.
- [ x] I will work with the maintainers to push this PR forward until submission.
