### PR TITLE
[PLUGGABLE_BACKEND] Add a backend independent state_sync on Trainer

### DIFF
--- a/keras/src/backend/jax/trainer.py
+++ b/keras/src/backend/jax/trainer.py
@@ -487,7 +487,7 @@ class JAXTrainer(base_trainer.Trainer):
                 # (if not already done by a callback).
                 # NOTE: doing this after each step would be a big performance
                 # bottleneck.
-                self.jax_state_sync()
+                self.state_sync()
 
                 # Override with model metrics instead of last step logs if
                 # needed.
@@ -530,7 +530,7 @@ class JAXTrainer(base_trainer.Trainer):
             training_finished = True
 
         finally:
-            self.jax_state_sync()
+            self.state_sync()
             if (
                 isinstance(self.optimizer, optimizers_module.Optimizer)
                 and epochs > 0
@@ -639,7 +639,7 @@ class JAXTrainer(base_trainer.Trainer):
                     break
 
         # Reattach state back to model (if not already done by a callback).
-        self.jax_state_sync()
+        self.state_sync()
 
         logs = pythonify_logs(self._get_metrics_result_or_logs(logs))
         callbacks.on_test_end(logs)
@@ -741,7 +741,7 @@ class JAXTrainer(base_trainer.Trainer):
                 if self.stop_predicting:
                     break
 
-        self.jax_state_sync()
+        self.state_sync()
         callbacks.on_predict_end()
         self._jax_state = None
         return tree.map_structure_up_to(batch_outputs, np.concatenate, outputs)
@@ -799,7 +799,7 @@ class JAXTrainer(base_trainer.Trainer):
             "optimizer_variables": optimizer_variables,
             "metrics_variables": metrics_variables,
         }
-        self.jax_state_sync()
+        self.state_sync()
 
         # Format return values
         logs = pythonify_logs(logs)
@@ -841,7 +841,7 @@ class JAXTrainer(base_trainer.Trainer):
             "non_trainable_variables": non_trainable_variables,
             "metrics_variables": metrics_variables,
         }
-        self.jax_state_sync()
+        self.state_sync()
 
         # Format return values.
         logs = pythonify_logs(logs)
@@ -873,11 +873,11 @@ class JAXTrainer(base_trainer.Trainer):
             "trainable_variables": trainable_variables,
             "non_trainable_variables": non_trainable_variables,
         }
-        self.jax_state_sync()
+        self.state_sync()
         batch_outputs = tree.map_structure(lambda x: np.array(x), batch_outputs)
         return batch_outputs
 
-    def jax_state_sync(self):
+    def state_sync(self):
         if not getattr(self, "_jax_state", None) or self._jax_state_synced:
             return
 
@@ -902,6 +902,10 @@ class JAXTrainer(base_trainer.Trainer):
             for ref_v, v in zip(self.metrics_variables, metrics_variables):
                 ref_v.assign(v)
         self._jax_state_synced = True
+
+    def jax_state_sync(self):
+        # Backwards compatibility alias for `state_sync`.
+        self.state_sync()
 
     def _get_state_sharding_spec(self):
         trainable_shardings = [
@@ -1021,7 +1025,7 @@ class JAXTrainer(base_trainer.Trainer):
         occupying extra memory. We remove those variable to save memory (for
         better memory utilization) at the beginning of the epoch, and reattach
         the value back to variables at the end of the epoch, via
-        `jax_state_sync()`.
+        `state_sync()`.
         """
         if trainable_variables:
             for v in self.trainable_variables:

--- a/keras/src/callbacks/callback.py
+++ b/keras/src/callbacks/callback.py
@@ -89,14 +89,13 @@ class Callback:
                 # instances instead.
                 return self._model.module
 
-        if backend.backend() == "jax" and hasattr(
-            self._model, "jax_state_sync"
-        ):
-            # With JAX, by default the model state is not
-            # attached to the model in the middle of an
-            # epoch. We have to force a sync before
-            # accessing model state for e.g. checkpointing.
-            self._model.jax_state_sync()
+        if hasattr(self._model, "state_sync"):
+            # On backends that run training steps statelessly (such as
+            # JAX), the model state is not attached to the model in the
+            # middle of an epoch. Force a sync before accessing model
+            # state for e.g. checkpointing. This is a no-op on the other
+            # backends.
+            self._model.state_sync()
         return self._model
 
     @utils.default

--- a/keras/src/trainers/trainer.py
+++ b/keras/src/trainers/trainer.py
@@ -312,6 +312,17 @@ class Trainer:
         for m in self.metrics:
             m.reset_state()
 
+    def state_sync(self):
+        """Syncs the backend training state back to the model variables.
+
+        Backends that run training steps statelessly (such as JAX) detach
+        the model state from the model variables in the middle of an epoch.
+        They override this method to write the current state back to the
+        variables so that it can be read, for example for checkpointing.
+
+        On backends that update variables in place, this is a no-op.
+        """
+
     def _get_own_metrics(self):
         metrics = []
         if self._loss_tracker is not None:


### PR DESCRIPTION
## Description

Splitting this out of #23076, addressing @hertschuh at `callback.py:103`, which asked for a backend independent `state_sync` that is a no-op everywhere except the stateless backends, keeping `jax_state_sync` for backwards compatibility.

`Callback.model` forces a sync before returning the model so a callback reading state mid epoch does not see stale values, guarded today by `backend.backend() == "jax" and hasattr(self._model, "jax_state_sync")`. Any backend that runs training steps statelessly needs the same thing and cannot get it without editing that line.

This adds a `state_sync()` on the base `Trainer` that does nothing, since backends updating variables in place have nothing to sync, and makes the jax trainer's method override it. The callback then just calls `self._model.state_sync()`. `jax_state_sync()` remains as an alias. On jax the sequence of syncs is identical to before.

This is the keras half of the change. The mlx backend currently names its equivalent `mlx_state_sync`, so it needs a matching rename in keras-mlx to override the new method, which I will send there separately. With both halves in place `CallbackTest::test_model_state_is_current_on_epoch_end` passes on mlx, where it is excluded today.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
