### PR TITLE
Fix rot90 for non-square arrays in TensorFlow backend

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -63,25 +63,13 @@ def rot90(array, k=1, axes=(0, 1)):
     array = tf.transpose(array, perm)
 
     if k == 1:
-        array = tf.reverse(array, axis=[array.shape.rank - 1])
-        last_two_swapped = list(range(array.shape.rank))
-        last_two_swapped[-2], last_two_swapped[-1] = (
-            last_two_swapped[-1],
-            last_two_swapped[-2],
-        )
-        array = tf.transpose(array, last_two_swapped)
+        array = tf.reverse(array, axis=[-1])
+        array = swapaxes(array, -1, -2)
     elif k == 2:
-        array = tf.reverse(
-            array, axis=[array.shape.rank - 2, array.shape.rank - 1]
-        )
+        array = tf.reverse(array, axis=[-2, -1])
     elif k == 3:
-        array = tf.reverse(array, axis=[array.shape.rank - 2])
-        last_two_swapped = list(range(array.shape.rank))
-        last_two_swapped[-2], last_two_swapped[-1] = (
-            last_two_swapped[-1],
-            last_two_swapped[-2],
-        )
-        array = tf.transpose(array, last_two_swapped)
+        array = tf.reverse(array, axis=[-2])
+        array = swapaxes(array, -1, -2)
 
     inv_perm = [0] * len(perm)
     for i, p in enumerate(perm):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -58,32 +58,30 @@ def rot90(array, k=1, axes=(0, 1)):
         axis if axis >= 0 else array.shape.rank + axis for axis in axes
     )
 
-    perm = [i for i in range(array.shape.rank) if i not in axes]
-    perm.extend(axes)
+    other_axes = [i for i in range(array.shape.rank) if i not in axes]
+    perm = other_axes + list(axes)
     array = tf.transpose(array, perm)
 
-    shape = tf.shape(array)
-    non_rot_shape = shape[:-2]
-    h, w = shape[-2], shape[-1]
-
-    array = tf.reshape(array, tf.concat([[-1], [h, w]], axis=0))
-
-    array = tf.reverse(array, axis=[2])
-    array = tf.transpose(array, [0, 2, 1])
-
-    if k % 2 == 1:
-        final_h, final_w = w, h
-    else:
-        final_h, final_w = h, w
-
-    if k > 1:
-        array = tf.reshape(array, tf.concat([[-1], [final_h, final_w]], axis=0))
-        for _ in range(k - 1):
-            array = tf.reverse(array, axis=[2])
-            array = tf.transpose(array, [0, 2, 1])
-
-    final_shape = tf.concat([non_rot_shape, [final_h, final_w]], axis=0)
-    array = tf.reshape(array, final_shape)
+    if k == 1:
+        array = tf.reverse(array, axis=[array.shape.rank - 1])
+        last_two_swapped = list(range(array.shape.rank))
+        last_two_swapped[-2], last_two_swapped[-1] = (
+            last_two_swapped[-1],
+            last_two_swapped[-2],
+        )
+        array = tf.transpose(array, last_two_swapped)
+    elif k == 2:
+        array = tf.reverse(
+            array, axis=[array.shape.rank - 2, array.shape.rank - 1]
+        )
+    elif k == 3:
+        array = tf.reverse(array, axis=[array.shape.rank - 2])
+        last_two_swapped = list(range(array.shape.rank))
+        last_two_swapped[-2], last_two_swapped[-1] = (
+            last_two_swapped[-1],
+            last_two_swapped[-2],
+        )
+        array = tf.transpose(array, last_two_swapped)
 
     inv_perm = [0] * len(perm)
     for i, p in enumerate(perm):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -26,6 +26,13 @@ class NumPyTestRot90(testing.TestCase):
         expected = np.rot90(array)
         self.assertAllClose(rotated, expected)
 
+    def test_non_square_rotation(self):
+        array = np.arange(6).reshape((2, 3))
+        for k in range(4):
+            rotated = knp.rot90(array, k=k)
+            expected = np.rot90(array, k=k)
+            self.assertAllClose(rotated, expected)
+
     @parameterized.named_parameters(
         ("k_0", 0, [[1, 2], [3, 4]]),
         ("k_1", 1, [[2, 4], [1, 3]]),


### PR DESCRIPTION
## Description
This PR fixes a bug in ops.rot90 for the TensorFlow backend where rotations of non-square arrays produced incorrect results for $k=2$ and $k=3$. The previous implementation used a loop that attempted to reshape the array into a 3D tensor (-1, h, w) but failed to correctly update or handle the dimensions when h != w across multiple 90-degree steps.

Reproduction script: https://colab.research.google.com/drive/1QseorYP77YAWo98rropFGT0o__-jRLEe?resourcekey=0-_GVQSlIvuJysCrvqpvlZFQ&usp=sharing

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
