### PR TITLE
Fix Torch stateful GRU/LSTM cuDNN backward in-place state update

### DIFF
--- a/keras/src/layers/rnn/gru.py
+++ b/keras/src/layers/rnn/gru.py
@@ -552,6 +552,14 @@ class GRU(RNN):
         if self.use_cudnn in ("auto", True):
             if not self.recurrent_dropout:
                 try:
+                    # Clone hidden state for PyTorch + stateful. The optimized
+                    # kernel retains the initial state for backward, while
+                    # Keras then assign()s the new state in-place (copy_),
+                    # which would mutate storage autograd still needs. The
+                    # generic RNN loop already clones inside step(); this
+                    # path bypasses that copy.
+                    if self.stateful and backend.backend() == "torch":
+                        initial_state = ops.copy(initial_state)
                     if training and self.dropout:
                         dp_mask = self.cell.get_dropout_mask(sequences[:, 0, :])
                         dp_mask = ops.expand_dims(dp_mask, axis=1)

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -476,3 +476,41 @@ class GRUTest(testing.TestCase):
                 "fallback."
             ),
         )
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="Reproduces torch stateful GRU backward (#23462).",
+    )
+    def test_stateful_backward(self):
+        # cuDNN GRU retains the initial hidden state for backward. Keras
+        # then updates the stateful Variable in-place via copy_. Without a
+        # clone on the optimized torch path, autograd raises RuntimeError
+        # on CUDA: "one of the variables needed for gradient computation
+        # has been modified by an inplace operation".
+        import torch
+        from unittest import mock
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        inputs = torch.randn(2, 3, 4, device=device)
+        layer = layers.GRU(5, stateful=True)
+
+        if device == "cuda":
+            real_vf_gru = torch._VF.gru
+            calls = []
+
+            def spy(*args, **kwargs):
+                calls.append(True)
+                return real_vf_gru(*args, **kwargs)
+
+            with mock.patch.object(torch._VF, "gru", side_effect=spy):
+                layer(inputs).sum().backward()
+            self.assertGreaterEqual(
+                len(calls),
+                1,
+                msg=(
+                    "torch._VF.gru was never invoked; the test did not "
+                    "exercise the cuDNN path from #23462."
+                ),
+            )
+        else:
+            layer(inputs).sum().backward()

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -487,8 +487,9 @@ class GRUTest(testing.TestCase):
         # clone on the optimized torch path, autograd raises RuntimeError
         # on CUDA: "one of the variables needed for gradient computation
         # has been modified by an inplace operation".
-        import torch
         from unittest import mock
+
+        import torch
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
         inputs = torch.randn(2, 3, 4, device=device)

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -453,7 +453,6 @@ class GRUTest(testing.TestCase):
         if not torch.cuda.is_available():
             self.skipTest("Requires a CUDA device.")
 
-
         x = torch.randn(4, 6, 5, device="cuda")
         layer = layers.GRU(8, return_sequences=True)
         layer(x)  # build on cuda

--- a/keras/src/layers/rnn/gru_test.py
+++ b/keras/src/layers/rnn/gru_test.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -451,7 +453,6 @@ class GRUTest(testing.TestCase):
         if not torch.cuda.is_available():
             self.skipTest("Requires a CUDA device.")
 
-        from unittest import mock
 
         x = torch.randn(4, 6, 5, device="cuda")
         layer = layers.GRU(8, return_sequences=True)
@@ -487,31 +488,28 @@ class GRUTest(testing.TestCase):
         # clone on the optimized torch path, autograd raises RuntimeError
         # on CUDA: "one of the variables needed for gradient computation
         # has been modified by an inplace operation".
-        from unittest import mock
 
         import torch
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        inputs = torch.randn(2, 3, 4, device=device)
+        if not torch.cuda.is_available():
+            self.skipTest("Requires a CUDA device.")
+
+        inputs = torch.randn(2, 3, 4, device="cuda")
         layer = layers.GRU(5, stateful=True)
+        real_vf_gru = torch._VF.gru
+        calls = []
 
-        if device == "cuda":
-            real_vf_gru = torch._VF.gru
-            calls = []
+        def spy(*args, **kwargs):
+            calls.append(True)
+            return real_vf_gru(*args, **kwargs)
 
-            def spy(*args, **kwargs):
-                calls.append(True)
-                return real_vf_gru(*args, **kwargs)
-
-            with mock.patch.object(torch._VF, "gru", side_effect=spy):
-                layer(inputs).sum().backward()
-            self.assertGreaterEqual(
-                len(calls),
-                1,
-                msg=(
-                    "torch._VF.gru was never invoked; the test did not "
-                    "exercise the cuDNN path from #23462."
-                ),
-            )
-        else:
+        with mock.patch.object(torch._VF, "gru", side_effect=spy):
             layer(inputs).sum().backward()
+        self.assertGreaterEqual(
+            len(calls),
+            1,
+            msg=(
+                "torch._VF.gru was never invoked; the test did not "
+                "exercise the cuDNN path from #23462."
+            ),
+        )

--- a/keras/src/layers/rnn/lstm.py
+++ b/keras/src/layers/rnn/lstm.py
@@ -533,6 +533,16 @@ class LSTM(RNN):
         if self.use_cudnn in ("auto", True):
             if not self.recurrent_dropout:
                 try:
+                    # Clone hidden/cell state for PyTorch + stateful. The
+                    # optimized kernel retains the initial states for
+                    # backward, while Keras then assign()s the new states
+                    # in-place (copy_), which would mutate storage autograd
+                    # still needs. The generic RNN loop already clones
+                    # inside step(); this path bypasses that copy.
+                    if self.stateful and backend.backend() == "torch":
+                        initial_state = tree.map_structure(
+                            ops.copy, initial_state
+                        )
                     if training and self.dropout:
                         dp_mask = self.cell.get_dropout_mask(sequences[:, 0, :])
                         dp_mask = ops.expand_dims(dp_mask, axis=1)

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from absl.testing import parameterized
 
