### PR TITLE
Fix symbolic output specs that disagree with eager execution

### DIFF
--- a/keras/src/ops/linalg.py
+++ b/keras/src/ops/linalg.py
@@ -244,7 +244,8 @@ class LuFactor(Operation):
         k = min(m, n)
         return (
             KerasTensor(batch_shape + (m, n), x.dtype),
-            KerasTensor(batch_shape + (k,), x.dtype),
+            # The pivots are indices, not values drawn from `x`.
+            KerasTensor(batch_shape + (k,), "int32"),
         )
 
 

--- a/keras/src/ops/linalg_test.py
+++ b/keras/src/ops/linalg_test.py
@@ -85,6 +85,8 @@ class LinalgOpsDynamicShapeTest(testing.TestCase):
         lu, p = linalg.lu_factor(x)
         self.assertEqual(lu.shape, (None, 2, 3))
         self.assertEqual(p.shape, (None, 2))
+        # The pivots are indices, so they are integers, not floats.
+        self.assertEqual(p.dtype, "int32")
 
     def test_matrix_rank(self):
         x = KerasTensor([None, 4, 5])
@@ -305,6 +307,8 @@ class LinalgOpsStaticShapeTest(testing.TestCase):
         lu, p = linalg.lu_factor(x)
         self.assertEqual(lu.shape, (10, 2, 3))
         self.assertEqual(p.shape, (10, 2))
+        # The pivots are indices, so they are integers, not floats.
+        self.assertEqual(p.dtype, "int32")
 
     def test_matrix_rank(self):
         x = KerasTensor([4, 3, 5])
@@ -536,6 +540,14 @@ class LinalgOpsCorrectnessTest(testing.TestCase):
         lu, pivots = map(ops.convert_to_numpy, linalg.lu_factor(x))
         x_reconstructed = _reconstruct(lu, pivots, m, n)
         self.assertAllClose(x_reconstructed, x, atol=1e-5)
+
+        # The symbolic pivots dtype must match the eager one.
+        _, symbolic_pivots = linalg.LuFactor().symbolic_call(
+            KerasTensor((m, n), dtype="float32")
+        )
+        self.assertEqual(
+            backend.standardize_dtype(pivots.dtype), symbolic_pivots.dtype
+        )
 
         m, n = 4, 3
         x = np.random.rand(m, n)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -8,6 +8,7 @@ from keras.src.backend import KerasTensor
 from keras.src.backend import any_symbolic_tensors
 from keras.src.backend import config
 from keras.src.backend import standardize_data_format
