### PR TITLE
Relax OpenVINO test tolerance in STFTSpectrogram error test

### DIFF
--- a/keras/src/layers/preprocessing/stft_spectrogram_test.py
+++ b/keras/src/layers/preprocessing/stft_spectrogram_test.py
@@ -318,7 +318,7 @@ class TestSpectrogram(testing.TestCase):
             if testing.uses_tpu():
                 tol_kwargs = {"atol": 5e-2, "rtol": 1e-3}
             elif backend.backend() == "openvino":
-                tol_kwargs = {"atol": 1e-2, "rtol": 1e-3}
+                tol_kwargs = {"atol": 1e-1, "rtol": 2e-2}
             else:
                 tol_kwargs = {"atol": 5e-4, "rtol": 1e-6}
 


### PR DESCRIPTION
## Description

#23394 relaxed the OpenVino tolerances, but the test is still flaky:
https://github.com/keras-team/keras/actions/runs/32095101648/job/95584829969
This further relaxes the tolerances to reduce flakiness.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
