### PR TITLE
Fix searchsorted for multi-dimensional values in Tensorflow backend

### DIFF
--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -2907,6 +2907,8 @@ def roll(x, shift, axis=None):
 
 
 def searchsorted(sorted_sequence, values, side="left"):
+    sorted_sequence = convert_to_tensor(sorted_sequence)
+    values = convert_to_tensor(values)
     if ndim(sorted_sequence) != 1:
         raise ValueError(
             "`searchsorted` only supports 1-D sorted sequences. "
@@ -2920,9 +2922,11 @@ def searchsorted(sorted_sequence, values, side="left"):
         if sequence_len is not None and sequence_len <= np.iinfo(np.int32).max
         else "int64"
     )
-    return tf.searchsorted(
-        sorted_sequence, values, side=side, out_type=out_type
+    values_shape = shape_op(values)
+    result = tf.searchsorted(
+        sorted_sequence, tf.reshape(values, [-1]), side=side, out_type=out_type
     )
+    return tf.reshape(result, values_shape)
 
 
 @sparse.elementwise_unary

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6674,6 +6674,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllEqual(knp.searchsorted(a, v), expected)
         self.assertAllEqual(knp.SearchSorted()(a, v), expected)
 
+        # Multi-dimensional values
+        v = np.array([[4, 3], [5, 1]])
+        expected = np.searchsorted(a, v).astype("int32")
+        self.assertAllEqual(knp.searchsorted(a, v), expected)
+
     def test_sign(self):
         x = np.array([[1, -2, 3], [-3, 2, -1]])
         self.assertAllClose(knp.sign(x), np.sign(x))


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/23452

## Description
This PR fixes a bug in the TensorFlow backend where ops.searchsorted would crash if the values tensor was multi dimensional.

The Issue:
The previous implementation passed multi-dimensional values directly to tf.searchsorted. However, tf.searchsorted requires that if values is N-D, the sorted_sequence must also be N-D with matching leading dimensions. This differed from NumPy's behavior (and other Keras backends), where a 1D sorted_sequence is broadcast against all elements of values.


Reproduction script: https://colab.research.google.com/drive/185aW8Nd1BU6OjF-8hGgMGQSa_FKwpNEs?resourcekey=0-k4wqKlrMgHXnMMoaSTwyeg&usp=sharing

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
