### PR TITLE
Fix RematScope(mode=None) returning RematMode instead of None

### DIFF
--- a/keras/src/backend/common/remat.py
+++ b/keras/src/backend/common/remat.py
@@ -127,6 +127,8 @@ def get_current_remat_mode():
     if not remat_scope_stack:
         return None
     active_scope = remat_scope_stack[-1]
+    if active_scope.mode is None:
+        return None
     return RematMode(
         active_scope.mode,
         active_scope.output_size_threshold,

--- a/keras/src/backend/common/remat_test.py
+++ b/keras/src/backend/common/remat_test.py
@@ -46,6 +46,17 @@ class TestRematScope(testing.TestCase):
             get_current_remat_mode()
         )  # Mode is restored to None after all scopes
 
+    def test_remat_scope_none(self):
+        """Test that mode=None returns None from get_current_remat_mode."""
+        with RematScope(mode=None):
+            self.assertIsNone(get_current_remat_mode())
+
+        with RematScope(mode="full"):
+            self.assertEqual(get_current_remat_mode().mode, "full")
+            with RematScope(mode=None):
+                self.assertIsNone(get_current_remat_mode())
+            self.assertEqual(get_current_remat_mode().mode, "full")
+
     def test_remat_scope_stack_management(self):
         """Test that the remat_scope_stack is managed correctly."""
         self.assertIsNone(


### PR DESCRIPTION
Fixes #23387 by ensuring get_current_remat_mode() returns None when RematScope(mode=None) is active.

Previously, get_current_remat_mode() returned a RematMode(mode=None, ...) object which evaluated as truthy (bool(mode) == True). This caused internal checks like if self._remat_mode: in Operation.**call** to evaluate to True and apply rematerialization even when mode=None was explicitly set to disable rematerialization.

## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.