### PR TITLE
Fix unravel_index coordinate order in TensorFlow backend

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2841,6 +2841,7 @@ def unravel_index(indices, shape):
     for dim in reversed(shape):
         coords.append(tf.cast(indices % dim, input_dtype))
         indices = indices // dim
+
     return tuple(reversed(coords))
 
 

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2837,21 +2837,10 @@ def unravel_index(indices, shape):
             f"`shape` argument cannot contain `None`. Received: shape={shape}"
         )
 
-    if indices.ndim == 1:
-        coords = []
-        for dim in reversed(shape):
-            coords.append(tf.cast(indices % dim, input_dtype))
-            indices = indices // dim
-        return tuple(reversed(coords))
-
-    indices_shape = indices.shape
     coords = []
-    for dim in shape:
-        coords.append(
-            tf.reshape(tf.cast(indices % dim, input_dtype), indices_shape)
-        )
+    for dim in reversed(shape):
+        coords.append(tf.cast(indices % dim, input_dtype))
         indices = indices // dim
-
     return tuple(reversed(coords))
 
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6547,6 +6547,21 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         ):
             self.assertAllClose(ind_knp, ind_np)
 
+        # Asymmetric shape test
+        x = np.array(100)
+        shape = (4, 5, 6)
+        for ind_knp, ind_np in zip(
+            knp.unravel_index(x, shape), np.unravel_index(x, shape)
+        ):
+            self.assertAllClose(ind_knp, ind_np)
+
+        x = np.array([[100, 101]])
+        shape = (4, 5, 6)
+        for ind_knp, ind_np in zip(
+            knp.unravel_index(x, shape), np.unravel_index(x, shape)
+        ):
+            self.assertAllClose(ind_knp, ind_np)
+
     @pytest.mark.skipif(
         not backend.SUPPORTS_COMPLEX_DTYPES,
         reason=f"{backend.backend()} backend doesn't support complex dtypes.",


### PR DESCRIPTION
## Description
This PR resolves a discrepancy in ops.unravel_index between the TensorFlow backend and NumPy (and other Keras backends). Previously, the TF backend implementation had separate logic for 1D and non-1D indices. The non-1D logic incorrectly iterated through the shape in forward order while calculating coordinates, leading to inverted results for asymmetric shapes.

  Example of the bug:
```
   shape = (4, 5, 6)
   index = 100
   # Expected (NumPy): [3, 1, 4]
   # Actual (TF 0D/2D): [5, 0, 0]  # Incorrectly calculated as if shape was reversed
```

reproduction script: https://colab.research.google.com/drive/1SdZRRVDUV3Dg8ORpTQmlOIA_U4f3_yyo?resourcekey=0-7XMyFCvdBdNJLhrdHE9Whw&usp=sharing

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
