### PR TITLE
[PLUGGABLE_BACKEND] Rename JaxCustomTrainTestStepModel to StatelessCustomTrainTestStepModel

### DIFF
--- a/keras/src/trainers/trainer_test.py
+++ b/keras/src/trainers/trainer_test.py
@@ -69,7 +69,7 @@ class CustomTrainTestStepModel(ExampleModel):
         return logs
 
 
-class JaxCustomTrainTestStepModel(ExampleModel):
+class StatelessCustomTrainTestStepModel(ExampleModel):
     def train_step(self, state, data):
         logs, state = super().train_step(state, data)
         logs["my_custom_metric"] = 10.0
@@ -744,7 +744,7 @@ class TestTrainer(testing.TestCase):
     @pytest.mark.requires_trainable_backend
     def test_fit_with_custom_train_step(self):
         if backend.backend() == "jax":
-            model = JaxCustomTrainTestStepModel(units=3)
+            model = StatelessCustomTrainTestStepModel(units=3)
         else:
             model = CustomTrainTestStepModel(units=3)
         x = np.ones((100, 4))
@@ -833,7 +833,7 @@ class TestTrainer(testing.TestCase):
     @pytest.mark.requires_trainable_backend
     def test_evaluate_with_custom_test_step(self, return_dict):
         if backend.backend() == "jax":
-            model = JaxCustomTrainTestStepModel(units=3)
+            model = StatelessCustomTrainTestStepModel(units=3)
         else:
             model = CustomTrainTestStepModel(units=3)
         x = np.ones((100, 4))


### PR DESCRIPTION
## Description

Splitting this out of #23076, addressing @hertschuh at `trainer_test.py:750`.

`JaxCustomTrainTestStepModel` overrides `train_step(self, state, data)`, which is the signature for any backend that runs steps statelessly rather than something specific to jax. Renaming it to `StatelessCustomTrainTestStepModel`. The backend checks at the two call sites are left alone, so there is no behavior change.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
