### PR TITLE
Fix sparsemax threshold when more than one logit is in the support

### DIFF
--- a/keras/src/activations/activations_test.py
+++ b/keras/src/activations/activations_test.py
@@ -992,6 +992,23 @@ class ActivationsTest(testing.TestCase):
             activations.sparsemax(x_3d, axis=-3), expected_result
         )
 
+        # Closely spaced logits keep more than one coordinate in the
+        # support. Every case above expects a one hot result, which only
+        # exercises a support of size one.
+        x_dense = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+        expected_result = np.array([0.0, 0.1, 0.2, 0.3, 0.4])
+        self.assertAllClose(activations.sparsemax(x_dense), expected_result)
+
+        # sparsemax projects onto the probability simplex, so whatever the
+        # support size, each slice along the axis sums to one.
+        x_2d = np.array([[0.1, 0.2, 0.3], [-1.0, 0.5, 0.4]])
+        self.assertAllClose(
+            np.sum(
+                backend.convert_to_numpy(activations.sparsemax(x_2d)), axis=-1
+            ),
+            np.ones(2),
+        )
+
         # result check with axis=-3 with 4d input
         x_4d = np.linspace(1, 12, num=12).reshape(-1, 1, 1, 2)
         expected_result = np.ones_like(x_4d)

--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -178,8 +178,8 @@ def sparsemax(x, axis=-1):
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
     k = jnp.sum(support, axis=axis, keepdims=True)
-    logits_cumsum_safe = jnp.where(support, logits_cumsum, 0.0)
-    tau = (jnp.sum(logits_cumsum_safe, axis=axis, keepdims=True) - 1) / k
+    logits_sorted_safe = jnp.where(support, logits_sorted, 0.0)
+    tau = (jnp.sum(logits_sorted_safe, axis=axis, keepdims=True) - 1) / k
     output = jnp.maximum(logits - tau, 0.0)
     return output
 

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -229,8 +229,8 @@ def sparsemax(x, axis=-1):
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
     k = np.sum(support, axis=axis, keepdims=True)
-    logits_cumsum_safe = np.where(support, logits_cumsum, 0.0)
-    tau = (np.sum(logits_cumsum_safe, axis=axis, keepdims=True) - 1) / k
+    logits_sorted_safe = np.where(support, logits_sorted, 0.0)
+    tau = (np.sum(logits_sorted_safe, axis=axis, keepdims=True) - 1) / k
     output = np.maximum(logits - tau, 0.0)
     return output
 

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -269,7 +269,7 @@ def sparsemax(x, axis=-1):
         ov_opset.convert(support, et).output(0), axis_1d, True
     ).output(0)
     sum_safe = ov_opset.reduce_sum(
-        ov_opset.select(support, logits_cumsum, zero_fp).output(0),
+        ov_opset.select(support, logits_sorted, zero_fp).output(0),
         axis_1d,
         True,
     ).output(0)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -197,9 +197,9 @@ def sparsemax(x, axis=-1):
     r = tf.reshape(r, r_shape)  # Reshape for broadcasting
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
-    logits_cumsum_safe = tf.where(support, logits_cumsum, 0.0)
+    logits_sorted_safe = tf.where(support, logits_sorted, 0.0)
     k = tf.reduce_sum(tf.cast(support, logits.dtype), axis=axis, keepdims=True)
-    tau = (tf.reduce_sum(logits_cumsum_safe, axis=axis, keepdims=True) - 1) / k
+    tau = (tf.reduce_sum(logits_sorted_safe, axis=axis, keepdims=True) - 1) / k
     output = tf.maximum(logits - tau, 0.0)
     return output
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -210,10 +210,10 @@ def sparsemax(x, axis=-1):
     support = logits_sorted - (logits_cumsum - 1) / r > 0
     # Find the threshold
     k = torch.sum(support, dim=axis, keepdim=True)
-    logits_cumsum_safe = torch.where(
-        support, logits_cumsum, torch.tensor(0.0, device=logits.device)
+    logits_sorted_safe = torch.where(
+        support, logits_sorted, torch.tensor(0.0, device=logits.device)
     )
-    tau = (torch.sum(logits_cumsum_safe, dim=axis, keepdim=True) - 1) / k
+    tau = (torch.sum(logits_sorted_safe, dim=axis, keepdim=True) - 1) / k
     output = torch.clamp(logits - tau, min=0.0)
     return output
 


### PR DESCRIPTION
## Description

`sparsemax` builds its threshold from the sum of the cumulative sums across the support rather than the cumulative sum at the last supported index, so `tau` comes out too large whenever more than one logit survives. All five backends carry the same expression.

On master `sparsemax([0.1, 0.2, 0.3, 0.4, 0.5])` returns all zeros, where it should return `[0, 0.1, 0.2, 0.3, 0.4]`. sparsemax projects onto the probability simplex, so the output has to sum to one and an all zero result is unambiguous rather than a tolerance question. Across 200 random inputs only 7 match a reference implementation of the Martins and Astudillo algorithm, and that holds on jax, torch, tensorflow and numpy alike. openvino has it too, which its own CI run on this PR caught.

The fix is to sum the sorted logits over the support instead of their cumulative sums. That is the same quantity as the cumulative sum at the last supported index, so it needs no new ops and stays a one line change per backend. Afterwards all of them match the reference on 200 of 200.

The existing tests miss it because every case uses `np.linspace(1, 12, ...)` and expects a one hot result, which only exercises a support of size one, and at that size the two expressions happen to agree. This adds a case with closely spaced logits and a check that each slice along the axis sums to one. Both fail on master and pass with the fix.

Found while porting sparsemax to the mlx backend in keras-team/keras-mlx. The port carried the same expression across, and chasing why its output did not sum to one led back here.

Tested with `keras/src/activations/activations_test.py` and `keras/src/ops/nn_test.py` on the jax, tensorflow, torch, numpy and openvino backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
