### PR TITLE
Fix three documented defaults that the signatures do not have

### DIFF
--- a/keras/src/applications/resnet.py
+++ b/keras/src/applications/resnet.py
@@ -306,7 +306,7 @@ def residual_block_v2(
         kernel_size: Kernel size of the bottleneck layer. Defaults to `3`.
         stride: Stride of the first layer. Defaults to `1`.
         conv_shortcut: Use convolution shortcut if `True`, otherwise
-            use identity shortcut. Defaults to `True`
+            use identity shortcut. Defaults to `False`
         name(optional): Name of the block
 
     Returns:

--- a/keras/src/ops/image.py
+++ b/keras/src/ops/image.py
@@ -2447,7 +2447,7 @@ def elastic_transform(
             and `"bilinear"`. Defaults to `"bilinear"`.
         fill_mode: Points outside the boundaries of the input are filled
             according to the given mode. Available methods are `"constant"`,
-            `"nearest"`, `"wrap"` and `"reflect"`. Defaults to `"constant"`.
+            `"nearest"`, `"wrap"` and `"reflect"`. Defaults to `"reflect"`.
             - `"reflect"`: `(d c b a | a b c d | d c b a)`
                 The input is extended by reflecting about the edge of the last
                 pixel.

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -520,7 +520,7 @@ def deserialize_keras_object(
         config: Python dict describing the object.
         custom_objects: Python dict containing a mapping between custom
             object names the corresponding classes or functions.
-        safe_mode: Boolean, defaults to False. If True, disables unsafe
+        safe_mode: Boolean, defaults to `True`. If `True`, disables unsafe
             lambda deserialization.
 
             Note that safe_mode is designed to protect against code


### PR DESCRIPTION
Three docstrings name a default the signature does not have. One of them is about a security control, which is why I am sending these together rather than sitting on them.

| where | docstring says | signature says |
|---|---|---|
| `serialization_lib.deserialize_keras_object` | `safe_mode` defaults to `False` | `safe_mode=True` |
| `applications.resnet.residual_block_v2` | `conv_shortcut` defaults to `True` | `conv_shortcut=False` |
| `ops.image.elastic_transform` | `fill_mode` defaults to `"constant"` | `fill_mode="reflect"` |

**`safe_mode`.** The line reads as if the protection against unsafe `lambda` deserialization is off until you ask for it. It has been on by default. Someone reading the docstring and wanting the safe behaviour would conclude they need to pass `safe_mode=True`, and someone reading it and wanting a lambda to load might reach for `safe_mode=False` without understanding they are turning something off.

**`residual_block_v2`.** `residual_block_v1` sits directly above it, really does default to `True`, and is documented correctly. That is most likely how the copy went wrong.

**`elastic_transform`.** Every other function in `ops/image.py` defaults `fill_mode` to `"constant"`. This one is the exception, and the docstring followed the house rule rather than the code.

Documentation only, no behaviour change.

How I found them: a checker I wrote that compares a documented default against the literal in the signature. `safe_mode` and `elastic_transform` only became visible after I taught it to join wrapped description lines, since in both the words "Defaults to" sit at the end of one line and the value on the next.


## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
