### PR TITLE
Unify int4 string/config resolution; fix int4/None reload

### DIFF
--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -321,14 +321,21 @@ class Int4DTypePolicy(QuantizedDTypePolicy):
                 f"{expected_format}, but got '{mode}'."
             )
 
-        # Validate and cast block_size
-        try:
-            block_size = int(parts[1])
-        except ValueError:
-            raise ValueError(
-                "Invalid mode for Int4DTypePolicy. <block_size> must be an "
-                f"integer. Expected format {expected_format}, but got '{mode}'."
-            )
+        # Validate and cast block_size. Older checkpoints encoded per-channel
+        # int4 as the literal "None" in the policy string (e.g.
+        # "int4/None_from_float32"); normalize it to -1 so those checkpoints
+        # still deserialize. Both "None" and -1 mean per-channel quantization.
+        if parts[1] == "None":
+            block_size = -1
+        else:
+            try:
+                block_size = int(parts[1])
+            except ValueError:
+                raise ValueError(
+                    "Invalid mode for Int4DTypePolicy. <block_size> must be "
+                    "an integer. Expected format "
+                    f"{expected_format}, but got '{mode}'."
+                )
 
         # Validate supported values
         if block_size < -1 or block_size == 0:
@@ -344,7 +351,9 @@ class Int4DTypePolicy(QuantizedDTypePolicy):
             source_name=source_name,
         )
 
-        self._name = f"{mode}_from_{source_name}"
+        # Use the normalized block_size so a loaded "int4/None" policy reports
+        # the canonical "int4/-1" name (identical for all other block sizes).
+        self._name = f"{base_mode}/{block_size}_from_{source_name}"
         self.mode = base_mode
         self.block_size = block_size
 

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -353,7 +353,7 @@ class Int4DTypePolicy(QuantizedDTypePolicy):
 
         # Use the normalized block_size so a loaded "int4/None" policy reports
         # the canonical "int4/-1" name (identical for all other block sizes).
-        self._name = f"{base_mode}/{block_size}_from_{source_name}"
+        self._name = f"{base_mode}/{block_size}_from_{self._source_name}"
         self.mode = base_mode
         self.block_size = block_size
 

--- a/keras/src/dtype_policies/dtype_policy_test.py
+++ b/keras/src/dtype_policies/dtype_policy_test.py
@@ -6,6 +6,7 @@ from keras.src.dtype_policies import serialize
 from keras.src.dtype_policies.dtype_policy import AWQDTypePolicy
 from keras.src.dtype_policies.dtype_policy import DTypePolicy
 from keras.src.dtype_policies.dtype_policy import FloatDTypePolicy
+from keras.src.dtype_policies.dtype_policy import Int4DTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedFloat8DTypePolicy
 from keras.src.dtype_policies.dtype_policy import dtype_policy
@@ -673,6 +674,36 @@ class QuantizedDTypePolicyEdgeCasesTest(test_case.TestCase):
             QuantizedDTypePolicy(
                 mode="int8", source_name="int7_from_mixed_bfloat16"
             )
+
+
+class Int4DTypePolicyTest(test_case.TestCase):
+    @parameterized.named_parameters(
+        ("grouped_128", "int4/128_from_float32", 128),
+        ("per_channel_neg1", "int4/-1_from_float32", -1),
+        # Legacy checkpoints spelled per-channel as the literal "None".
+        ("legacy_none", "int4/None_from_float32", -1),
+    )
+    def test_parse_block_size(self, policy_name, expected_block_size):
+        policy = get(policy_name)
+        self.assertIsInstance(policy, Int4DTypePolicy)
+        self.assertEqual(policy.mode, "int4")
+        self.assertEqual(policy.block_size, expected_block_size)
+
+    def test_legacy_none_normalizes_name(self):
+        """`int4/None` must load and report the canonical `int4/-1` name."""
+        policy = get("int4/None_from_float32")
+        self.assertEqual(policy.name, "int4/-1_from_float32")
+        # It must compare equal to the explicit per-channel policy.
+        self.assertEqual(policy, get("int4/-1_from_float32"))
+
+    @parameterized.named_parameters(
+        ("non_integer", "int4/abc_from_float32"),
+        ("zero", "int4/0_from_float32"),
+        ("below_neg1", "int4/-2_from_float32"),
+    )
+    def test_invalid_block_size_rejected(self, policy_name):
+        with self.assertRaises(ValueError):
+            get(policy_name)
 
 
 class DTypePolicyGlobalFunctionsEdgeCasesTest(test_case.TestCase):

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -1171,13 +1171,16 @@ class Dense(Layer):
             self._kernel.assign(kernel_value)
             self.kernel_scale.assign(kernel_scale)
         elif mode == "int4":
