### PR TITLE
[PLUGGABLE_BACKEND] Convert non-jax backend tensors to numpy in ensure_tensor

### DIFF
--- a/keras/src/utils/tf_utils.py
+++ b/keras/src/utils/tf_utils.py
@@ -31,8 +31,10 @@ def get_tensor_spec(t, dynamic_batch=False, name=None):
 def ensure_tensor(inputs, dtype=None):
     """Ensures the input is a Tensor, SparseTensor or RaggedTensor."""
     if not isinstance(inputs, (tf.Tensor, tf.SparseTensor, tf.RaggedTensor)):
-        if backend.backend() == "torch" and backend.ops.is_tensor(inputs):
-            # Plain `np.asarray()` conversion fails with PyTorch.
+        if backend.backend() != "jax" and backend.ops.is_tensor(inputs):
+            # Plain `np.asarray()` conversion fails with PyTorch, and
+            # `tf.convert_to_tensor` does not accept tensors from other
+            # backends. Convert to numpy explicitly first.
             inputs = backend.ops.convert_to_numpy(inputs)
         inputs = tf.convert_to_tensor(inputs, dtype)
     if dtype is not None and inputs.dtype != dtype:


### PR DESCRIPTION
## Description

Splitting this out of #23076, addressing @hertschuh at `tf_utils.py:36`.

`ensure_tensor` converts to numpy before `tf.convert_to_tensor` only when the backend is torch, but that conversion is needed for every backend whose tensors tensorflow cannot consume directly, which is all of them except jax. Inverting the check to `!= "jax"` leaves torch and tensorflow behaving exactly as they do today, since tensorflow tensors return early from the `isinstance` guard above, and lets other backends through the same path.

Kept as `backend.ops.is_tensor` rather than `backend.is_tensor` from the suggestion, since that is where `is_tensor` lives on this branch.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
