### PR TITLE
Fix division-by-zero in gptq_quantize_matrix

### DIFF
--- a/keras/src/quantizers/gptq.py
+++ b/keras/src/quantizers/gptq.py
@@ -188,6 +188,16 @@ def gptq_quantize_matrix(
             # Error feedback for remaining columns within the block
             # block_inv_hessian_diag: scalar
             current_block_influence = block_inv_hessian[block_idx, block_idx]
+            # A (near-)zero diagonal element of the inverse Hessian makes
+            # the error term blow up to NaN/Inf and silently corrupts all
+            # subsequent weight updates. Guard the division with a small
+            # epsilon (sign-preserving) so quantization always completes.
+            eps = 1e-8
+            current_block_influence = ops.where(
+                ops.abs(current_block_influence) < eps,
+                ops.where(current_block_influence < 0, -eps, eps),
+                current_block_influence,
+            )
             # We divide by current_block_influence to get the
             # correct scaling of the error term.
             err = ops.divide(

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -335,6 +335,43 @@ class GPTQTest(testing.TestCase):
 
         self.assertAllClose(dequantized_weights, out, atol=1e-6)
 
+    def test_zero_diagonal_inv_hessian_does_not_corrupt_weights(self):
+        """A zero inverse-Hessian diagonal must not corrupt other columns.
+
+        Regression test for a division-by-zero in `gptq_quantize_matrix`:
+        if a diagonal element of the inverse Hessian underflows to zero,
+        the error term becomes NaN/Inf and silently corrupts all subsequent
+        weight columns (the corrupted values cast to garbage integers,
+        rendering the quantized matrix unusable).
+
+        With off-diagonal elements equal to zero, a finite error term cannot
+        affect any other column, so quantizing with a zero diagonal must give
+        the same result as quantizing with a healthy diagonal.
+        """
+        in_features, out_features = 16, 8
+        weights = ops.reshape(
+            ops.linspace(
+                -0.9, 1.1, in_features * out_features, dtype="float32"
+            ),
+            (in_features, out_features),
+        )
+        weights_transpose = ops.transpose(weights)
+
+        def quantize(diagonal_value):
+            inverse_hessian = np.eye(in_features, dtype=np.float32)
+            inverse_hessian[2, 2] = diagonal_value
+            quantized_weights, _, _, _ = gptq_quantize_matrix(
+                weights_transpose,
+                ops.array(inverse_hessian, dtype="float32"),
+                blocksize=4,
+                group_size=1,  # per-column quantization
+                activation_order=False,
+                compute_scale_zero=_compute_scale_zero,
+            )
+            return ops.convert_to_numpy(quantized_weights)
+
+        self.assertAllClose(quantize(0.0), quantize(1.0))
+
     def test_activation_order_produces_equivalent_weights(self):
         """
         Tests that quantizing with `activation_order=True` yields the same


### PR DESCRIPTION
## Description

Fixes #23413.

In `gptq_quantize_matrix` the error feedback term is computed by dividing by `inv_hessian[j, j]`. When a diagonal element of the inverse Hessian underflows to `0.0` (e.g. under some backends / precision settings), this division produces `NaN`/`Inf`, which silently corrupts every subsequent weight column (the corrupted weights cast to garbage integers such as `INT32_MIN`, rendering the quantized matrix unusable — see the reproducer in the issue).

**Fix:** guard the division with a small sign-preserving epsilon (`1e-8`), so the error feedback stays finite and quantization always completes. This matches the expected behavior described in the issue.

**Test:** added `test_zero_diagonal_inv_hessian_does_not_corrupt_weights`. It leverages the fact that when the off-diagonal elements of the inverse Hessian are zero, a *finite* error term cannot affect any other column — so quantizing with a zero diagonal element must produce exactly the same result as quantizing with a healthy diagonal. Verified that the test fails without the fix (JAX backend) and passes with it; the full `gptq_test.py` and `gptq_core_test.py` suites pass (63 tests).

**AI disclosure (per the AI-Assisted Contribution Policy):** this PR was prepared with an AI coding assistant acting under my direction. I have reviewed the changes, verified the fix and the regression test locally, and I take full responsibility for this contribution. I will respond to review comments.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.