-            from keras.src.quantizers.quantization_config import (
-                Int4QuantizationConfig,
-            )
-
-            block_size = None
-            if isinstance(self.quantization_config, Int4QuantizationConfig):
-                block_size = self.quantization_config.block_size
+            # Resolve the group size from the (already-resolved) config or the
+            # layer's dtype policy. `get_block_size_for_layer` is the single
+            # source of truth shared with `_int4_build` and the dtype-policy
+            # naming below, so the quantized values, the built variables, and
+            # the saved policy string can never disagree. A bare
+            # `quantize("int4")` reaches here with the canonical
+            # `Int4QuantizationConfig()` (grouped, block_size=128); a
+            # `block_size` of `None` or `-1` selects the per-channel escape
+            # hatch.
+            block_size = get_block_size_for_layer(self, config)
 
             if block_size is None or block_size == -1:
                 # Per-channel quantization

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -1697,3 +1697,112 @@ class DenseTest(testing.TestCase):
         x = np.random.rand(3, 10).astype("float32")
         y = layer(x)
         self.assertEqual(tuple(y.shape), (3, 8))
+
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_string_matches_default_config(self):
+        """`quantize("int4")` must resolve to the exact same scheme as the
+        default `Int4QuantizationConfig()` (grouped, block_size=128): identical
+        variables (names/shapes/dtypes/values), dtype policy, and outputs."""
+        input_dim, output_dim = 256, 64
+        kernel = np.random.RandomState(0).randn(input_dim, output_dim)
+        kernel = kernel.astype("float32")
+
+        def build_quantized(config):
+            layer = layers.Dense(units=output_dim)
+            layer.build((None, input_dim))
+            layer._kernel.assign(kernel)
+            layer.quantize("int4", config=config)
+            return layer
+
+        layer_str = build_quantized(config=None)
+        layer_cfg = build_quantized(config=Int4QuantizationConfig())
+
+        # Same dtype policy: grouped, block_size=128.
+        self.assertEqual(layer_str.dtype_policy.name, "int4/128_from_float32")
+        self.assertEqual(
+            layer_str.dtype_policy.name, layer_cfg.dtype_policy.name
+        )
+        self.assertEqual(layer_str._int4_block_size, 128)
+
+        # Same variables: names, shapes, dtypes, and values.
+        vars_str = {v.name: v for v in layer_str.weights}
+        vars_cfg = {v.name: v for v in layer_cfg.weights}
+        self.assertEqual(set(vars_str.keys()), set(vars_cfg.keys()))
+        for name, v_str in vars_str.items():
+            v_cfg = vars_cfg[name]
+            self.assertEqual(tuple(v_str.shape), tuple(v_cfg.shape))
+            self.assertEqual(
+                backend.standardize_dtype(v_str.dtype),
+                backend.standardize_dtype(v_cfg.dtype),
+            )
+            self.assertAllClose(v_str, v_cfg)
+
+        # Same outputs.
+        x = np.random.RandomState(1).randn(4, input_dim).astype("float32")
+        self.assertAllClose(layer_str(x), layer_cfg(x))
+
+    @parameterized.named_parameters(
+        ("none", None),
+        ("neg1", -1),
+    )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_per_channel_escape_hatch(self, block_size):
+        """`block_size=None` and `block_size=-1` both select the per-channel
+        escape hatch: one scale per output channel, no zero-point / g_idx, and
+        an `int4/-1` dtype policy."""
+        input_dim, output_dim = 256, 64
+        layer = layers.Dense(units=output_dim)
+        layer.build((None, input_dim))
+        layer.quantize(
+            "int4", config=Int4QuantizationConfig(block_size=block_size)
+        )
+        self.assertEqual(tuple(layer.kernel_scale.shape), (output_dim,))
+        self.assertFalse(hasattr(layer, "kernel_zero"))
+        self.assertFalse(hasattr(layer, "g_idx"))
+        self.assertEqual(layer.dtype_policy.name, "int4/-1_from_float32")
+
+    @parameterized.named_parameters(
+        ("block_none", "None", True),
+        ("block_neg1", "-1", True),
+        ("block_128", "128", False),
+    )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_policy_string_reload_builds_right_variables(
+        self, block_token, per_channel
+    ):
+        """Old checkpoints identified only by their int4 dtype-policy string
+        must deserialize and rebuild the correct variables. Covers the legacy
+        `int4/None` spelling of per-channel plus `int4/-1` and `int4/128`."""
+        input_dim, output_dim = 256, 64
+        policy = f"int4/{block_token}_from_float32"
+        layer = layers.Dense(units=output_dim, dtype=policy)
+        layer.build((None, input_dim))
+
+        self.assertEqual(layer.quantization_mode, "int4")
+        if per_channel:
+            self.assertEqual(tuple(layer.kernel_scale.shape), (output_dim,))
+            self.assertFalse(hasattr(layer, "g_idx"))
+        else:
+            block_size = int(block_token)
+            n_groups = math.ceil(input_dim / block_size)
+            self.assertEqual(
+                tuple(layer.kernel_scale.shape), (n_groups, output_dim)
+            )
+            self.assertTrue(hasattr(layer, "g_idx"))
+            self.assertEqual(tuple(layer.g_idx.shape), (input_dim,))
+
+        # The packed kernel is always [input_dim, ceil(output_dim / 2)] int8.
+        self.assertEqual(
+            tuple(layer._kernel.shape), (input_dim, (output_dim + 1) // 2)
+        )
+        self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
+
+        # A forward pass runs without error.
+        x = np.random.random((2, input_dim)).astype("float32")
+        self.assertEqual(tuple(layer(x).shape), (2, output_dim))

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -1319,14 +1319,12 @@ class EinsumDense(Layer):
             kernel_scale = self._adjust_scale_for_quant(kernel_scale, "kernel")
             del self._kernel
         elif mode == "int4":
-            from keras.src.quantizers.quantization_config import (
-                Int4QuantizationConfig,
-            )
-
-            block_size = None
-            if isinstance(self.quantization_config, Int4QuantizationConfig):
-                block_size = self.quantization_config.block_size
-
+            # `get_block_size_for_layer` is the single source of truth for the
+            # group size, shared with `_int4_build` and the dtype-policy naming
+            # below (see `Dense.quantize`). A bare `quantize("int4")` resolves
+            # to the canonical `Int4QuantizationConfig()` (grouped,
+            # block_size=128); `None`/`-1` selects per-channel.
+            block_size = get_block_size_for_layer(self, config)
             use_grouped = block_size is not None and block_size != -1
 
             # Flatten kernel to 2D: rows = reduced dims, columns = non-reduced

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1984,3 +1984,102 @@ class EinsumDenseTest(testing.TestCase):
         # Verify outputs match
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
+
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_string_matches_default_config(self):
+        """`quantize("int4")` must resolve to the exact same scheme as the
+        default `Int4QuantizationConfig()` (grouped, block_size=128): identical
+        variables (names/shapes/dtypes/values), dtype policy, and outputs."""
+        input_dim, output_dim = 256, 64
+        kernel = np.random.RandomState(0).randn(input_dim, output_dim)
+        kernel = kernel.astype("float32")
+
+        def build_quantized(config):
+            layer = layers.EinsumDense(
+                equation="ab,bc->ac", output_shape=(output_dim,), bias_axes="c"
+            )
+            layer.build((None, input_dim))
+            layer._kernel.assign(kernel)
+            layer.quantize("int4", config=config)
+            return layer
+
+        layer_str = build_quantized(config=None)
+        layer_cfg = build_quantized(config=Int4QuantizationConfig())
+
+        self.assertEqual(layer_str.dtype_policy.name, "int4/128_from_float32")
+        self.assertEqual(
+            layer_str.dtype_policy.name, layer_cfg.dtype_policy.name
+        )
+
+        vars_str = {v.name: v for v in layer_str.weights}
+        vars_cfg = {v.name: v for v in layer_cfg.weights}
+        self.assertEqual(set(vars_str.keys()), set(vars_cfg.keys()))
+        for name, v_str in vars_str.items():
+            v_cfg = vars_cfg[name]
+            self.assertEqual(tuple(v_str.shape), tuple(v_cfg.shape))
+            self.assertEqual(
+                backend.standardize_dtype(v_str.dtype),
+                backend.standardize_dtype(v_cfg.dtype),
+            )
+            self.assertAllClose(v_str, v_cfg)
+
+        x = np.random.RandomState(1).randn(4, input_dim).astype("float32")
+        self.assertAllClose(layer_str(x), layer_cfg(x))
+
+    @parameterized.named_parameters(
+        ("none", None),
+        ("neg1", -1),
+    )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_per_channel_escape_hatch(self, block_size):
+        """`block_size=None` and `block_size=-1` both select the per-channel
+        escape hatch: no zero-point / g_idx and an `int4/-1` dtype policy."""
+        layer = layers.EinsumDense(
+            equation="ab,bc->ac", output_shape=(64,), bias_axes="c"
+        )
+        layer.build((None, 256))
+        layer.quantize(
+            "int4", config=Int4QuantizationConfig(block_size=block_size)
+        )
+        self.assertFalse(hasattr(layer, "kernel_zero"))
+        self.assertFalse(hasattr(layer, "g_idx"))
+        self.assertEqual(layer.dtype_policy.name, "int4/-1_from_float32")
+
+    @parameterized.named_parameters(
+        ("block_none", "None", True),
+        ("block_neg1", "-1", True),
+        ("block_128", "128", False),
+    )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_policy_string_reload_builds_right_variables(
+        self, block_token, per_channel
+    ):
+        """Old checkpoints identified only by their int4 dtype-policy string
+        must deserialize and rebuild the correct variables. Covers the legacy
+        `int4/None` spelling of per-channel plus `int4/-1` and `int4/128`."""
+        input_dim, output_dim = 256, 64
+        policy = f"int4/{block_token}_from_float32"
+        layer = layers.EinsumDense(
+            equation="ab,bc->ac",
+            output_shape=(output_dim,),
+            bias_axes="c",
+            dtype=policy,
+        )
+        layer.build((None, input_dim))
+
+        self.assertEqual(layer.quantization_mode, "int4")
+        if per_channel:
+            self.assertFalse(hasattr(layer, "g_idx"))
+        else:
+            self.assertTrue(hasattr(layer, "g_idx"))
+            self.assertEqual(tuple(layer.g_idx.shape), (input_dim,))
+        self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
+
+        x = np.random.random((2, input_dim)).astype("float32")
+        self.assertEqual(tuple(layer(x).shape), (2, output_dim))

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -599,14 +599,12 @@ class Embedding(Layer):
             self._embeddings.assign(embeddings_value)
             self.embeddings_scale.assign(embeddings_scale)
         elif mode == "int4":
-            from keras.src.quantizers.quantization_config import (
-                Int4QuantizationConfig,
-            )
-
-            block_size = None
-            if isinstance(self.quantization_config, Int4QuantizationConfig):
-                block_size = self.quantization_config.block_size
-
+            # `get_block_size_for_layer` is the single source of truth for the
+            # group size, shared with `_int4_build` and the dtype-policy naming
+            # below (see `Dense.quantize`). A bare `quantize("int4")` resolves
+            # to the canonical `Int4QuantizationConfig()` (grouped,
+            # block_size=128); `None`/`-1` selects per-channel.
+            block_size = get_block_size_for_layer(self, config)
             use_grouped = block_size is not None and block_size != -1
 
             if not use_grouped:

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -985,3 +985,104 @@ class EmbeddingTest(test_case.TestCase):
         # Verify outputs match
         y_after = loaded_model(x)
         self.assertAllClose(y_before, y_after)
+
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_string_matches_default_config(self):
+        """`quantize("int4")` must resolve to the exact same scheme as the
+        default `Int4QuantizationConfig()` (grouped, block_size=128): identical
+        variables (names/shapes/dtypes/values), dtype policy, and outputs."""
+        input_dim, output_dim = 32, 256
+        embeddings = np.random.RandomState(0).randn(input_dim, output_dim)
+        embeddings = embeddings.astype("float32")
+
+        def build_quantized(config):
+            layer = layers.Embedding(input_dim=input_dim, output_dim=output_dim)
+            layer.build()
+            layer._embeddings.assign(embeddings)
+            layer.quantize("int4", config=config)
+            return layer
+
+        layer_str = build_quantized(config=None)
+        layer_cfg = build_quantized(config=Int4QuantizationConfig())
+
+        self.assertEqual(layer_str.dtype_policy.name, "int4/128_from_float32")
+        self.assertEqual(
+            layer_str.dtype_policy.name, layer_cfg.dtype_policy.name
+        )
+
+        vars_str = {v.name: v for v in layer_str.weights}
+        vars_cfg = {v.name: v for v in layer_cfg.weights}
+        self.assertEqual(set(vars_str.keys()), set(vars_cfg.keys()))
+        for name, v_str in vars_str.items():
+            v_cfg = vars_cfg[name]
+            self.assertEqual(tuple(v_str.shape), tuple(v_cfg.shape))
+            self.assertEqual(
+                backend.standardize_dtype(v_str.dtype),
+                backend.standardize_dtype(v_cfg.dtype),
+            )
+            self.assertAllClose(v_str, v_cfg)
+
+        x = np.array([[1, 2, 3], [4, 5, 6]], dtype="int32")
+        self.assertAllClose(layer_str(x), layer_cfg(x))
+
+    @parameterized.named_parameters(
+        ("none", None),
+        ("neg1", -1),
+    )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_per_channel_escape_hatch(self, block_size):
+        """`block_size=None` and `block_size=-1` both select the per-channel
+        escape hatch: no zero-point / g_idx and an `int4/-1` dtype policy."""
+        layer = layers.Embedding(input_dim=32, output_dim=256)
+        layer.build()
+        layer.quantize(
+            "int4", config=Int4QuantizationConfig(block_size=block_size)
+        )
+        self.assertEqual(tuple(layer.embeddings_scale.shape), (32,))
+        self.assertFalse(hasattr(layer, "embeddings_zero"))
+        self.assertFalse(hasattr(layer, "g_idx"))
+        self.assertEqual(layer.dtype_policy.name, "int4/-1_from_float32")
+
+    @parameterized.named_parameters(
+        ("block_none", "None", True),
+        ("block_neg1", "-1", True),
+        ("block_128", "128", False),
+    )
+    @pytest.mark.skipif(
+        testing.tensorflow_uses_gpu(), reason="Segfault on Tensorflow GPU"
+    )
+    def test_int4_policy_string_reload_builds_right_variables(
+        self, block_token, per_channel
+    ):
+        """Old checkpoints identified only by their int4 dtype-policy string
+        must deserialize and rebuild the correct variables. Covers the legacy
+        `int4/None` spelling of per-channel plus `int4/-1` and `int4/128`."""
+        input_dim, output_dim = 32, 256
+        policy = f"int4/{block_token}_from_float32"
+        layer = layers.Embedding(
+            input_dim=input_dim, output_dim=output_dim, dtype=policy
+        )
+        layer.build()
+
+        self.assertEqual(layer.quantization_mode, "int4")
+        if per_channel:
+            self.assertEqual(tuple(layer.embeddings_scale.shape), (input_dim,))
+            self.assertFalse(hasattr(layer, "g_idx"))
+        else:
+            block_size = int(block_token)
+            n_groups = math.ceil(output_dim / block_size)
+            self.assertEqual(
+                tuple(layer.embeddings_scale.shape), (input_dim, n_groups)
+            )
+            self.assertTrue(hasattr(layer, "g_idx"))
+            self.assertEqual(tuple(layer.g_idx.shape), (output_dim,))
+        self.assertEqual(
+            backend.standardize_dtype(layer._embeddings.dtype), "int8"
+        )
+
+        x = np.array([[1, 2, 3], [4, 5, 6]], dtype="int32")
+        self.assertEqual(tuple(layer(x).shape), (2, 3, output_dim))

--- a/keras/src/models/model.py
+++ b/keras/src/models/model.py
@@ -482,7 +482,28 @@ class Model(Trainer, base_trainer.Trainer, Layer):
         Args:
             mode: The mode of the quantization. Supported modes are:
                 `"int8"`, `"int4"`, `"float8"`, `"gptq"`, `"awq"`. This is
-                optional if `config` is provided.
+                optional if `config` is provided. Passing a bare string uses
+                the default configuration for that mode, which is identical to
+                passing the corresponding config object with default arguments
+                (e.g. `quantize("int4")` matches
+                `quantize(config=Int4QuantizationConfig())`). The activation
+                (A) times weight (W) semantics of each mode are:
+
+                -   `"int8"`: **W8A8 dynamic**. Weights and activations are both
+                    quantized to `int8` and multiplied with a real integer
+                    GEMM; activation scales are computed dynamically per call.
+                -   `"int4"`: **W4A16 weight-only**, **grouped** with
+                    `block_size=128` by default. Only weights are quantized (to
+                    4 bits, packed two per `int8` byte); this is storage-only
+                    today (weights are dequantized to float before each
+                    matmul). Pass `Int4QuantizationConfig(block_size=-1)` for
+                    per-channel.
+                -   `"float8"`: **float8 QDQ** mixed-precision training scheme
+                    (not post-training compression); weights and activations
+                    are dynamically cast to `float8` during training.
+                -   `"gptq"` / `"awq"`: 4-bit weight-only post-training
+                    quantization; requires a `GPTQConfig` / `AWQConfig` passed
+                    via `config`.
             config: The configuration object specifying additional
                 quantization options. This argument allows to configure
                 the weight and activation quantizers. be an instance of

--- a/keras/src/quantizers/quantization_config.py
+++ b/keras/src/quantizers/quantization_config.py
@@ -66,6 +66,11 @@ class QuantizationConfig:
 class Int8QuantizationConfig(QuantizationConfig):
     """Int8 quantization config.
 
+    Scheme: **W8A8 dynamic** (`int8` weights times `int8` activations). Both
+    the weights and the activations are quantized to 8-bit integers, and the
+    matmul runs as a real integer GEMM. Activation scales are computed
+    dynamically at run time (per call), so no calibration data is required.
+
     Args:
         weight_quantizer: Quantizer for weights.
         activation_quantizer: Quantizer for activations. If "default", uses
@@ -95,15 +100,27 @@ class Int8QuantizationConfig(QuantizationConfig):
 class Int4QuantizationConfig(QuantizationConfig):
     """Int4 quantization config.
 
+    Scheme: **W4A16 weight-only** (`int4` weights times `float16`/high-precision
+    activations). Only the weights are quantized to 4 bits (packed two per
+    `int8` byte); activations stay in the compute dtype. This is
+    **storage-only** today: the packed weights are dequantized back to float
+    before every matmul, so it reduces the model's memory footprint but does
+    not (yet) run a 4-bit GEMM. By default the weights use **grouped**
+    (sub-channel) quantization with a group size of 128 along the input
+    dimension, which is more accurate than per-channel at scale. Pass
+    `block_size=-1` (or `None`) for the per-channel escape hatch.
+
     Args:
         weight_quantizer: Quantizer for weights.
         activation_quantizer: Quantizer for activations. If "default", uses
-            AbsMaxQuantizer with axis=-1.
+            weight-only quantization (activations are left unquantized).
         block_size: Size of groups along the input dimension for sub-channel
             quantization. If a positive integer, uses sub-channel quantization
             with `ceil(input_dim / block_size)` groups. If `None` or `-1`,
             uses per-channel quantization (one scale per output channel).
-            Default: `128` (sub-channel with 128-element groups).
+            Default: `128` (sub-channel with 128-element groups). This default
+            is identical to what the bare string shortcut `quantize("int4")`
+            resolves to.
     """
 
     def __init__(
@@ -184,6 +201,12 @@ class Int4QuantizationConfig(QuantizationConfig):
 @keras_export("keras.quantizers.Float8QuantizationConfig")
 class Float8QuantizationConfig(QuantizationConfig):
     """FP8 quantization config.
+
+    Scheme: **float8 QDQ** (quantize-dequantize) mixed-precision *training*.
+    Unlike the int8/int4 schemes, this is not a post-training weight
+    compression: both weights and activations are dynamically cast to `float8`
+    with maintained amax histories, and the forward/backward passes simulate
+    fp8 arithmetic to keep training numerically faithful.
 
     FP8 mixed-precision training does not support user defined quantizers.
     This config is only used to indicate that FP8 mixed-precision training


### PR DESCRIPTION
## Description

`quantize("int4")` and `quantize("int4", config=Int4QuantizationConfig())` are meant to resolve to one canonical scheme (grouped, block_size=128, weight-only). At the public API they already do, because the `quantize` wrapper in `layer.py` runs `validate_and_resolve_config`, which turns the bare string into the default `Int4QuantizationConfig()`. But each layer's `quantize()` (`Dense`, `EinsumDense`, `Embedding`) then re-derived the group size a second time with a *different* default:

```py
    block_size = None
    if isinstance(self.quantization_config, Int4QuantizationConfig):
        block_size = self.quantization_config.block_size
```

This local path silently falls back to per-channel (`None`) and duplicates `get_block_size_for_layer`, which `_int4_build` and the dtype-policy naming in the same method already use. Two resolution paths that must agree is a latent divergence. Separately, the legacy per-channel policy string `int4/None_from_*` failed to deserialize (`int("None")` raised), so a checkpoint identified by that string could not be loaded.

## Changes

- `Dense`, `EinsumDense`, `Embedding` `quantize()` now derive `block_size` from the single canonical helper `get_block_size_for_layer(self, config)`, removing the redundant `None`-defaulting branch and the local `Int4QuantizationConfig` import. The quantized values, the built variables, and the saved policy string now share one source of truth.
- `Int4DTypePolicy` accepts the legacy `int4/None` spelling and normalizes it to `-1` (per-channel), so `int4/None_from_*`, `int4/-1_from_*`, and `int4/128_from_*` all deserialize and rebuild the right variables.
- Docstrings for `Model.quantize`, `Int8/Int4/Float8QuantizationConfig` now state the A x W semantics of every mode: int8 = W8A8 dynamic (real int8 GEMM); int4 = W4A16 grouped g128 weight-only, storage-only today (weights dequantized before each matmul); float8 = QDQ mixed-precision training.

## Verification

This  script quantizes a `Dense(64)`, `input_dim=256`, three ways and prints variables + outputs; before/after captured on master vs this branch. Gist: https://gist.github.com/JyotinderSingh/cec90c952782a90fa6b1068c56cd9b54

- String vs default-config: Identical variables and outputs on both master and branch (A vs B max abs diff = 0.0; both dtype policy int4/128), grouped g128 kernel_scale (2, 64) with kernel_zero + g_idx. Per-channel (block_size =-1) differs as expected (kernel_scale (64,), no g_idx). This refactor is behavior-preserving at the public API and removes the redundant path.
- Old-checkpoint policy reload, the one behavioral fix: master:  int4/None_from_float32 -> FAIL (ValueError, must be an integer)
    branch:  int4/None_from_float32 -> OK   (name int4/-1_from_float32, bs=-1)
  int4/-1 and int4/128 load OK on both.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.