### PR TITLE
Add tf_idf output mode test coverage for StringLookup

### DIFF
--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -224,14 +224,17 @@ class StringLookupTest(testing.TestCase):
         layer = layers.StringLookup(
             vocabulary=["a", "b", "c"],
             output_mode="tf_idf",
-            idf_weights=[0.3, 0.5, 0.2],
+            idf_weights=[0.2, 0.4, 0.6],
         )
         output = layer(["a", "b"])
-        self.assertAllClose(output, [0.0, 0.3, 0.5, 0.0])
+        self.assertAllClose(output, [0.0, 0.2, 0.4, 0.0])
         output = layer([["a", "a"], ["c", "a"]])
         self.assertAllClose(
-            output, [[0.0, 0.6, 0.0, 0.0], [0.0, 0.3, 0.0, 0.2]]
+            output, [[0.0, 0.4, 0.0, 0.0], [0.0, 0.2, 0.0, 0.6]]
         )
+        # Test with OOV token (should map to index 0 with average IDF weight)
+        output = layer(["a", "b", "d"])
+        self.assertAllClose(output, [0.4, 0.2, 0.4, 0.0])
 
     def test_output_mode_multi_hot_binary(self):
         layer = layers.StringLookup(

--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -220,6 +220,19 @@ class StringLookupTest(testing.TestCase):
         output = layer(["a", "a", "a", "b", "b"])
         self.assertEqual(output.shape[-1], len(layer.get_vocabulary()))
 
+    def test_output_mode_tf_idf(self):
+        layer = layers.StringLookup(
+            vocabulary=["a", "b", "c"],
+            output_mode="tf_idf",
+            idf_weights=[0.3, 0.5, 0.2],
+        )
+        output = layer(["a", "b"])
+        self.assertAllClose(output, [0.0, 0.3, 0.5, 0.0])
+        output = layer([["a", "a"], ["c", "a"]])
+        self.assertAllClose(
+            output, [[0.0, 0.6, 0.0, 0.0], [0.0, 0.3, 0.0, 0.2]]
+        )
+
     def test_output_mode_multi_hot_binary(self):
         layer = layers.StringLookup(
             vocabulary=["a", "b"],


### PR DESCRIPTION
`StringLookupTest` has a `# TODO: increase coverage. Most features
aren't being tested.` comment at the top of the file. Looking through
the existing tests, `tf_idf` was the one documented `output_mode`
with zero coverage — `int`, `count`, `multi_hot`, and `one_hot` all
have dedicated tests, but `tf_idf` had none.

## Change
Added `test_output_mode_tf_idf`, following the same pattern already
used in `TextVectorizationTest.test_output_mode_tf_idf_output`
(since `StringLookup` and `TextVectorization` share the underlying
`IndexLookup` implementation).

## Testing
Ran the full `string_lookup_test.py` suite locally — all 20 tests
pass, 1 pre-existing skip (unrelated torch backend test), nothing
broken by this change.

This is my first Keras contribution — happy to adjust based on
feedback.

## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.