### PR TITLE
Fix sparsemax computing the wrong threshold

### DIFF
--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -999,6 +999,15 @@ class ActivationsTest(testing.TestCase):
             activations.sparsemax(x_4d, axis=-3), expected_result
         )
 
+        # The checks above all use widely spaced logits, for which the support
+        # holds a single element and the output is one-hot. With closely
+        # spaced logits several elements are in the support: the sorted logits
+        # `[1, 0.5, 0]` have cumulative sums `[1, 1.5, 1.5]` and a support of
+        # the first two entries, so `tau = (1.5 - 1) / 2 = 0.25`.
+        x = np.array([[0.0, 0.5, 1.0]], dtype="float32")
+        expected_result = np.array([[0.0, 0.25, 0.75]], dtype="float32")
+        self.assertAllClose(activations.sparsemax(x), expected_result)
+
     def test_get_method(self):
         obj = activations.get("relu")
         self.assertEqual(obj, activations.relu)

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -178,8 +178,11 @@ def sparsemax(x, axis=-1):
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
     k = jnp.sum(support, axis=axis, keepdims=True)
-    logits_cumsum_safe = jnp.where(support, logits_cumsum, 0.0)
-    tau = (jnp.sum(logits_cumsum_safe, axis=axis, keepdims=True) - 1) / k
+    # `tau` is derived from the k-th cumulative sum, which is the sum of the
+    # `k` largest logits. `support` is a prefix mask, so masking the sorted
+    # logits gives that sum directly.
+    logits_masked = jnp.where(support, logits_sorted, 0.0)
+    tau = (jnp.sum(logits_masked, axis=axis, keepdims=True) - 1) / k
     output = jnp.maximum(logits - tau, 0.0)
     return output
 

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -220,21 +220,25 @@ def log_softmax(x, axis=-1):
 def sparsemax(x, axis=-1):
     # Sort logits along the specified axis in descending order
     logits = convert_to_tensor(x)
-    logits_sorted = -1.0 * np.sort(-1.0 * logits, axis=axis)
+    # Python floats promote `bfloat16` and NumPy promotes `float32 / int64` to
+    # `float64`, so the constants and the integer counts are materialized in
+    # the dtype of `logits` to keep the computation in the input dtype.
+    zero = np.array(0.0, logits.dtype)
+    logits_sorted = -np.sort(-logits, axis=axis)
     logits_cumsum = np.cumsum(logits_sorted, axis=axis)
     r = np.arange(1, logits.shape[axis] + 1)
     r_shape = [1] * logits.ndim
     r_shape[axis] = -1  # Broadcast to match the target axis
-    r = r.reshape(r_shape)
-    support = logits_sorted - (logits_cumsum - 1) / r > 0
+    r = r.reshape(r_shape).astype(logits.dtype)
+    support = logits_sorted - (logits_cumsum - 1) / r > zero
     # Find the threshold
-    k = np.sum(support, axis=axis, keepdims=True)
+    k = np.sum(support, axis=axis, keepdims=True).astype(logits.dtype)
     # `tau` is derived from the k-th cumulative sum, which is the sum of the
     # `k` largest logits. `support` is a prefix mask, so masking the sorted
     # logits gives that sum directly.
-    logits_masked = np.where(support, logits_sorted, 0.0)
+    logits_masked = np.where(support, logits_sorted, zero)
     tau = (np.sum(logits_masked, axis=axis, keepdims=True) - 1) / k
-    output = np.maximum(logits - tau, 0.0)
+    output = np.maximum(logits - tau, zero)
     return output
 
 

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -229,8 +229,11 @@ def sparsemax(x, axis=-1):
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
     k = np.sum(support, axis=axis, keepdims=True)
-    logits_cumsum_safe = np.where(support, logits_cumsum, 0.0)
-    tau = (np.sum(logits_cumsum_safe, axis=axis, keepdims=True) - 1) / k
+    # `tau` is derived from the k-th cumulative sum, which is the sum of the
+    # `k` largest logits. `support` is a prefix mask, so masking the sorted
+    # logits gives that sum directly.
+    logits_masked = np.where(support, logits_sorted, 0.0)
+    tau = (np.sum(logits_masked, axis=axis, keepdims=True) - 1) / k
     output = np.maximum(logits - tau, 0.0)
     return output
 

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -268,14 +268,17 @@ def sparsemax(x, axis=-1):
     k = ov_opset.reduce_sum(
         ov_opset.convert(support, et).output(0), axis_1d, True
     ).output(0)
