### PR TITLE
Fix Zizmor CI Failure by updating dorny/paths-filter to v4.0.3

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
 
       - name: Check for changes in keras/src/applications
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Upstream `dorny/paths-filter` updated tag `v4` to `ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d` (`v4.0.3`), causing Zizmor to flag the older `v4.0.2` SHA pin as out of sync with tag `v4`. Updating the SHA pin and version comment to `v4.0.3` resolves the Zizmor security failure cleanly without needing an ignore directive.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.