### PR TITLE
Fix OpenVINO eigh Jacobi rotation convergence and conftest test skip matching

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -77,13 +77,16 @@ def pytest_collection_modifyitems(config, items):
         # this is more granular mechanism to exclude tests rather
         # than using --ignore option
         for skipped_test in openvino_skipped_tests:
-            if skipped_test in item.nodeid:
-                item.add_marker(
-                    skip_if_backend(
-                        "openvino",
-                        "Not supported operation by openvino backend",
+            idx = item.nodeid.find(skipped_test)
+            if idx != -1:
+                remainder = item.nodeid[idx + len(skipped_test) :]
+                if remainder == "" or remainder.startswith(("_", "[")):
+                    item.add_marker(
+                        skip_if_backend(
+                            "openvino",
+                            "Not supported operation by openvino backend",
+                        )
                     )
-                )
 
 
 def skip_if_backend(given_backend, reason):

--- a/keras/src/backend/openvino/linalg.py
+++ b/keras/src/backend/openvino/linalg.py
@@ -493,8 +493,10 @@ def eigh(a):
     argmax_flat_sq = ov_opset.squeeze(argmax_flat, one_const).output(
         0
     )  # shape [B]
-    p = ov_opset.divide(argmax_flat_sq, l_n).output(0)  # shape [B]
-    q = ov_opset.mod(argmax_flat_sq, l_n).output(0)  # shape [B]
+    raw_p = ov_opset.divide(argmax_flat_sq, l_n).output(0)  # shape [B]
+    raw_q = ov_opset.mod(argmax_flat_sq, l_n).output(0)  # shape [B]
+    p = ov_opset.minimum(raw_p, raw_q).output(0)
+    q = ov_opset.maximum(raw_p, raw_q).output(0)
     p_unsqueezed = ov_opset.unsqueeze(p, one_const).output(0)
     q_unsqueezed = ov_opset.unsqueeze(q, one_const).output(0)
     b_indices = ov_opset.range(


### PR DESCRIPTION
Fixes #23441 by addressing both the test skipping logic and the mathematical convergence bug in OpenVINO `eigh`:

1. **Test Skipping Match Logic (`conftest.py`)**: Fixed the substring match logic so that listing `LinalgOpsCorrectnessTest::test_eig` in `excluded_concrete_tests.txt` does not accidentally skip `LinalgOpsCorrectnessTest::test_eigh`. The remainder string following the match is now checked to be either empty or start with `_` or `[`.
2. **OpenVINO `eigh` Givens Rotation Convergence (`keras/src/backend/openvino/linalg.py`)**: Guaranteed $p < q$ index ordering ($p = \min(p, q)$ and $q = \max(p, q)$) in the Jacobi eigenvalue solver loop before constructing Givens rotation parameters. Previously, when off-diagonal indices returned $p > q$, the sign was inverted relative to the Givens rotation convention, causing rotation iterations to diverge for matrices of dimension $n \ge 3$.



## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.