### PR TITLE
Normalize backend.is_tensor to backend.ops.is_tensor

### DIFF
--- a/keras/src/layers/preprocessing/index_lookup_test.py
+++ b/keras/src/layers/preprocessing/index_lookup_test.py
@@ -8,6 +8,7 @@ from tensorflow import data as tf_data
 from keras.src import backend
 from keras.src import layers
 from keras.src import models
+from keras.src import ops
 from keras.src import testing
 from keras.src.saving import saving_api
 
@@ -354,7 +355,7 @@ class IndexLookupLayerTest(testing.TestCase):
             sparse=True,
         )
         output = layer([[1, 2], [3, 4]])
-        self.assertEqual(backend.is_tensor(output), True)
+        self.assertEqual(ops.is_tensor(output), True)
         self.assertIsInstance(output, tf.SparseTensor)
         self.assertAllClose(
             tf.sparse.to_dense(output), np.array([[0, 1, 1, 0], [1, 0, 0, 1]])

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -300,7 +300,9 @@ def standardize_reshape_shape(newshape, newshape_arg_name="newshape"):
     tensors are returned as is, since their dimensions are only known at
     runtime.
     """
-    if backend.is_tensor(newshape) or isinstance(newshape, KerasTensor):
+    from keras.src import ops
+
+    if ops.is_tensor(newshape) or isinstance(newshape, KerasTensor):
         return newshape
     try:
         newshape = tuple(newshape)
@@ -318,8 +320,9 @@ def validate_reshape_shape(newshape, newshape_arg_name="newshape"):
     scalars resolved at runtime, such as `torch.SymInt` under `torch.compile`)
     are not validated here.
     """
+    from keras.src import ops
 
-    if backend.is_tensor(newshape) or isinstance(newshape, KerasTensor):
+    if ops.is_tensor(newshape) or isinstance(newshape, KerasTensor):
         return
 
     neg_one_count = 0
@@ -347,10 +350,12 @@ def compute_reshape_output_shape(input_shape, newshape, newshape_arg_name):
 
     This utility does not special case the 0th dimension (batch size).
     """
+    from keras.src import ops
+
     newshape = standardize_reshape_shape(newshape, newshape_arg_name)
     # If `newshape` is a tensor, we infer the output rank based on its shape.
     # For example, a 1D tensor of shape (4,) indicates a 4D output shape.
-    if backend.is_tensor(newshape) or isinstance(newshape, KerasTensor):
+    if ops.is_tensor(newshape) or isinstance(newshape, KerasTensor):
         shape = getattr(newshape, "shape", None)
         if shape and len(shape) == 1 and shape[0] is not None:
             return (None,) * shape[0]

--- a/keras/src/ops/operation_utils.py
+++ b/keras/src/ops/operation_utils.py
@@ -2,7 +2,6 @@ import math
 
 import numpy as np
 
-from keras.src import backend
 from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.backend import KerasTensor


### PR DESCRIPTION
## Description

`pluggable_backends` relies on `backend.ops.is_tensor` and does not implement `backend.is_tensor`. This is causing the MLX CI to fail: https://github.com/keras-team/keras-mlx/actions/runs/32410916747/job/96560877940?pr=26#step:8:97309

cc @MarcosAsh @SamanehSaadat 

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
