### PR TITLE
Preserve compile config after HDF5 save

### DIFF
--- a/keras/src/legacy/saving/legacy_h5_format_test.py
+++ b/keras/src/legacy/saving/legacy_h5_format_test.py
@@ -143,6 +143,16 @@ class LegacyH5WholeModelTest(testing.TestCase):
         ref_input = np.random.random((1, 3))
         self._check_reloading_model(ref_input, model)
 
+    def test_saving_preserves_compile_config(self):
+        model = models.Sequential([layers.Input((3,)), layers.Dense(2)])
+        model.compile(optimizer="adam", loss="mean_squared_error")
+        compile_config = model.get_compile_config()
+
+        temp_filepath = os.path.join(self.get_temp_dir(), "model.h5")
+        legacy_h5_format.save_model_to_hdf5(model, temp_filepath)
+
+        self.assertEqual(model.get_compile_config(), compile_config)
+
     def test_saving_lambda(self):
         mean = ops.random.uniform((4, 2, 3))
         std = ops.abs(ops.random.uniform((4, 2, 3))) + 1e-5

--- a/keras/src/legacy/saving/saving_utils.py
+++ b/keras/src/legacy/saving/saving_utils.py
@@ -112,7 +112,7 @@ def model_metadata(model, include_optimizer=True, require_config=True):
     )
     if getattr(model, "optimizer", False) and include_optimizer:
         if model.compiled:
-            training_config = model._compile_config.config
+            training_config = model._compile_config.config.copy()
             training_config.pop("optimizer", None)  # Handled separately.
             metadata["training_config"] = _serialize_nested_config(
                 training_config


### PR DESCRIPTION
## Description

Saving a compiled model to legacy HDF5 currently mutates the live model's compile configuration. `model_metadata()` takes a direct reference to `model._compile_config.config` and removes its `optimizer` entry while preparing the separate legacy optimizer metadata.

After one `.h5` save, `model.get_compile_config()` therefore no longer contains the optimizer. A later native `.keras` save and load can silently compile the restored model with the default RMSprop optimizer instead of the original optimizer (for example, Adam).

This change copies the compile configuration before removing the legacy-only duplicate optimizer entry. The HDF5 metadata remains unchanged, while saving no longer modifies the model being saved.

A regression test verifies that the complete public compile configuration is identical before and after an HDF5 save.

## Tests

- `KERAS_BACKEND=torch .venv/bin/pytest -q keras/src/legacy/saving/legacy_h5_format_test.py` (12 passed, 11 skipped, 2 subtests passed)
- `KERAS_BACKEND=tensorflow .venv/bin/pytest -q keras/src/legacy/saving/legacy_h5_format_test.py::LegacyH5WholeModelTest::test_saving_preserves_compile_config` (1 passed)
- `KERAS_BACKEND=jax .venv/bin/pytest -q keras/src/legacy/saving/legacy_h5_format_test.py::LegacyH5WholeModelTest::test_saving_preserves_compile_config` (1 passed)
- `pre-commit run --files keras/src/legacy/saving/saving_utils.py keras/src/legacy/saving/legacy_h5_format_test.py` (API generation, Ruff lint, and Ruff format passed)

## AI-assisted contribution disclosure

AI assistance was used during code inspection and regression-test preparation. I personally reviewed and understand every changed line, reproduced the failure before the fix, and ran all validation listed above. I take full responsibility for the contribution and will respond to maintainer feedback myself.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.