+from keras.src.backend.common import dtypes
 from keras.src.backend.common.backend_utils import canonicalize_axes
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import check_conv_input_channels
@@ -3210,7 +3211,17 @@ def _layer_normalization(
 
 class Polar(Operation):
     def compute_output_spec(self, abs_, angle):
-        return KerasTensor(shape=abs_.shape)
+        dtype = backend.standardize_dtype(
+            dtypes.result_type(
+                getattr(abs_, "dtype", backend.floatx()),
+                getattr(angle, "dtype", backend.floatx()),
+            )
+        )
+        # `polar` combines two real tensors into a complex one, so the output
+        # is the complex dtype of matching width.
+        dtype = "complex128" if dtype == "float64" else "complex64"
+        output_shape = operation_utils.broadcast_shapes(abs_.shape, angle.shape)
+        return KerasTensor(shape=output_shape, dtype=dtype)
 
     def call(self, abs_, angle):
         return _polar(abs_, angle)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1404,10 +1404,15 @@ class NNOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(knn.layer_normalization(x, gamma, beta).shape, x.shape)
 
     def test_polar(self):
-        abs_ = KerasTensor([1, 2])
+        abs_ = KerasTensor([3, 4])
         angle = KerasTensor([3, 4])
         out = knn.polar(abs_, angle)
         self.assertEqual(out.shape, abs_.shape)
+        self.assertEqual(out.dtype, "complex64")
+
+        # `polar` broadcasts its two inputs against each other.
+        out = knn.polar(KerasTensor([2, 1]), KerasTensor([1, 3]))
+        self.assertEqual(out.shape, (2, 3))
 
 
 class NNOpsCorrectnessTest(testing.TestCase):
@@ -1676,6 +1681,14 @@ class NNOpsCorrectnessTest(testing.TestCase):
         out = knn.polar(abs_, angle)
         self.assertAllClose(
             out, [-0.41614684 + 0.9092974j, -1.979985 + 0.28224j], atol=1e-3
+        )
+        # The symbolic dtype must match the eager one, which is complex.
+        symbolic_out = knn.Polar().symbolic_call(
+            KerasTensor((2,), dtype="float32"),
+            KerasTensor((2,), dtype="float32"),
+        )
+        self.assertEqual(
+            backend.standardize_dtype(out.dtype), symbolic_out.dtype
         )
 
     def test_sparsemax(self):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9394,7 +9394,15 @@ class Corrcoef(Operation):
             dtype = "float64"
         else:
             dtype = dtypes.result_type(dtype, float)
-        return KerasTensor(x.shape, dtype=dtype)
+        if len(x.shape) > 2:
+            raise ValueError(
+                "Input tensor must have at most 2 dimensions. "
+                f"Received: x.shape={x.shape}"
+            )
+        # The correlation matrix of the `N` variables of a 2D input of shape
+        # `(N, D)` has shape `(N, N)`. A 1D input yields a scalar.
+        output_shape = (x.shape[0], x.shape[0]) if len(x.shape) == 2 else ()
+        return KerasTensor(output_shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.corrcoef", "keras.ops.numpy.corrcoef"])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1681,8 +1681,12 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.copy(x).shape, (None, 3))
 
     def test_corrcoef(self):
+        # `corrcoef` correlates the rows of a 2D input, so the output is
+        # square in the number of rows regardless of the number of columns.
         x = KerasTensor((3, None))
-        self.assertEqual(knp.corrcoef(x).shape, (3, None))
+        self.assertEqual(knp.corrcoef(x).shape, (3, 3))
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.corrcoef(x).shape, (None, None))
 
     def test_cos(self):
         x = KerasTensor((None, 3))
@@ -5836,6 +5840,18 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.corrcoef(x), np.corrcoef(x))
         self.assertAllClose(knp.Corrcoef()(x), np.corrcoef(x))
+
+        # The symbolic shape must match the eager shape for a non-square
+        # input, where the number of variables differs from the number of
+        # observations.
+        x = np.random.uniform(size=(3, 5)).astype("float32")
+        self.assertEqual(knp.corrcoef(x).shape, (3, 3))
+        self.assertEqual(
+            knp.Corrcoef().symbolic_call(KerasTensor((3, 5))).shape, (3, 3)
+        )
+
+        with self.assertRaises(ValueError):
+            knp.Corrcoef().symbolic_call(KerasTensor((2, 3, 5)))
 
     def test_cos(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])


### PR DESCRIPTION
## Description

Three ops declare an output spec that does not match what they actually return, so a
functional model built with them reports a different shape or dtype than it produces at
run time. Each mismatch reproduces on all four backends.

### 1. `ops.corrcoef` — wrong output shape

`Corrcoef.compute_output_spec()` returned `x.shape`. `corrcoef` correlates the **rows** of
a 2D input, so an input of shape `(N, D)` produces the `(N, N)` correlation matrix:

```python
import numpy as np
from keras import ops
from keras.src.backend import KerasTensor

x = np.random.uniform(size=(3, 5)).astype("float32")
ops.corrcoef(x).shape                    # (3, 3)
ops.corrcoef(KerasTensor((3, 5))).shape  # (3, 5)   <- wrong
```

The shape was only correct when the input happened to be square. The spec also silently
accepted 3D+ inputs, which every backend rejects eagerly (`m has more than 2 dimensions`),
so it now raises a `ValueError` symbolically too. A 1D input yields a scalar, matching
`np.corrcoef`.

### 2. `ops.polar` — missing dtype, and no broadcasting

`Polar.compute_output_spec()` was `return KerasTensor(shape=abs_.shape)`, which is wrong
twice over:

```python
a = np.random.uniform(size=(2, 3)).astype("float32")
ops.polar(a, a).dtype                                      # complex64
ops.polar(KerasTensor((2, 3)), KerasTensor((2, 3))).dtype  # float32   <- wrong

ops.polar(KerasTensor((2, 1)), KerasTensor((1, 3))).shape  # (2, 1)    <- wrong
# eager broadcasts the same inputs to (2, 3)
```

