### PR TITLE
Fix categorical_crossentropy label smoothing for custom axis

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2184,7 +2184,7 @@ def categorical_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if y_pred.shape[-1] == 1:
+    if y_pred.shape[axis] == 1:
         warnings.warn(
             "In loss categorical_crossentropy, expected "
             "y_pred.shape to be (batch_size, num_classes) "
@@ -2195,7 +2195,7 @@ def categorical_crossentropy(
         )
 
     if label_smoothing:
-        num_classes = ops.cast(ops.shape(y_true)[-1], y_pred.dtype)
+        num_classes = ops.cast(ops.shape(y_true)[axis], y_pred.dtype)
         y_true = y_true * (1.0 - label_smoothing) + (
             label_smoothing / num_classes
         )
@@ -2262,7 +2262,7 @@ def categorical_focal_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if y_pred.shape[-1] == 1:
+    if y_pred.shape[axis] == 1:
         warnings.warn(
             "In loss categorical_focal_crossentropy, expected "
             "y_pred.shape to be (batch_size, num_classes) "
@@ -2273,7 +2273,7 @@ def categorical_focal_crossentropy(
         )
 
     if label_smoothing:
-        num_classes = ops.cast(ops.shape(y_true)[-1], y_pred.dtype)
+        num_classes = ops.cast(ops.shape(y_true)[axis], y_pred.dtype)
         y_true = y_true * (1.0 - label_smoothing) + (
             label_smoothing / num_classes
         )

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2184,7 +2184,10 @@ def categorical_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if y_pred.shape[axis] == 1:
+    if y_pred.shape is not None:
+        axis = canonicalize_axis(axis, len(y_pred.shape))
+
+    if y_pred.shape is not None and y_pred.shape[axis] == 1:
         warnings.warn(
             "In loss categorical_crossentropy, expected "
             "y_pred.shape to be (batch_size, num_classes) "
@@ -2262,7 +2265,10 @@ def categorical_focal_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if y_pred.shape[axis] == 1:
+    if y_pred.shape is not None:
+        axis = canonicalize_axis(axis, len(y_pred.shape))
+
+    if y_pred.shape is not None and y_pred.shape[axis] == 1:
         warnings.warn(
             "In loss categorical_focal_crossentropy, expected "
             "y_pred.shape to be (batch_size, num_classes) "

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2186,19 +2186,19 @@ def categorical_crossentropy(
 
     if y_pred.shape is not None:
         axis = canonicalize_axis(axis, len(y_pred.shape))
-
-    if y_pred.shape is not None and y_pred.shape[axis] == 1:
-        warnings.warn(
-            "In loss categorical_crossentropy, expected "
-            "y_pred.shape to be (batch_size, num_classes) "
-            f"with num_classes > 1. Received: y_pred.shape={y_pred.shape}. "
-            "Consider using 'binary_crossentropy' if you only have 2 classes.",
-            SyntaxWarning,
-            stacklevel=2,
-        )
+        if y_pred.shape[axis] == 1:
+            warnings.warn(
+                "In loss categorical_crossentropy, expected "
+                "y_pred.shape to be (batch_size, num_classes) "
+                f"with num_classes > 1. Received: y_pred.shape={y_pred.shape}. "
+                "Consider using 'binary_crossentropy' if you only "
+                "have 2 classes.",
+                SyntaxWarning,
+                stacklevel=2,
+            )
 
     if label_smoothing:
-        num_classes = ops.cast(ops.shape(y_true)[axis], y_pred.dtype)
+        num_classes = ops.cast(ops.shape(y_pred)[axis], y_pred.dtype)
         y_true = y_true * (1.0 - label_smoothing) + (
             label_smoothing / num_classes
         )
@@ -2267,19 +2267,19 @@ def categorical_focal_crossentropy(
 
     if y_pred.shape is not None:
         axis = canonicalize_axis(axis, len(y_pred.shape))
-
-    if y_pred.shape is not None and y_pred.shape[axis] == 1:
-        warnings.warn(
-            "In loss categorical_focal_crossentropy, expected "
-            "y_pred.shape to be (batch_size, num_classes) "
-            f"with num_classes > 1. Received: y_pred.shape={y_pred.shape}. "
-            "Consider using 'binary_crossentropy' if you only have 2 classes.",
-            SyntaxWarning,
-            stacklevel=2,
-        )
+        if y_pred.shape[axis] == 1:
+            warnings.warn(
+                "In loss categorical_focal_crossentropy, expected "
+                "y_pred.shape to be (batch_size, num_classes) "
+                f"with num_classes > 1. Received: y_pred.shape={y_pred.shape}. "
+                "Consider using 'binary_crossentropy' if you only "
+                "have 2 classes.",
+                SyntaxWarning,
+                stacklevel=2,
+            )
 
     if label_smoothing:
-        num_classes = ops.cast(ops.shape(y_true)[axis], y_pred.dtype)
+        num_classes = ops.cast(ops.shape(y_pred)[axis], y_pred.dtype)
         y_true = y_true * (1.0 - label_smoothing) + (
             label_smoothing / num_classes
         )

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import numpy as np
 import pytest
@@ -1165,6 +1166,37 @@ class CategoricalCrossentropyTest(testing.TestCase):
         loss = cce_obj(y_true, logits, sample_weight=2.3)
         self.assertAlmostEqual(loss, 0.1317)
 
+    def test_warning_for_invalid_shape(self):
+        # 2D case: should warn
+        y_true = np.array([[1], [1]], dtype="float32")
+        y_pred = np.array([[0.5], [0.5]], dtype="float32")
+        with pytest.warns(
+            SyntaxWarning,
+            match=r"expected y_pred.shape to be \(batch_size, num_classes\)",
+        ):
+            losses.categorical_crossentropy(y_true, y_pred)
+
+        # 3D case: axis=1, classes=1, should warn
+        y_true = np.ones((2, 1, 4), dtype="float32")
+        y_pred = np.ones((2, 1, 4), dtype="float32")
+        with pytest.warns(
+            SyntaxWarning,
+            match=r"expected y_pred.shape to be \(batch_size, num_classes\)",
+        ):
+            losses.categorical_crossentropy(y_true, y_pred, axis=1)
+
+        # 3D case: axis=1, classes=4, should NOT warn
+        y_true = np.ones((2, 4, 1), dtype="float32")
+        y_pred = np.ones((2, 4, 1), dtype="float32")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            losses.categorical_crossentropy(y_true, y_pred, axis=1)
+            # Check if any SyntaxWarning was issued
+            syntax_warnings = [
+                warn for warn in w if issubclass(warn.category, SyntaxWarning)
+            ]
+            self.assertEqual(len(syntax_warnings), 0)
+
     def test_sample_weighted(self):
         cce_obj = losses.CategoricalCrossentropy()
         y_true = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -1843,6 +1875,37 @@ class CategoricalFocalCrossentropyTest(testing.TestCase):
         cce_obj = losses.CategoricalFocalCrossentropy(from_logits=True)
         loss = cce_obj(y_true, logits, sample_weight=2.3)
         self.assertAlmostEqual(loss, 0.000794, 4)
+
+    def test_warning_for_invalid_shape(self):
+        # 2D case: should warn
+        y_true = np.array([[1], [1]], dtype="float32")
+        y_pred = np.array([[0.5], [0.5]], dtype="float32")
+        with pytest.warns(
+            SyntaxWarning,
+            match=r"expected y_pred.shape to be \(batch_size, num_classes\)",
+        ):
+            losses.categorical_focal_crossentropy(y_true, y_pred)
+
+        # 3D case: axis=1, classes=1, should warn
+        y_true = np.ones((2, 1, 4), dtype="float32")
+        y_pred = np.ones((2, 1, 4), dtype="float32")
+        with pytest.warns(
+            SyntaxWarning,
+            match=r"expected y_pred.shape to be \(batch_size, num_classes\)",
+        ):
+            losses.categorical_focal_crossentropy(y_true, y_pred, axis=1)
+
+        # 3D case: axis=1, classes=4, should NOT warn
+        y_true = np.ones((2, 4, 1), dtype="float32")
+        y_pred = np.ones((2, 4, 1), dtype="float32")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            losses.categorical_focal_crossentropy(y_true, y_pred, axis=1)
+            # Check if any SyntaxWarning was issued
+            syntax_warnings = [
+                warn for warn in w if issubclass(warn.category, SyntaxWarning)
+            ]
+            self.assertEqual(len(syntax_warnings), 0)
 
     def test_sample_weighted(self):
         cce_obj = losses.CategoricalFocalCrossentropy()

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1213,6 +1213,35 @@ class CategoricalCrossentropyTest(testing.TestCase):
         expected_value = 400.0 * label_smoothing / 3.0
         self.assertAlmostEqual(loss, expected_value)
 
+    def test_label_smoothing_with_axis(self):
+        # (batch, classes, spatial)
+        num_classes = 3
+        y_true = np.array(
+            [[[1, 0], [0, 1], [0, 0]], [[0, 1], [1, 0], [0, 0]]],
+            dtype="float32",
+        )
+        y_pred = np.array(
+            [
+                [[0.8, 0.1], [0.1, 0.8], [0.1, 0.1]],
+                [[0.1, 0.8], [0.8, 0.1], [0.1, 0.1]],
+            ],
+            dtype="float32",
+        )
+        label_smoothing = 0.1
+        axis = 1
+        cce_obj = losses.CategoricalCrossentropy(
+            label_smoothing=label_smoothing, axis=axis
+        )
+        loss = cce_obj(y_true, y_pred)
+
+        y_true_smoothed = y_true * (1.0 - label_smoothing) + (
+            label_smoothing / num_classes
+        )
+        expected_loss = -np.sum(y_true_smoothed * np.log(y_pred), axis=axis)
+        expected_loss = np.mean(expected_loss)
+
+        self.assertAlmostEqual(loss, expected_loss, decimal=5)
+
     def test_shape_mismatch(self):
         y_true = np.array([[0], [1], [2]])
         y_pred = np.array(
@@ -1853,6 +1882,43 @@ class CategoricalFocalCrossentropyTest(testing.TestCase):
 
         expected_value = 0.06685
         self.assertAlmostEqual(loss, expected_value, 3)
+
+    def test_label_smoothing_with_axis(self):
+        # (batch, classes, spatial)
+        num_classes = 3
+        y_true = np.array(
+            [[[1, 0], [0, 1], [0, 0]], [[0, 1], [1, 0], [0, 0]]],
+            dtype="float32",
+        )
+        y_pred = np.array(
+            [
+                [[0.8, 0.1], [0.1, 0.8], [0.1, 0.1]],
+                [[0.1, 0.8], [0.8, 0.1], [0.1, 0.1]],
+            ],
+            dtype="float32",
+        )
+        label_smoothing = 0.1
+        axis = 1
+        focal_obj = losses.CategoricalFocalCrossentropy(
+            label_smoothing=label_smoothing, axis=axis
+        )
+        loss = focal_obj(y_true, y_pred)
+
+        # Manually compute smoothed focal loss for verification
+        y_true_smoothed = y_true * (1.0 - label_smoothing) + (
+            label_smoothing / num_classes
+        )
+        # alpha=0.25, gamma=2.0 (defaults)
+        alpha = 0.25
+        gamma = 2.0
+
+        cross_entropy = -y_true_smoothed * np.log(y_pred)
+        p_t = y_pred
+        focal_loss = alpha * np.power(1 - p_t, gamma) * cross_entropy
+        expected_loss = np.sum(focal_loss, axis=axis)
+        expected_loss = np.mean(expected_loss)
+
+        self.assertAlmostEqual(loss, expected_loss, decimal=5)
 
     def test_dtype_arg(self):
         logits = np.array([[4.9, -0.5, 2.05]])


### PR DESCRIPTION
Fixes https://github.com/keras-team/keras/issues/23451

## Description
This PR fixes a bug in categorical_crossentropy and categorical_focal_crossentropy where the label_smoothing logic incorrectly assumed the class dimension was always the last axis.

Root Cause
When label_smoothing is enabled, the loss function calculates the number of classes (num_classes) to redistribute probability mass from the ground truth. Previously, this was hardcoded to num_classes = ops.shape(y_true)[-1].

If a user specified a custom axis (e.g., axis=1 for (batch, classes, spatial) data), the implementation would use the size of the last dimension (often a spatial or temporal dimension) instead of the actual class dimension. This resulted in:
   1. Invalid probability distributions: The smoothed labels would not sum to 1.0.
   2. Incorrect loss values: Model training would be driven by silently corrupted gradients.

Additionally, the implementation contained a warning for singleton class dimensions that was also hardcoded to check only the last axis.

Reproduction script: https://colab.research.google.com/drive/1LyDEp9HJI-MoCOAwTfmqbEBV8ec-O9cj?resourcekey=0-IuR4p5aMkSy2FYyeEgYC_g&usp=sharing

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
