### PR TITLE
Flag-guard the backend-agnostic ops usage

### DIFF
--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -22,6 +22,10 @@ _NNX_ENABLED = False
 _MAX_EPOCHS = None
 _MAX_STEPS_PER_EPOCH = None
 
+# This flag forces Keras to use backend-agnostic ops even if there is
+# backend-specific implementation available.
+_USE_BACKEND_AGNOSTIC_OPS = False
+
 
 @keras_export(["keras.config.floatx", "keras.backend.floatx"])
 def floatx():
@@ -461,3 +465,18 @@ if "KERAS_NNX_ENABLED" in os.environ:
         _NNX_ENABLED = False
 
 set_nnx_enabled(_NNX_ENABLED)
+
+if "KERAS_USE_BACKEND_AGNOSTIC_OPS" in os.environ:
+    env_val = os.environ["KERAS_USE_BACKEND_AGNOSTIC_OPS"].lower()
+    _USE_BACKEND_AGNOSTIC_OPS = env_val in ("true", "1", "yes")
+
+
+def _use_backend_agnostic_ops():
+    """Returns the flag that checks if backend-agnostic ops are forced."""
+    return _USE_BACKEND_AGNOSTIC_OPS
+
+
+def _set_use_backend_agnostic_ops(value):
+    """Internal helper to force backend-agnostic ops for testing/benchmarks."""
+    global _USE_BACKEND_AGNOSTIC_OPS
+    _USE_BACKEND_AGNOSTIC_OPS = bool(value)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -381,7 +381,9 @@ def squareplus(x, b=4):
 
 
 def _squareplus(x, b):
-    if hasattr(backend.nn, "squareplus"):
+    if not config._use_backend_agnostic_ops() and hasattr(
+        backend.nn, "squareplus"
+    ):
         return backend.nn.squareplus(x, b)
     x = backend.convert_to_tensor(x)
     b = backend.convert_to_tensor(b, dtype=x.dtype)


### PR DESCRIPTION
## Description
This PR flag-guards the backend-agnostic ops usage if there is backend-specific implementation. This flag allows us to easily switch back and forth between forcing the backend-agnostic ops and allowing the backend specific ops usage which makes benchmarking and testing easier. The flag is added to the only backend-agnostic implementation that we have (`squareplus`).

The default value is false so this PR is no-op for existing code.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ x] I am a human, and not a bot.
- [ x] I will be responsible for responding to review comments in a timely manner.
- [ x] I will work with the maintainers to push this PR forward until submission.