- No `dtype` was passed, so it defaulted to `floatx()`, but `polar` builds a complex
  tensor via `_get_complex_tensor_from_tuple`.
- It returned `abs_.shape`, but `_polar` computes `abs_ * cos(angle)`, which broadcasts.

Fixed to promote the two input dtypes, map the result to the complex dtype of matching
width, and broadcast the shapes. This follows the existing precedent in
`ViewAsComplex.compute_output_spec` (`keras/src/ops/math.py`), which also returns a
complex dtype.

### 3. `ops.lu_factor` — pivots typed as float

`LuFactor.compute_output_spec()` declared the pivots as `x.dtype`. Pivots are row indices,
and every backend returns `int32`:

```python
x = np.random.uniform(size=(3, 3)).astype("float32")
ops.lu_factor(x)[1].dtype                    # int32
ops.lu_factor(KerasTensor((3, 3)))[1].dtype  # float32   <- wrong
```

## Tests

Two existing tests asserted the buggy behavior and are corrected rather than added to:

- `NumpyOneInputOpsDynamicShapeTest::test_corrcoef` asserted `(3, None) -> (3, None)`; it
  now asserts `(3, 3)`, plus a `(None, 3) -> (None, None)` case.
- `NNOpsStaticShapeTest::test_polar` passed `abs_=(1, 2)` and `angle=(3, 4)` — shapes that
  are not broadcast-compatible, i.e. an input eager execution rejects — and asserted the
  output was `abs_.shape`. It now uses compatible shapes and additionally checks the dtype
  and a genuine broadcasting case.

New assertions:

- `NumpyOneInputOpsCorrectnessTest::test_corrcoef` — eager and symbolic shapes agree for a
  non-square input; 3D input raises.
- `NNOpsCorrectnessTest::test_polar_corectness` — symbolic dtype equals the eager dtype.
- `LinalgOpsDynamicShapeTest::test_lu_factor` and `LinalgOpsStaticShapeTest::test_lu_factor`
  — pivots are `int32`.
- `LinalgOpsCorrectnessTest::test_lu_factor` — symbolic pivots dtype equals the eager one.

After the fix, eager and symbolic agree on every backend:

```
             numpy / jax / tensorflow / torch
corrcoef     eager (3, 3)    | symbolic (3, 3)
polar        eager complex64 | symbolic complex64
lu_factor    eager int32     | symbolic int32
```

Test runs: `keras/src/ops/nn_test.py` and `keras/src/ops/linalg_test.py` fully green on
numpy, jax, tensorflow and torch (634 / 645 / 648 / 634 passed). Full
`keras/src/ops/numpy_test.py` green on numpy (5508 passed) and tensorflow (5462 passed);
`-k corrcoef` green on all four.

## Notes for reviewers

Two adjacent issues I deliberately left out of this PR:

1. **`NNOpsDtypeTest::test_polar` is a copy-paste of the `hard_tanh` dtype test** — its
   body calls `jnn.hard_tanh` / `knn.hard_tanh` / `knn.HardTanh()`, so `polar` currently
   has no dtype coverage despite the test name. I did not repoint it at `polar`, because
   it is parameterized over `FLOAT_DTYPES` and eager `polar` raises for `float16` and
   `bfloat16` on the jax, tensorflow and torch backends. Fixing it means either
   restricting the test to `float32` or adding half-precision support to `polar`. Happy to
   do either in a follow-up — let me know which you prefer.
2. **`polar` returns `complex128` for `float64` inputs on torch but `complex64` on
   numpy/jax**, because those backends downcast `float64` to `floatx()` first. That is the
   broader inconsistency already being addressed in #23225, so the spec here maps
   `float64 -> complex128` and everything else to `complex64`.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.

## AI assistance disclosure

Per the AI-Assisted Contribution Policy: I used an AI coding assistant to help locate these
spec mismatches and to draft the patches, the tests and the test runs reported above. I
have reviewed the change, I understand the mechanism behind each of the three fixes, and I
take responsibility for the code submitted here. Review responses will be written by me.
