### PR TITLE
Set Dependabot GitHub Actions updates to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,12 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Configuration for Dependabot version updates.
+# Documentation: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
### Summary
Updates `.github/dependabot.yml` to check for GitHub Actions version updates on a weekly schedule (instead of monthly).

### Benefits
- Automatically opens PRs when new commit SHA pins or release tags are published in [keras-team/shared-workflows](https://github.com/keras-team/shared-workflows) or external actions.
- Keeps reusable workflows up-to-date with zero manual tracking toil.

### Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.