### PR TITLE
Align AWQ with reference (mean stat, weight-aware scale, clipping)

### DIFF
--- a/keras/src/quantizers/awq.py
+++ b/keras/src/quantizers/awq.py
@@ -40,7 +40,7 @@ def _get_weight_scale(weights, group_size):
         Per-in-channel weight statistic ``[in_features]``.
     """
     weights = ops.cast(weights, "float32")
-    out_features, in_features = weights.shape
+    out_features, in_features = ops.shape(weights)
     w_abs = ops.abs(weights)
     if group_size and group_size > 0 and in_features % group_size == 0:
         n_groups = in_features // group_size
@@ -131,7 +131,7 @@ def awq_search_optimal_scales(
     Returns:
         best_scales: Optimal per-channel scales [in_features].
     """
-    in_features = weights.shape[1]
+    in_features = ops.shape(weights)[1]
 
     # Per-channel activation statistic (reference AWQ uses mean(|x|)).
     x_stat = ops.cast(activation_magnitudes, "float32")
@@ -230,11 +230,11 @@ def awq_search_best_clip(
         gs: Effective group size used for reshaping.
         n_group: Number of groups.
     """
-    out_features, in_features = weights_scaled.shape
+    out_features, in_features = ops.shape(weights_scaled)
     awq_scales = ops.cast(awq_scales, "float32")
 
     x = ops.cast(activation_sample, "float32")
-    if len(x.shape) > 2:
+    if ops.ndim(x) > 2:
         x = ops.reshape(x, (-1, in_features))
     # Effective input to the scaled weights (see docstring).
     x_scaled = ops.divide(x, awq_scales)
@@ -337,8 +337,7 @@ def awq_quantize_matrix(
         awq_scales: AWQ per-channel scales [in_features].
         g_idx: Group indices [in_features].
     """
-    in_features = weights_transpose.shape[1]
-    out_features = weights_transpose.shape[0]
+    out_features, in_features = ops.shape(weights_transpose)
 
     # Step 1: Find optimal AWQ scales via grid search
     awq_scales = awq_search_optimal_scales(

--- a/keras/src/quantizers/awq.py
+++ b/keras/src/quantizers/awq.py
@@ -17,6 +17,85 @@ from keras.src.quantizers.quantizers import dequantize_with_zero_point
 from keras.src.quantizers.quantizers import quantize_with_sz_map
 from keras.src.quantizers.quantizers import quantize_with_zero_point
 
+# Maximum number of activation rows stashed per layer for the AutoAWQ-style
+# clipping search. Bounds calibration memory; a few hundred rows is enough to
+# estimate per-group reconstruction error (matches AutoAWQ's ``n_sample_token``
+# default of 512).
+MAX_CLIP_SAMPLE_ROWS = 512
+
+
+def _get_weight_scale(weights, group_size):
+    """Per-in-channel weight magnitude used in the AWQ scale formula.
+
+    Mirrors llm-awq's ``get_weight_scale`` (and AutoAWQ's weight term): the
+    weights are normalized by their per-group maximum so each group lives on a
+    0-1 scale, then averaged over the output channels to obtain a single
+    statistic per input channel.
+
+    Args:
+        weights: Weight matrix ``[out_features, in_features]``.
+        group_size: Quantization group size (``-1`` for per-channel).
+
+    Returns:
+        Per-in-channel weight statistic ``[in_features]``.
+    """
+    weights = ops.cast(weights, "float32")
+    out_features, in_features = weights.shape
+    w_abs = ops.abs(weights)
+    if group_size and group_size > 0 and in_features % group_size == 0:
+        n_groups = in_features // group_size
+        w_grouped = ops.reshape(w_abs, (out_features, n_groups, group_size))
+        group_max = ops.max(w_grouped, axis=2, keepdims=True)
+        w_norm = ops.divide(w_grouped, ops.add(group_max, 1e-6))
+        w_norm = ops.reshape(w_norm, (out_features, in_features))
+    else:
+        group_max = ops.max(w_abs, axis=1, keepdims=True)
+        w_norm = ops.divide(w_abs, ops.add(group_max, 1e-6))
+    return ops.mean(w_norm, axis=0)
+
+
+def _fake_quantize_weights(weights_scaled, in_features, group_size):
+    """Quantize then dequantize a weight matrix (4-bit asymmetric).
+
+    Shared by the scale search and the clipping search so both evaluate the
+    exact same quantizer that is used to produce the final packed weights.
+
+    Args:
+        weights_scaled: Weight matrix ``[out_features, in_features]``.
+        in_features: Number of input features (columns).
+        group_size: Quantization group size (``-1`` for per-channel).
+
+    Returns:
+        The dequantized weight matrix, same shape as ``weights_scaled``.
+    """
+    if group_size == -1:
+        scale_q, zero_q, maxq = compute_quantization_parameters(
+            weights_scaled,
+            bits=4,
+            symmetric=False,
+            per_channel=True,
+            group_size=-1,
+            compute_dtype="float32",
+        )
+        quantized = quantize_with_zero_point(
+            weights_scaled, scale_q, zero_q, maxq
+        )
+        return dequantize_with_zero_point(quantized, scale_q, zero_q)
+
+    scale_q, zero_q, maxq = compute_quantization_parameters(
+        weights_scaled,
+        bits=4,
+        symmetric=False,
+        per_channel=True,
+        group_size=group_size,
+        compute_dtype="float32",
+    )
+    g_idx = ops.cast(ops.arange(0, in_features) // group_size, "int32")
+    quantized = quantize_with_sz_map(
+        weights_scaled, scale_q, zero_q, g_idx, maxq
+    )
+    return dequantize_with_sz_map(quantized, scale_q, zero_q, g_idx)
+
 
 def awq_search_optimal_scales(
     weights,
@@ -36,7 +115,11 @@ def awq_search_optimal_scales(
     to the expanded weight magnitude. During inference, we divide by scales
     to restore the original magnitude.
 
-    Scale formula: scales = x_max.pow(ratio).clamp(min=1e-4)
+    Scale formula (reference llm-awq / AutoAWQ):
+        scales = (x_stat**ratio / w_stat**(1 - ratio)).clamp(min=1e-4)
+    where ``x_stat`` is the per-channel activation magnitude and ``w_stat`` is
+    the per-in-channel weight magnitude from :func:`_get_weight_scale`. Scales
+    are then normalized by ``sqrt(max * min)``.
     Loss function: Activation-weighted MSE (approximates output error)
 
     Args:
@@ -48,13 +131,17 @@ def awq_search_optimal_scales(
     Returns:
         best_scales: Optimal per-channel scales [in_features].
     """
-    in_features = ops.shape(weights)[1]
+    in_features = weights.shape[1]
 
-    # Compute per-channel activation magnitudes (x_max)
-    # activations should already be per-channel max magnitudes
-    x_max = ops.cast(activation_magnitudes, "float32")
-    # Avoid zero or very small values
-    x_max = ops.where(ops.less(x_max, 1e-8), ops.ones_like(x_max), x_max)
+    # Per-channel activation statistic (reference AWQ uses mean(|x|)).
+    x_stat = ops.cast(activation_magnitudes, "float32")
+    # Avoid zero or very small values.
+    x_stat = ops.where(ops.less(x_stat, 1e-8), ops.ones_like(x_stat), x_stat)
+
+    # Per-in-channel weight statistic (llm-awq get_weight_scale). This is the
+    # term the previous implementation dropped.
+    w_stat = _get_weight_scale(weights, group_size)
+    w_stat = ops.where(ops.less(w_stat, 1e-8), ops.ones_like(w_stat), w_stat)
 
     best_loss = None
     best_scales = ops.ones((in_features,), dtype="float32")
@@ -63,11 +150,10 @@ def awq_search_optimal_scales(
     for i in range(num_grid_points + 1):
         ratio = i / num_grid_points
 
-        # Compute scales: x_max^ratio (clipped to avoid numerical issues)
-        if ratio == 0:
-            scales = ops.ones_like(x_max)
-        else:
-            scales = ops.power(x_max, ratio)
+        # Reference scale formula: balance activation and weight magnitudes.
+        scales = ops.divide(
+            ops.power(x_stat, ratio), ops.power(w_stat, 1.0 - ratio)
+        )
         scales = ops.maximum(scales, 1e-4)
 
         # Normalize scales to avoid extreme values
@@ -79,53 +165,19 @@ def awq_search_optimal_scales(
         # weights_scaled: [out_features, in_features]
         weights_scaled = ops.multiply(weights, scales)
 
-        if group_size == -1:
-            # Per-channel quantization (no grouping)
-            scale_q, zero_q, maxq = compute_quantization_parameters(
-                weights_scaled,
-                bits=4,
-                symmetric=False,
-                per_channel=True,
-                group_size=-1,
-                compute_dtype="float32",
-            )
-
-            # Quantize and dequantize
-            quantized = quantize_with_zero_point(
-                weights_scaled, scale_q, zero_q, maxq
-            )
-            dequantized = dequantize_with_zero_point(quantized, scale_q, zero_q)
-        else:
-            # Grouped quantization - use proper per-row grouping
-            scale_q, zero_q, maxq = compute_quantization_parameters(
-                weights_scaled,
-                bits=4,
-                symmetric=False,
-                per_channel=True,
-                group_size=group_size,
-                compute_dtype="float32",
-            )
-
-            # Compute group indices: maps each input feature to its group
-            g_idx = ops.cast(ops.arange(0, in_features) // group_size, "int32")
-
-            # Quantize and dequantize using group index mapping
-            quantized = quantize_with_sz_map(
-                weights_scaled, scale_q, zero_q, g_idx, maxq
-            )
-            dequantized = dequantize_with_sz_map(
-                quantized, scale_q, zero_q, g_idx
-            )
+        dequantized = _fake_quantize_weights(
+            weights_scaled, in_features, group_size
+        )
 
         # Scale back down by DIVIDING to restore original magnitude
         reconstructed = ops.divide(dequantized, scales)
 
         # Compute activation-weighted MSE loss
         # This approximates the output error: ||W*X - W_hat*X||^2
-        # by weighting each channel's error by x_max^2
+        # by weighting each channel's error by x_stat^2
         weight_error = ops.square(ops.subtract(weights, reconstructed))
         # Weight by activation magnitudes squared (broadcast over out_features)
-        weighted_error = ops.multiply(weight_error, ops.square(x_max))
+        weighted_error = ops.multiply(weight_error, ops.square(x_stat))
         loss = ops.mean(weighted_error)
 
         # Track best
@@ -141,26 +193,142 @@ def awq_search_optimal_scales(
     return best_scales
 
 
+def awq_search_best_clip(
+    weights_scaled,
+    activation_sample,
+    awq_scales,
+    *,
+    group_size=-1,
+    n_grid=20,
+    max_shrink=0.5,
+    oc_batch_size=64,
+):
+    """Search per-group weight clipping bounds (AutoAWQ ``best_clip``).
+
+    After the AWQ scales have been applied, quantization error can be further
+    reduced by clipping the weight magnitudes. For each output channel and
+    quantization group this grid-searches a shrink factor on the per-group max
+    and keeps the value that minimizes the reconstruction error of the layer
+    output against a stashed activation sample.
+
+    The reconstruction uses the *scaled* input (``x / awq_scales``) so that it
+    matches the effective inference computation ``(x / s) @ (W * s)^T``.
+
+    Args:
+        weights_scaled: Scaled weight matrix ``[out_features, in_features]``
+            (``W * awq_scales``).
+        activation_sample: Raw activation sample ``[rows, in_features]``.
+        awq_scales: Per-in-channel AWQ scales ``[in_features]``.
+        group_size: Quantization group size (``-1`` for per-channel).
+        n_grid: Number of shrink factors to try. Defaults to 20.
+        max_shrink: Maximum fractional shrink of the per-group max (the search
+            spans ``[1, 1 - max_shrink]``). Defaults to 0.5.
+        oc_batch_size: Output-channel batch size, to bound peak memory.
+
+    Returns:
+        best_max: Per-group clipping bound ``[out_features, n_group, 1]``.
+        gs: Effective group size used for reshaping.
+        n_group: Number of groups.
+    """
+    out_features, in_features = weights_scaled.shape
+    awq_scales = ops.cast(awq_scales, "float32")
+
+    x = ops.cast(activation_sample, "float32")
+    if len(x.shape) > 2:
+        x = ops.reshape(x, (-1, in_features))
+    # Effective input to the scaled weights (see docstring).
+    x_scaled = ops.divide(x, awq_scales)
+
+    if group_size and group_size > 0 and in_features % group_size == 0:
+        gs = group_size
+    else:
+        # Per-channel, or a group size that does not evenly divide the input:
+        # fall back to a single group per output channel for the clip search.
+        gs = in_features
+    n_group = in_features // gs
+
+    x_grouped = ops.reshape(x_scaled, (-1, n_group, gs))  # [rows, n_group, gs]
+    w_grouped = ops.reshape(weights_scaled, (out_features, n_group, gs))
+    org_max = ops.max(
+        ops.abs(w_grouped), axis=-1, keepdims=True
+    )  # [oc, n_group, 1]
+
+    n_shrink = max(1, int(n_grid))
+    step = max_shrink / n_grid
+    fq_group_size = gs if n_group > 1 else -1
+
+    best_max_parts = []
+    n_batches = (out_features + oc_batch_size - 1) // oc_batch_size
+    for b in range(n_batches):
+        start = b * oc_batch_size
+        end = min(start + oc_batch_size, out_features)
+        ocb = end - start
+        w = w_grouped[start:end]  # [ocb, n_group, gs]
+        omax = org_max[start:end]  # [ocb, n_group, 1]
+
+        # Reference output for this output-channel batch: [ocb, rows, n_group].
+        org_out = ops.einsum("rng,ong->orn", x_grouped, w)
+
+        best_max = omax
+        min_err = None
+        for i_s in range(n_shrink):
+            max_val = ops.multiply(omax, 1.0 - i_s * step)  # [ocb, n_group, 1]
+            w_clamped = ops.clip(w, ops.negative(max_val), max_val)
+            w_deq = _fake_quantize_weights(
+                ops.reshape(w_clamped, (ocb, in_features)),
+                in_features,
+                fq_group_size,
+            )
+            w_deq = ops.reshape(w_deq, (ocb, n_group, gs))
+            cur_out = ops.einsum("rng,ong->orn", x_grouped, w_deq)
+            err = ops.mean(
+                ops.square(ops.subtract(cur_out, org_out)), axis=1
+            )  # [ocb, n_group]
+            err = ops.expand_dims(err, axis=-1)  # [ocb, n_group, 1]
+            if min_err is None:
+                min_err = err
+                best_max = max_val
+            else:
+                better = ops.less(err, min_err)
+                min_err = ops.where(better, err, min_err)
+                best_max = ops.where(better, max_val, best_max)
+        best_max_parts.append(best_max)
+
+    best_max = ops.concatenate(best_max_parts, axis=0)  # [oc, n_group, 1]
+    return best_max, gs, n_group
+
+
 def awq_quantize_matrix(
     weights_transpose,
     activation_magnitudes,
     *,
     num_grid_points=20,
     group_size=-1,
+    apply_clip=False,
+    activation_sample=None,
+    clip_n_grid=20,
+    clip_max_shrink=0.5,
 ):
     """Quantize a weight matrix using AWQ.
 
     This function performs the complete AWQ quantization process:
     1. Find optimal per-channel scales via grid search
     2. Apply scales to weights
-    3. Compute quantization parameters
-    4. Quantize weights
+    3. (Optional) Search and apply per-group clipping bounds
+    4. Compute quantization parameters
+    5. Quantize weights
 
     Args:
         weights_transpose: Weight matrix [out_features, in_features].
         activation_magnitudes: Per-channel activation magnitudes [in_features].
         num_grid_points: Number of grid search points.
         group_size: Group size for quantization.
+        apply_clip: Whether to run the AutoAWQ-style clipping search. Requires
+            ``activation_sample`` to be provided.
+        activation_sample: Optional raw activation sample [rows, in_features]
+            used only for the clipping search.
+        clip_n_grid: Number of shrink factors for the clipping search.
+        clip_max_shrink: Maximum fractional shrink for the clipping search.
 
     Returns:
         quantized_weights: Quantized weights [out_features, in_features].
@@ -169,7 +337,8 @@ def awq_quantize_matrix(
         awq_scales: AWQ per-channel scales [in_features].
         g_idx: Group indices [in_features].
     """
-    in_features = ops.shape(weights_transpose)[1]
+    in_features = weights_transpose.shape[1]
+    out_features = weights_transpose.shape[0]
 
     # Step 1: Find optimal AWQ scales via grid search
     awq_scales = awq_search_optimal_scales(
@@ -182,6 +351,20 @@ def awq_quantize_matrix(
     # Step 2: Apply AWQ scales by MULTIPLYING (expand salient weights)
     # weights_scaled: [out_features, in_features]
     weights_scaled = ops.multiply(weights_transpose, awq_scales)
+
+    # Step 3: (Optional) Search and apply per-group clipping bounds.
+    if apply_clip and activation_sample is not None:
+        best_max, gs, n_group = awq_search_best_clip(
+            weights_scaled,
+            activation_sample,
+            awq_scales,
+            group_size=group_size,
+            n_grid=clip_n_grid,
+            max_shrink=clip_max_shrink,
+        )
+        w_grouped = ops.reshape(weights_scaled, (out_features, n_group, gs))
+        w_grouped = ops.clip(w_grouped, ops.negative(best_max), best_max)
+        weights_scaled = ops.reshape(w_grouped, (out_features, in_features))
 
     if group_size == -1:
         # Per-channel quantization (no grouping)
@@ -231,10 +414,11 @@ class AWQ:
     performs AWQ quantization on layer weights.
 
     The AWQ algorithm works by:
-    1. Collecting per-channel maximum activation magnitudes
+    1. Collecting per-channel mean activation magnitudes
     2. Using activation magnitudes to determine weight saliency
     3. Finding optimal per-channel scales via grid search
-    4. Applying scales before quantization to protect salient weights
+    4. (Optional) Searching per-group weight clipping bounds
+    5. Applying scales before quantization to protect salient weights
 
     Args:
         layer: The layer to quantize (Dense or EinsumDense).
@@ -283,14 +467,22 @@ class AWQ:
         else:
             raise TypeError(f"Unsupported layer type for AWQ: {type(layer)}")
 
-        # Initialize activation magnitude accumulator (per-channel max)
+        # Initialize activation magnitude accumulator (running per-channel
+        # MEAN of |x|, as in the reference AWQ implementations).
         self.activation_magnitudes = ops.zeros((self.rows,), dtype="float32")
+
+        # Bounded stash of raw activation rows for the clipping search.
+        self._clip_samples = []
+        self._clip_sample_rows = 0
 
     def update_activation_magnitudes(self, input_batch):
         """Update per-channel activation magnitude statistics.
 
-        This method tracks the maximum absolute activation value for each
-        input channel across all calibration batches.
+        This tracks the running per-channel MEAN of the absolute activation
+        value across all calibration batches (matching llm-awq / AutoAWQ),
+        accumulated with a numerically stable batch-count-weighted update. It
+        also stashes a bounded sample of raw activation rows that the clipping
+        search reuses.
 
         Args:
             input_batch: Input activations tensor [batch, ..., in_features].
@@ -305,15 +497,26 @@ class AWQ:
             input_batch = ops.reshape(input_batch, (-1, input_batch.shape[-1]))
 
         x = ops.cast(input_batch, "float32")
+        n = int(ops.shape(x)[0])
 
-        # Compute per-channel max absolute value for this batch
-        batch_max = ops.max(ops.abs(x), axis=0)
-
-        # Update running max
-        self.activation_magnitudes = ops.maximum(
-            self.activation_magnitudes, batch_max
+        # Running per-channel mean of |x| via a stable weighted update:
+        #   mean <- mean + (batch_mean - mean) * n / (count + n)
+        batch_mean = ops.mean(ops.abs(x), axis=0)
+        new_count = self.num_samples + n
+        delta = ops.subtract(batch_mean, self.activation_magnitudes)
+        self.activation_magnitudes = ops.add(
+            self.activation_magnitudes, ops.multiply(delta, n / new_count)
         )
-        self.num_samples = self.num_samples + int(ops.shape(x)[0])
+        self.num_samples = new_count
+
+        # Stash a bounded sample of raw activations for the clipping search.
+        if (
+            getattr(self.config, "apply_clip", False)
+            and self._clip_sample_rows < MAX_CLIP_SAMPLE_ROWS
+        ):
+            take = min(n, MAX_CLIP_SAMPLE_ROWS - self._clip_sample_rows)
+            self._clip_samples.append(x[:take])
+            self._clip_sample_rows += take
 
     def quantize_layer(self):
         """Perform AWQ quantization on the layer.
@@ -327,12 +530,20 @@ class AWQ:
 
         weights_matrix = ops.transpose(self.layer.kernel)
 
+        # Assemble the stashed activation sample for the clipping search.
+        apply_clip = bool(getattr(self.config, "apply_clip", False))
+        activation_sample = None
+        if apply_clip and self._clip_samples:
+            activation_sample = ops.concatenate(self._clip_samples, axis=0)
+
         # Perform AWQ quantization
         quantized, scale, zero, awq_scales, g_idx = awq_quantize_matrix(
             weights_matrix,
             self.activation_magnitudes,
             num_grid_points=self.config.num_grid_points,
             group_size=self.config.group_size,
+            apply_clip=apply_clip and activation_sample is not None,
+            activation_sample=activation_sample,
         )
 
         # Cast to uint8 for storage
@@ -357,3 +568,5 @@ class AWQ:
         """Free memory used by the quantizer."""
         del self.activation_magnitudes
         del self.layer
+        self._clip_samples = []
+        self._clip_sample_rows = 0

--- a/keras/src/quantizers/awq_config.py
+++ b/keras/src/quantizers/awq_config.py
@@ -40,6 +40,12 @@ class AWQConfig(QuantizationConfig):
         num_grid_points: The number of grid search points for finding optimal
             per-channel scales. Higher values may find better scales but
             take longer. Defaults to 20.
+        apply_clip: Whether to run the AutoAWQ-style weight clipping search
+            after the scale search. This grid-searches a per-group shrink
+            factor on the weight max and clips the (scaled) weights to the
+            value that minimizes activation-aware reconstruction error before
+            quantization. Improves accuracy at a small calibration cost.
+            Defaults to True.
         quantization_layer_structure: A dictionary defining the model's
             quantization structure. It should contain:
             - "pre_block_layers": list of layers to run before the first
@@ -79,6 +85,7 @@ class AWQConfig(QuantizationConfig):
         sequence_length: int = 512,
         group_size: int = 128,
         num_grid_points: int = 20,
+        apply_clip: bool = True,
         quantization_layer_structure: dict = None,
     ):
         super().__init__()
@@ -107,6 +114,7 @@ class AWQConfig(QuantizationConfig):
         self.sequence_length = sequence_length
         self.group_size = group_size
         self.num_grid_points = num_grid_points
+        self.apply_clip = apply_clip
         self.quantization_layer_structure = quantization_layer_structure
 
     @property
@@ -135,6 +143,7 @@ class AWQConfig(QuantizationConfig):
             "sequence_length": self.sequence_length,
             "group_size": self.group_size,
             "num_grid_points": self.num_grid_points,
+            "apply_clip": self.apply_clip,
         }
 
     @classmethod

--- a/keras/src/quantizers/awq_config_test.py
+++ b/keras/src/quantizers/awq_config_test.py
@@ -23,6 +23,7 @@ class AWQConfigTest(testing.TestCase):
         self.assertEqual(config.sequence_length, 512)
         self.assertEqual(config.group_size, 128)
         self.assertEqual(config.num_grid_points, 20)
+        self.assertTrue(config.apply_clip)
         self.assertEqual(config.mode, "awq")
 
     def test_config_custom_values(self):
@@ -98,9 +99,21 @@ class AWQConfigTest(testing.TestCase):
         self.assertEqual(cfg["weight_bits"], 4)
         self.assertEqual(cfg["group_size"], 64)
         self.assertEqual(cfg["num_grid_points"], 30)
+        self.assertTrue(cfg["apply_clip"])
         # Dataset and tokenizer should not be serialized
         self.assertIsNone(cfg["dataset"])
         self.assertIsNone(cfg["tokenizer"])
+
+    def test_config_apply_clip(self):
+        """Test apply_clip flag round-trips through serialization."""
+        config = AWQConfig(
+            dataset=["test"],
+            tokenizer=self.MockTokenizer(),
+            apply_clip=False,
+        )
+        self.assertFalse(config.apply_clip)
+        restored = AWQConfig.from_config(config.get_config())
+        self.assertFalse(restored.apply_clip)
 
     def test_dtype_policy_string(self):
         """Test dtype policy string generation."""

--- a/keras/src/quantizers/awq_test.py
+++ b/keras/src/quantizers/awq_test.py
@@ -13,7 +13,9 @@ from keras.src import ops
 from keras.src import saving
 from keras.src import testing
 from keras.src.quantizers.awq import AWQ
+from keras.src.quantizers.awq import _get_weight_scale
 from keras.src.quantizers.awq import awq_quantize_matrix
+from keras.src.quantizers.awq import awq_search_best_clip
 from keras.src.quantizers.awq import awq_search_optimal_scales
 from keras.src.quantizers.awq_config import AWQConfig
 
@@ -76,6 +78,91 @@ class AWQAlgorithmTest(testing.TestCase):
         # Should handle gracefully without NaN or Inf
         self.assertFalse(ops.any(ops.isnan(scales)))
         self.assertFalse(ops.any(ops.isinf(scales)))
+
+    def test_get_weight_scale_shape_and_range(self):
+        """Weight statistic is per-in-channel and normalized to (0, 1]."""
+        weights = RNG.standard_normal((32, 64)).astype("float32")
+        for group_size in (-1, 16):
+            w_stat = _get_weight_scale(weights, group_size)
+            self.assertEqual(w_stat.shape, (64,))
+            self.assertTrue(ops.all(ops.greater(w_stat, 0)))
+            self.assertTrue(ops.all(ops.less_equal(w_stat, 1.0 + 1e-6)))
+
+    def test_search_best_clip_shapes(self):
+        """Clip search returns a per-group bound not exceeding the max."""
+        weights = RNG.standard_normal((64, 32)).astype("float32")
+        scales = ops.add(
+            ops.abs(RNG.standard_normal((32,)).astype("float32")), 0.1
+        )
+        weights_scaled = ops.multiply(weights, scales)
+        sample = RNG.standard_normal((128, 32)).astype("float32")
+
+        best_max, gs, n_group = awq_search_best_clip(
+            weights_scaled, sample, scales, group_size=8, n_grid=20
+        )
+        self.assertEqual(gs, 8)
+        self.assertEqual(n_group, 4)
+        self.assertEqual(best_max.shape, (64, 4, 1))
+        # Bound must be positive and never exceed the original per-group max.
+        w_grouped = ops.reshape(weights_scaled, (64, 4, 8))
+        org_max = ops.max(ops.abs(w_grouped), axis=-1, keepdims=True)
+        self.assertTrue(ops.all(ops.greater(best_max, 0)))
+        self.assertTrue(
+            ops.all(ops.less_equal(best_max, ops.add(org_max, 1e-6)))
+        )
+
+    def test_clip_reduces_per_group_reconstruction_error(self):
+        """Clipping must not increase the per-group output recon error.
+
+        The clip search selects, per (output channel, group), the shrink factor
+        minimizing the reconstruction error of that group's partial output
+        against the (unclipped) scaled weights. Because the search grid always
+        includes the no-shrink candidate, this error can only decrease. This
+        test measures that exact objective with vs without clipping on weights
+        with injected outliers.
+        """
+        from keras.src.quantizers.quantizers import dequantize_with_sz_map
+
+        keras.utils.set_random_seed(0)
+        out_features, in_features, group_size = 64, 128, 32
+        n_group = in_features // group_size
+
+        weights = RNG.standard_normal((out_features, in_features)).astype(
+            "float32"
+        )
+        # Inject weight outliers on a few output rows so clipping matters.
+        weights[::16] *= 6.0
+        sample = RNG.standard_normal((256, in_features)).astype("float32")
+        x_stat = ops.mean(ops.abs(sample), axis=0)
+
+        def _per_group_error(apply_clip):
+            q, sc, z, aw, gi = awq_quantize_matrix(
+                weights,
+                x_stat,
+                num_grid_points=10,
+                group_size=group_size,
+                apply_clip=apply_clip,
+                activation_sample=sample,
+            )
+            # Same FP reference for both: unclipped scaled weights.
+            w_scaled = ops.multiply(weights, aw)
+            x_scaled = ops.divide(sample, aw)
+            w_hat = dequantize_with_sz_map(q, sc, z, ops.cast(gi, "int32"))
+            xg = ops.reshape(x_scaled, (-1, n_group, group_size))
+            wg_fp = ops.reshape(w_scaled, (out_features, n_group, group_size))
+            wg_q = ops.reshape(w_hat, (out_features, n_group, group_size))
+            fp = ops.einsum("rng,ong->orn", xg, wg_fp)
+            qt = ops.einsum("rng,ong->orn", xg, wg_q)
+            return float(ops.sum(ops.square(ops.subtract(qt, fp)))), aw
+
+        err_no_clip, aw_no = _per_group_error(False)
+        err_clip, aw_clip = _per_group_error(True)
+        # Scale search is independent of clipping, so scales must match.
+        self.assertAllClose(aw_no, aw_clip, atol=1e-6)
+        # The clip search can only reduce this objective.
+        self.assertLessEqual(err_clip, err_no_clip + 1e-4)
+        # On outlier weights it should strictly help.
+        self.assertLess(err_clip, err_no_clip)
 
     def test_quantize_matrix_shapes(self):
         """Test that quantize_matrix returns correct shapes."""
@@ -281,7 +368,12 @@ class AWQLayerTest(testing.TestCase):
         )
 
     def test_awq_activation_accumulation(self):
-        """Test that activation magnitudes accumulate correctly."""
+        """Test that activation magnitudes accumulate as a running mean.
+
+        The reference AWQ statistic is the per-channel mean of |x|. The running
+        update must be equivalent to computing that mean over all rows seen so
+        far, regardless of how the rows are split into batches.
+        """
         layer = layers.Dense(32)
         layer.build(input_shape=(None, 16))
 
@@ -291,23 +383,68 @@ class AWQLayerTest(testing.TestCase):
         layer.quantize(config=config)
         awq_obj = AWQ(layer, config)
 
-        # First batch
-        batch1 = ops.abs(RNG.standard_normal((10, 16)).astype("float32"))
-        batch1_max = ops.max(batch1, axis=0)
+        # First batch.
+        batch1 = RNG.standard_normal((10, 16)).astype("float32")
         awq_obj.update_activation_magnitudes(batch1)
 
-        # Second batch with higher values in some channels
-        batch2 = ops.add(
-            ops.abs(RNG.standard_normal((10, 16)).astype("float32")), 1.0
-        )
-        batch2_max = ops.max(batch2, axis=0)
+        # Second batch with a different row count to exercise the weighting.
+        batch2 = ops.add(RNG.standard_normal((30, 16)).astype("float32"), 1.0)
         awq_obj.update_activation_magnitudes(batch2)
 
-        # Accumulated magnitudes should be element-wise max
-        expected_max = ops.maximum(batch1_max, batch2_max)
+        # Running mean must equal the mean of |x| over all rows.
+        combined = ops.concatenate([ops.abs(batch1), ops.abs(batch2)], axis=0)
+        expected_mean = ops.mean(combined, axis=0)
+        self.assertEqual(awq_obj.num_samples, 40)
         self.assertAllClose(
-            awq_obj.activation_magnitudes, expected_max, atol=1e-6
+            awq_obj.activation_magnitudes, expected_mean, atol=1e-6
         )
+
+    def test_awq_clip_sample_capture(self):
+        """Test that a bounded activation sample is stashed for clipping."""
+        from keras.src.quantizers.awq import MAX_CLIP_SAMPLE_ROWS
+
+        layer = layers.Dense(32)
+        layer.build(input_shape=(None, 16))
+
+        config = AWQConfig(
+            dataset=None, tokenizer=None, group_size=-1, num_grid_points=5
+        )
+        layer.quantize(config=config)
+        awq_obj = AWQ(layer, config)
+
+        # Feed more rows than the cap across several batches.
+        for _ in range(4):
+            batch = RNG.standard_normal((MAX_CLIP_SAMPLE_ROWS // 2, 16)).astype(
+                "float32"
+            )
+            awq_obj.update_activation_magnitudes(batch)
+
+        # The stash is bounded by MAX_CLIP_SAMPLE_ROWS.
+        self.assertEqual(awq_obj._clip_sample_rows, MAX_CLIP_SAMPLE_ROWS)
+        total_rows = int(
+            sum(int(ops.shape(s)[0]) for s in awq_obj._clip_samples)
+        )
+        self.assertEqual(total_rows, MAX_CLIP_SAMPLE_ROWS)
+
+    def test_awq_clip_disabled_skips_sample(self):
+        """Test that apply_clip=False does not stash a sample."""
+        layer = layers.Dense(32)
+        layer.build(input_shape=(None, 16))
+
+        config = AWQConfig(
+            dataset=None,
+            tokenizer=None,
+            group_size=-1,
+            num_grid_points=5,
+            apply_clip=False,
+        )
+        layer.quantize(config=config)
+        awq_obj = AWQ(layer, config)
+        awq_obj.update_activation_magnitudes(
+            RNG.standard_normal((32, 16)).astype("float32")
+        )
+        self.assertEqual(awq_obj._clip_sample_rows, 0)
+        self.assertEqual(awq_obj._clip_samples, [])
 
     def test_awq_layer_variables_created(self):
         """Test that AWQ layer variables are properly created."""


### PR DESCRIPTION
## Description

The Keras AWQ implementation diverged from the reference algorithms (llm-awq / AutoAWQ) in three ways that hurt quantized accuracy:
1. The activation statistic was a running MAX of |x|, whereas reference AWQ uses the per-channel MEAN of |x|. Max over-weights a single outlier token and destabilizes the saliency estimate.
2. The scale search used `scales = x_max**ratio` only, dropping the weight-magnitude term. The reference formula balances activation and weight magnitude: `scales = x_stat**ratio / w_stat**(1-ratio)`.
3. There was no weight-clipping step. AutoAWQ additionally grid-searches a per-group clip on the weight max to minimize reconstruction error.

### Changes

`keras/src/quantizers/awq.py`:
- `update_activation_magnitudes` now keeps a running per-channel MEAN of |x| via a numerically stable, batch-count-weighted incremental update (`mean += (batch_mean - mean) * n / (count + n)`). It also stashes a bounded raw-activation sample (`MAX_CLIP_SAMPLE_ROWS=512`) for clipping.
- `awq_search_optimal_scales` now uses the reference scale formula with the new `_get_weight_scale()` term (|W| normalized per group, averaged over the output axis, as in llm-awq get_weight_scale). The existing `1e-4` clamp and `sqrt(max*min)` normalization and the ratio-in-[0,1] grid are kept; the activation-weighted MSE selection loss is unchanged.
- New `awq_search_best_clip()` implements AutoAWQ's best-clip: for each output channel and group it grid-searches ~20 shrink factors on the per-group max and keeps the value minimizing reconstruction MSE of the layer output against the stashed sample (reconstruction uses the scaled input x/awq_scales to match inference). Output channels are batched to bound memory. Gated by AWQConfig.apply_clip and applied after the scale search, before final quantization.
- `_fake_quantize_weights()` factors the shared quantize/dequantize path so the scale search, clip search, and final quantization all evaluate the exact same 4-bit kernel.

`keras/src/quantizers/awq_config.py`:
- New serialized knob `apply_clip (default True)`, round-tripped in `get_config`/`from_config`.

### Evidence

[[Script](https://gist.github.com/JyotinderSingh/6f25918c0e683a174db33bd8f07f92b0)]

Both old and new reuse the identical 4-bit quantizer kernel; only the AWQ scale/statistic/clipping logic differs.

1. Per-layer activation-weighted reconstruction error mean((W - W_recon)^2 * x_mean^2) over 18 randomized layers with injected outlier channels (out/in/group in {64..256}/{128..512}/ {-1,32,64,128}):
```
      NEW <= OLD on 18/18 layers.
      Mean error OLD=1.102e-01, NEW=9.701e-02 (ratio 0.880, ~12% lower).
      Per-layer NEW/OLD ratios span 0.688..0.985.
```

2. Tiny end-to-end transformer classifier (awq_test.py pattern, scaled to embed=128, heads=8, ff=384, 2 blocks, gs=128, with channel outliers baked into the block input), averaged over 5 model seeds, KL / top-1 agreement vs the float model (lower KL / higher top-1 better):
```
      mean KL      OLD=0.00278  NEW=0.00258  (0.930x, ~7% lower)
      mean top-1   OLD=0.800    NEW=0.850
      NEW beats OLD on both averaged metrics.
```

### Non-goals / Caveats
- Non-goal: folding awq_scales into stored weights / preceding ops using fused kernels is deferred.
- The clip search minimizes per-(output-channel, group) partial-output MSE independently (as in AutoAWQ), not the full summed-output MSE.
- Clipping falls back to a single per-output-channel group when the group size does not evenly divide in_features.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
