### PR TITLE
Fix NumPy normalize shape for 1D inputs

### DIFF
--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -24,12 +24,11 @@ def normalize(x, axis=-1, order=2):
 
     if isinstance(x, np.ndarray):
         # NumPy input
-        norm = np.asarray(np.linalg.norm(x, order, axis))
-        norm[norm == 0] = 1
+        norm = np.linalg.norm(x, order, axis)
+        norm = np.where(norm == 0, 1, norm)
 
-        # axis cannot be `None`
         if axis is None:
-            axis = -1
+            return x / norm
 
         return x / np.expand_dims(norm, axis)
 

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -24,7 +24,7 @@ def normalize(x, axis=-1, order=2):
 
     if isinstance(x, np.ndarray):
         # NumPy input
-        norm = np.atleast_1d(np.linalg.norm(x, order, axis))
+        norm = np.asarray(np.linalg.norm(x, order, axis))
         norm[norm == 0] = 1
 
         # axis cannot be `None`

--- a/keras/src/utils/numerical_utils_test.py
+++ b/keras/src/utils/numerical_utils_test.py
@@ -94,6 +94,15 @@ class TestNumericalUtils(testing.TestCase):
         self.assertEqual(out.shape, x.shape)
         self.assertAllClose(out, expected)
 
+    @parameterized.parameters([-1, 0, None])
+    def test_normalize_numpy_1d_preserves_shape(self, axis):
+        x = np.array([3.0, 4.0])
+
+        out = numerical_utils.normalize(x, axis=axis)
+
+        self.assertEqual(out.shape, x.shape)
+        self.assertAllClose(out, np.array([0.6, 0.8]))
+
     def test_build_pos_neg_masks(self):
         query_labels = np.array([0, 1, 2, 2, 0])
         key_labels = np.array([0, 1, 2, 0, 2])


### PR DESCRIPTION
## Description

`keras.utils.normalize()` currently changes a one-dimensional NumPy input from shape `(n,)` to `(1, n)`, while the backend-tensor path correctly preserves `(n,)`.

For a 1D input, `np.linalg.norm` returns a scalar. Wrapping that scalar with `np.atleast_1d` gives it shape `(1,)`; the subsequent `np.expand_dims` produces `(1, 1)`, and NumPy broadcasting adds an unintended leading dimension to the result.

This change keeps the scalar or array returned by `np.linalg.norm`, replaces zero norms with `np.where`, and returns `x / norm` directly when `axis=None`. For an explicit axis, expanding the denominator along that axis preserves the one-dimensional input shape.

The regression test covers `axis=-1`, `axis=0`, and `axis=None` and checks both the output shape and normalized values.

## Validation

- `KERAS_BACKEND=numpy python -m pytest keras/src/utils/numerical_utils_test.py -q` (16 passed)
- `KERAS_BACKEND=jax python -m pytest keras/src/utils/numerical_utils_test.py -q` (16 passed)
- `python -m ruff check keras/src/utils/numerical_utils.py keras/src/utils/numerical_utils_test.py` (passed)
- `python -m ruff format --check keras/src/utils/numerical_utils.py keras/src/utils/numerical_utils_test.py` (passed)
- `git diff --check` (passed)

## AI assistance disclosure

OpenAI Codex assisted with repository auditing, reproduction, implementation, upstream synchronization, and test execution. The reported tests were run against the final diff.

## Contributor Agreement

**Please review the [AI-Assisted Contribution Policy](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md#ai-assisted-contribution-policy) and confirm these before marking the PR ready:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