-    sum_safe = ov_opset.reduce_sum(
-        ov_opset.select(support, logits_cumsum, zero_fp).output(0),
+    # `tau` is derived from the k-th cumulative sum, which is the sum of the
+    # `k` largest logits. `support` is a prefix mask, so masking the sorted
+    # logits gives that sum directly.
+    sum_masked = ov_opset.reduce_sum(
+        ov_opset.select(support, logits_sorted, zero_fp).output(0),
         axis_1d,
         True,
     ).output(0)
-    tau = ov_opset.divide(ov_opset.subtract(sum_safe, one).output(0), k).output(
-        0
-    )
+    tau = ov_opset.divide(
+        ov_opset.subtract(sum_masked, one).output(0), k
+    ).output(0)
     return OpenVINOKerasTensor(
         ov_opset.maximum(ov_opset.subtract(x, tau).output(0), zero_fp).output(0)
     )

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -197,9 +197,12 @@ def sparsemax(x, axis=-1):
     r = tf.reshape(r, r_shape)  # Reshape for broadcasting
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
-    logits_cumsum_safe = tf.where(support, logits_cumsum, 0.0)
+    # `tau` is derived from the k-th cumulative sum, which is the sum of the
+    # `k` largest logits. `support` is a prefix mask, so masking the sorted
+    # logits gives that sum directly.
+    logits_masked = tf.where(support, logits_sorted, 0.0)
     k = tf.reduce_sum(tf.cast(support, logits.dtype), axis=axis, keepdims=True)
-    tau = (tf.reduce_sum(logits_cumsum_safe, axis=axis, keepdims=True) - 1) / k
+    tau = (tf.reduce_sum(logits_masked, axis=axis, keepdims=True) - 1) / k
     output = tf.maximum(logits - tau, 0.0)
     return output
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -210,10 +210,13 @@ def sparsemax(x, axis=-1):
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
     k = torch.sum(support, dim=axis, keepdim=True)
-    logits_cumsum_safe = torch.where(
-        support, logits_cumsum, torch.tensor(0.0, device=logits.device)
+    # `tau` is derived from the k-th cumulative sum, which is the sum of the
+    # `k` largest logits. `support` is a prefix mask, so masking the sorted
+    # logits gives that sum directly.
+    logits_masked = torch.where(
+        support, logits_sorted, torch.tensor(0.0, device=logits.device)
     )
-    tau = (torch.sum(logits_cumsum_safe, dim=axis, keepdim=True) - 1) / k
+    tau = (torch.sum(logits_masked, dim=axis, keepdim=True) - 1) / k
     output = torch.clamp(logits - tau, min=0.0)
     return output
 

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1703,6 +1703,14 @@ class NNOpsCorrectnessTest(testing.TestCase):
             self.assertAllClose(out.sum(axis=-1), np.ones(4), atol=1e-5)
             self.assertTrue((out >= 0).all())
 
+    def test_sparsemax_dtype(self):
+        # The output dtype must follow the input dtype rather than being
+        # promoted by the integer counts or the scalar constants.
+        x = np.random.uniform(size=(2, 5)).astype("float32")
+        for dtype in ("float16", "float32", "bfloat16"):
+            out = knn.sparsemax(ops.cast(x, dtype))
+            self.assertEqual(backend.standardize_dtype(out.dtype), dtype)
+
     def test_max_pool(self):
         data_format = backend.config.image_data_format()
         # Test 1D max pooling.

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1685,6 +1685,24 @@ class NNOpsCorrectnessTest(testing.TestCase):
             [0.0, 0.0, 0.0, 0.0, 1.0],
         )
 
+        # The case above is one-hot: the support holds a single element, for
+        # which the threshold happens to be correct even when it is derived
+        # from the wrong quantity. With closely spaced logits the support
+        # holds several elements. Here the sorted logits are `[1, 0.5, 0]`
+        # with cumulative sums `[1, 1.5, 1.5]`, the support is the first two
+        # entries, so `tau = (1.5 - 1) / 2 = 0.25`.
+        x = np.array([0.0, 0.5, 1.0], dtype=np.float32)
+        self.assertAllClose(knn.sparsemax(x), [0.0, 0.25, 0.75])
+
+        # `sparsemax` is a projection onto the probability simplex, so the
+        # output is non-negative and sums to 1 along `axis`.
+        rng = np.random.default_rng(1234)
+        for scale in (0.3, 1.0, 3.0):
+            x = (rng.normal(scale=scale, size=(4, 7))).astype("float32")
+            out = backend.convert_to_numpy(knn.sparsemax(x))
+            self.assertAllClose(out.sum(axis=-1), np.ones(4), atol=1e-5)
+            self.assertTrue((out >= 0).all())
+
     def test_max_pool(self):
         data_format = backend.config.image_data_format()
         # Test 1D max pooling.


### PR DESCRIPTION
Fixes #23425

## Description

`keras.ops.sparsemax` and `keras.activations.sparsemax` return incorrect values on every
backend whenever more than one element falls in the support. The output is not a
projection onto the probability simplex — it does not sum to 1.

```python
import numpy as np
from keras import ops

x = np.array([[0.0, 0.5, 1.0]], dtype="float32")
ops.sparsemax(x)
# current:  [[0.  , 0.  , 0.25]]   sum = 0.25   <- wrong, on all backends
# expected: [[0.  , 0.25, 0.75]]   sum = 1.0
```

### Cause

Sparsemax (Martins & Astudillo, 2016, Algorithm 1) defines the threshold as

```
tau(z) = (cumsum[k] - 1) / k
```

where `cumsum[k]` is the **k-th** cumulative sum of the descending-sorted logits and `k`
is the size of the support. Every backend instead sums *all* the cumulative sums that
fall in the support:

```python
logits_cumsum_safe = np.where(support, logits_cumsum, 0.0)   # masks the CUMULATIVE SUMS
tau = (np.sum(logits_cumsum_safe, axis=axis, keepdims=True) - 1) / k
```

For the example above the sorted logits are `[1, 0.5, 0]` with cumulative sums
`[1, 1.5, 1.5]` and a support of the first two entries, so `tau` should be
`(1.5 - 1) / 2 = 0.25`. The current code computes `(1 + 1.5 - 1) / 2 = 0.75`.

The identical line appears in all five backends: `numpy/nn.py`, `jax/nn.py`,
`tensorflow/nn.py`, `torch/nn.py` and `openvino/nn.py`.

### Why it was not caught

The result is only correct when the support holds exactly one element, because the masked
sum then collapses to `cumsum[0]`. Every existing test uses widely separated logits — the
`keras.ops` test uses `[-0.5, 0, 1, 2, 3]` and all the `activations` tests use
`np.linspace(1, 12, ...)` — so all of them produce one-hot output and pass either way.

Over 2000 random inputs (2–8 logits, scales 0.3/1.0/3.0), the current implementation
computes the wrong threshold in **1381 of them (69%)**.

### Fix

The support is a prefix of the descending-sorted logits, so the k-th cumulative sum is
exactly the sum of the sorted logits that fall in the support. Masking `logits_sorted`
instead of `logits_cumsum` gives the correct `tau` without needing a gather:

```python
logits_masked = np.where(support, logits_sorted, 0.0)
tau = (np.sum(logits_masked, axis=axis, keepdims=True) - 1) / k
```

One line per backend, no change in complexity or op count.

### Second fix: dtype promotion on the numpy backend (added in review)

The numpy backend also returned `float64` for every input dtype, while the other backends
preserve the input dtype:

```python
ops.sparsemax(ops.cast(x, "float16"))   # numpy backend -> float64, elsewhere -> float16
```

Three separate promotions were at work: `k` is an `int64` count and NumPy promotes
`float32 / int64` to `float64`; and the Python float literals in `np.where(..., 0.0)` and
`np.maximum(..., 0.0)` promote `bfloat16`. The constants and counts are now materialized
in the dtype of `logits`, matching the idiom already used by `relu`, `relu6` and `elu` in
the same file. `r` is cast as well, so the `support` comparison is evaluated in the input
dtype like it is on the TensorFlow and PyTorch backends, rather than in `float64`.

## Tests

- `NNOpsCorrectnessTest::test_sparsemax_dtype` — new; asserts the output dtype follows the
  input for `float16`, `float32` and `bfloat16`. Fails on the numpy backend before the
  dtype fix.
- `NNOpsCorrectnessTest::test_sparsemax` — adds `[0.0, 0.5, 1.0] -> [0.0, 0.25, 0.75]`, a
  support of size 2 whose expected output is exactly representable in `float32`. Also adds
  a property check over random inputs at three scales: the output is non-negative and sums
  to 1 along `axis`.
- `ActivationsTest::test_sparsemax` — adds the same support-of-size-2 case, so the
  `keras.activations` entry point is covered too.

Both new checks fail on numpy, jax, tensorflow and torch before the fix and pass after.

Verified against the reference algorithm on 300 random batches per backend after the fix:
max absolute deviation `1.6e-07` (float32 rounding), and every row sums to 1.

Full test files green on all four locally available backends:

| Backend | `nn_test.py` + `activations_test.py` |
|---|---|
| numpy | 449 passed, 27 skipped |
| jax | 459 passed, 17 skipped |
| tensorflow | 462 passed, 14 skipped |
| torch | 448 passed, 28 skipped |

## Notes for reviewers

- **The OpenVINO change is untested locally** — I do not have an OpenVINO runtime
  available. The edit is the direct analogue of the other four
  (`ov_opset.select(support, logits_cumsum, ...)` becomes
  `ov_opset.select(support, logits_sorted, ...)`), and `test_sparsemax` is not in
  `excluded_concrete_tests.txt`, so CI will exercise it.
- **This changes numerical output** for any model using `sparsemax`. That is the point of
  the fix, but it is worth calling out explicitly: previously saved models will now produce
  different — correct — activations.
- The numpy dtype fix was added during review, after it was flagged on a line this PR
  already touches. Casting `k` alone is not sufficient — `bfloat16` still promotes to
  `float64` through the Python float literals in `np.where` and `np.maximum` — so the
  constants are materialized in the input dtype as well.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.

## AI assistance disclosure

Per the AI-Assisted Contribution Policy: I used an AI coding assistant to help find this
bug and to draft the patch, the tests and the verification reported above. I have reviewed
the change, I understand why masking the sorted logits yields the k-th cumulative sum, and
I take responsibility for the code submitted here. Review responses will be written by me.
