### PR TITLE
Validate duplicate axes in symbolic shape inference

### DIFF
--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1475,6 +1475,9 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.sum(x, axis=1).shape, (None, 3))
         self.assertEqual(knp.sum(x, axis=1, keepdims=True).shape, (None, 1, 3))
 
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            knp.sum(x, axis=(1, -2))
+
     def test_amax(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.amax(x).shape, ())
@@ -1869,6 +1872,9 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.expand_dims(x, (1, 2)).shape, (None, 1, 1, 3))
         self.assertEqual(knp.expand_dims(x, (-1, -2)).shape, (None, 3, 1, 1))
         self.assertEqual(knp.expand_dims(x, (-1, 1)).shape, (None, 1, 3, 1))
+
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            knp.expand_dims(x, (1, -3))
 
     def test_expm1(self):
         x = KerasTensor((None, 3))

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1475,7 +1475,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.sum(x, axis=1).shape, (None, 3))
         self.assertEqual(knp.sum(x, axis=1, keepdims=True).shape, (None, 1, 3))
 
-        with self.assertRaisesRegex(ValueError, "duplicate"):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"axis=\(1, -2\).*canonicalizes to \(1, 1\).*input of rank 3",
+        ):
             knp.sum(x, axis=(1, -2))
 
     def test_amax(self):
@@ -1873,7 +1876,10 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(knp.expand_dims(x, (-1, -2)).shape, (None, 3, 1, 1))
         self.assertEqual(knp.expand_dims(x, (-1, 1)).shape, (None, 1, 3, 1))
 
-        with self.assertRaisesRegex(ValueError, "duplicate"):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"axis=\(1, -3\).*canonicalizes to \(1, 1\).*output of rank 4",
+        ):
             knp.expand_dims(x, (1, -3))
 
     def test_expm1(self):

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -67,12 +67,15 @@ def compute_expand_dims_output_shape(input_shape, axis):
     input_shape = list(input_shape)
     if axis is None:
         axis = len(input_shape)
+    original_axis = axis
     axis = to_tuple_or_list(axis)
     out_ndim = len(axis) + len(input_shape)
     axis = [canonicalize_axis(a, out_ndim) for a in axis]
     if len(set(axis)) != len(axis):
         raise ValueError(
-            f"`axis` must not contain duplicate entries. Received: axis={axis}."
+            "Argument `axis` must not contain duplicate dimensions after "
+            f"canonicalization. Received: axis={original_axis} (which "
+            f"canonicalizes to {tuple(axis)} for output of rank {out_ndim})."
         )
     shape_iter = iter(input_shape)
     new_shape = [
@@ -474,10 +477,13 @@ def reduce_shape(shape, axis=None, keepdims=False):
     elif isinstance(axis, int):
         axis = (axis,)
 
+    original_axis = axis
     axis = tuple(canonicalize_axis(a, len(shape)) for a in axis)
     if len(set(axis)) != len(axis):
         raise ValueError(
-            f"`axis` must not contain duplicate entries. Received: axis={axis}."
+            "Argument `axis` must not contain duplicate dimensions after "
+            f"canonicalization. Received: axis={original_axis} (which "
+            f"canonicalizes to {axis} for input of rank {len(shape)})."
         )
 
     if keepdims:

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -70,6 +70,10 @@ def compute_expand_dims_output_shape(input_shape, axis):
     axis = to_tuple_or_list(axis)
     out_ndim = len(axis) + len(input_shape)
     axis = [canonicalize_axis(a, out_ndim) for a in axis]
+    if len(set(axis)) != len(axis):
+        raise ValueError(
+            f"`axis` must not contain duplicate entries. Received: axis={axis}."
+        )
     shape_iter = iter(input_shape)
     new_shape = [
         1 if ax in axis else next(shape_iter) for ax in range(out_ndim)
@@ -471,6 +475,10 @@ def reduce_shape(shape, axis=None, keepdims=False):
         axis = (axis,)
 
     axis = tuple(canonicalize_axis(a, len(shape)) for a in axis)
+    if len(set(axis)) != len(axis):
+        raise ValueError(
+            f"`axis` must not contain duplicate entries. Received: axis={axis}."
+        )
 
     if keepdims:
         for ax in axis:


### PR DESCRIPTION
## Description

Symbolic shape inference accepted axis tuples that became duplicates after canonicalization. For example, `keras.ops.sum(x, axis=(1, -2))` on a rank-3 symbolic tensor treated both entries as axis 1, while eager backends reject the duplicate. `expand_dims(x, axis=(1, -3))` could instead leak `StopIteration` from shape construction.

This change validates uniqueness after canonicalizing axes in the shared reduction and `expand_dims` shape helpers. It raises a clear `ValueError` and keeps symbolic behavior aligned with eager execution. Two public-operation regressions cover both paths.

AI assistance was used to identify and test the edge cases. I reviewed the complete change and verified it locally.

## Validation

- focused regression tests: 2 passed
- `operation_utils_test.py` and `numpy_test.py`: 5,540 passed, 705 skipped
- Ruff check and format check on changed files
- `git diff --check`

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