+from keras.src import backend
 from keras.src import initializers
 from keras.src import layers
 from keras.src import testing
@@ -370,3 +371,39 @@ class LSTMTest(testing.TestCase):
             tpu_atol=1e-3,
             tpu_rtol=1e-3,
         )
+
+    @pytest.mark.skipif(
+        backend.backend() != "torch",
+        reason="Reproduces torch stateful LSTM backward (#23462).",
+    )
+    def test_stateful_backward(self):
+        # Same in-place state issue as stateful cuDNN GRU: the optimized
+        # kernel retains initial states for backward, then Keras copy_s
+        # into the stateful Variables.
+        import torch
+        from unittest import mock
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        inputs = torch.randn(2, 3, 4, device=device)
+        layer = layers.LSTM(5, stateful=True)
+
+        if device == "cuda":
+            real_vf_lstm = torch._VF.lstm
+            calls = []
+
+            def spy(*args, **kwargs):
+                calls.append(True)
+                return real_vf_lstm(*args, **kwargs)
+
+            with mock.patch.object(torch._VF, "lstm", side_effect=spy):
+                layer(inputs).sum().backward()
+            self.assertGreaterEqual(
+                len(calls),
+                1,
+                msg=(
+                    "torch._VF.lstm was never invoked; the test did not "
+                    "exercise the cuDNN path from #23462."
+                ),
+            )
+        else:
+            layer(inputs).sum().backward()

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -380,31 +382,28 @@ class LSTMTest(testing.TestCase):
         # Same in-place state issue as stateful cuDNN GRU: the optimized
         # kernel retains initial states for backward, then Keras copy_s
         # into the stateful Variables.
-        from unittest import mock
 
         import torch
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        inputs = torch.randn(2, 3, 4, device=device)
+        if not torch.cuda.is_available():
+            self.skipTest("Requires a CUDA device.")
+
+        inputs = torch.randn(2, 3, 4, device="cuda")
         layer = layers.LSTM(5, stateful=True)
+        real_vf_lstm = torch._VF.lstm
+        calls = []
 
-        if device == "cuda":
-            real_vf_lstm = torch._VF.lstm
-            calls = []
+        def spy(*args, **kwargs):
+            calls.append(True)
+            return real_vf_lstm(*args, **kwargs)
 
-            def spy(*args, **kwargs):
-                calls.append(True)
-                return real_vf_lstm(*args, **kwargs)
-
-            with mock.patch.object(torch._VF, "lstm", side_effect=spy):
-                layer(inputs).sum().backward()
-            self.assertGreaterEqual(
-                len(calls),
-                1,
-                msg=(
-                    "torch._VF.lstm was never invoked; the test did not "
-                    "exercise the cuDNN path from #23462."
-                ),
-            )
-        else:
+        with mock.patch.object(torch._VF, "lstm", side_effect=spy):
             layer(inputs).sum().backward()
+        self.assertGreaterEqual(
+            len(calls),
+            1,
+            msg=(
+                "torch._VF.lstm was never invoked; the test did not "
+                "exercise the cuDNN path from #23462."
+            ),
+        )

--- a/keras/src/layers/rnn/lstm_test.py
+++ b/keras/src/layers/rnn/lstm_test.py
@@ -380,8 +380,9 @@ class LSTMTest(testing.TestCase):
         # Same in-place state issue as stateful cuDNN GRU: the optimized
         # kernel retains initial states for backward, then Keras copy_s
         # into the stateful Variables.
-        import torch
         from unittest import mock
+
+        import torch
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
         inputs = torch.randn(2, 3, 4, device=device)


### PR DESCRIPTION
## Summary
- Fixes #23462: a stateful `GRU` (and the same hole in `LSTM`) fails during `backward()` on the Torch + CUDA cuDNN path because `torch._VF.gru`/`lstm` retains the initial hidden state, then Keras updates the stateful `Variable` in-place via `copy_`.
- This is the same class of bug as #20875 / #20916, which cloned state inside `RNN.inner_loop.step()`. The later optimized `GRU`/`LSTM` `inner_loop` bypasses that copy, so the cuDNN path was unprotected.
- The issue's proposed fix is the right one: clone only for `stateful` + Torch on the optimized path (`ops.copy` / `tree.map_structure(ops.copy, ...)`), so non-stateful layers do not pay an extra copy and `use_cudnn=False` keeps using the existing `step()` clone.

## Test plan
- [x] Added `GRUTest.test_stateful_backward` and `LSTMTest.test_stateful_backward` (Torch-only). On CUDA they also assert `torch._VF.gru`/`lstm` actually ran, so the test cannot silently pass via the pure-Torch fallback.
- [ ] Torch + CUDA: `pytest keras/src/layers/rnn/gru_test.py keras/src/layers/rnn/lstm_test.py -k stateful_backward`
- [ ] Confirm the original repro no longer raises:

```python
import os
os.environ["KERAS_BACKEND"] = "torch"
import keras, torch
assert torch.cuda.is_available()
inputs = torch.randn(2, 3, 4, device="cuda")
keras.layers.GRU(5, stateful=True)(inputs).sum().backward()
```

## AI-assisted contribution
An AI coding agent was used to inspect the issue, implement this patch, and draft tests. I reviewed and understand the change and take responsibility for it, per the Keras [AI-Assisted Contribution Policy](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md#ai-assisted-contribution-policy).

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.