### PR TITLE
Batch GPTQ calibration forwards and use Cholesky inverse-Hessian

### DIFF
--- a/keras/src/quantizers/gptq.py
+++ b/keras/src/quantizers/gptq.py
@@ -26,7 +26,7 @@ def _stable_permutation(metric):
 
 def gptq_quantize_matrix(
     weights_transpose,
-    inv_hessian,
+    hessian,
     *,
     blocksize=128,
     group_size=-1,
@@ -53,18 +53,24 @@ def gptq_quantize_matrix(
     - invH[block, future] denotes the cross-block slice of the inverse Hessian,
     - W[:, future] are the columns yet to be quantized.
 
+    The inverse Hessian used for error propagation is derived from the
+    (already dampened) Hessian using the reference GPTQ/AutoGPTQ Cholesky
+    formulation rather than a dense matrix inverse: the upper-triangular
+    Cholesky factor of `H^-1` is computed via triangular solves and indexed
+    directly inside the error-correction loop.
+
     Args:
         weights_transpose: Transposed weight matrix [out_features, in_features]
          to quantize.
-        inv_hessian: Inverse Hessian matrix [in_features, in_features] for
-         error propagation.
+        hessian: Dampened Hessian matrix [in_features, in_features]. The upper
+         Cholesky factor of its inverse drives error propagation.
         blocksize: Size of the blocks to process (default: 128).
         group_size: Size of the groups for parameter reuse
          (default: -1, no grouping).
         activation_order: Whether to apply activation-order permutation
          (default: False).
         order_metric: Metric for ordering features
-         (default: None, uses 1 / diag(invH)).
+         (default: None, uses diag(H)).
         compute_scale_zero: Function to compute scale and zero for
          quantization.
 
@@ -78,11 +84,9 @@ def gptq_quantize_matrix(
     in_features = ops.shape(weights_transpose)[1]
 
     if activation_order:
-        # Use 1 / diag(inverse_hessian) as importance proxy by default.
+        # Use diag(H) as the importance proxy by default (as in AutoGPTQ).
         if order_metric is None:
-            order_metric = ops.reciprocal(
-                ops.add(ops.diagonal(inv_hessian), 1e-12)
-            )
+            order_metric = ops.diagonal(hessian)
         else:
             # sanitize provided metric
             order_metric = ops.cast(order_metric, "float32")
@@ -96,11 +100,19 @@ def gptq_quantize_matrix(
         inv_perm = ops.argsort(perm)
 
         weights_transpose = ops.take(weights_transpose, perm, axis=1)
-        inv_hessian = ops.take(
-            ops.take(inv_hessian, perm, axis=0), perm, axis=1
-        )
+        # Permute the Hessian *before* factorization. Cholesky does not commute
+        # with permutation, so the factor must be computed on the reordered H.
+        hessian = ops.take(ops.take(hessian, perm, axis=0), perm, axis=1)
     else:
         perm = inv_perm = None
+
+    # Reference GPTQ/AutoGPTQ inverse-Hessian factorization. Compute `H^-1`
+    # from its lower Cholesky factor using triangular solves (no dense inverse),
+    # then take the UPPER Cholesky factor of `H^-1`. Indexing this factor inside
+    # the loop below reproduces AutoGPTQ's error-propagation exactly.
+    cholesky_lower = linalg.cholesky(hessian)
+    inverse_hessian = linalg.cholesky_inverse(cholesky_lower)
+    inv_hessian = linalg.cholesky(inverse_hessian, upper=True)
 
     # weights_buffer: [out_features, in_features]
     weights_buffer = weights_transpose
@@ -455,12 +467,12 @@ class GPTQ:
             ops.diag(hessian_diagonal),
         )
 
-        # Compute the inverse Hessian, which is used for error correction
-        inverse_hessian = linalg.inv(hessian_matrix)
-
+        # The inverse Hessian used for error correction is derived inside
+        # `gptq_quantize_matrix` from the dampened Hessian using a numerically
+        # stable Cholesky formulation (triangular solves, no dense inverse).
         quantized, scale, zero, g_idx = gptq_quantize_matrix(
             weights_matrix,
-            inv_hessian=inverse_hessian,
+            hessian=hessian_matrix,
             blocksize=blocksize,
             group_size=self.config.group_size,
             activation_order=self.config.activation_order,

--- a/keras/src/quantizers/gptq_config.py
+++ b/keras/src/quantizers/gptq_config.py
@@ -120,6 +120,12 @@ class GPTQConfig(QuantizationConfig):
             Defaults to 4.
         num_samples: (int, optional) The number of calibration data samples to
             use from the dataset. Defaults to 128.
+        calibration_batch_size: (int, optional) The number of calibration
+            samples to run through each block per forward pass during
+            calibration. Larger values reduce the number of forward passes
+            (and therefore wall-clock calibration time) without changing the
+            quantization result, at the cost of higher peak activation memory.
+            Defaults to 8.
         sequence_length: (int, optional) The sequence length to use for each
             calibration sample. Defaults to 512.
         hessian_damping: (float, optional) The % of Hessian damping to use for
@@ -147,6 +153,7 @@ class GPTQConfig(QuantizationConfig):
         *,
         weight_bits: int = 4,
         num_samples: int = 128,
+        calibration_batch_size: int = 8,
         per_channel: bool = True,
         sequence_length: int = 512,
         hessian_damping: float = 0.01,
@@ -163,6 +170,10 @@ class GPTQConfig(QuantizationConfig):
             )
         if num_samples <= 0:
             raise ValueError("num_samples must be a positive integer.")
+        if calibration_batch_size <= 0:
+            raise ValueError(
+                "calibration_batch_size must be a positive integer."
+            )
         if sequence_length <= 0:
             raise ValueError("sequence_length must be a positive integer.")
         if hessian_damping < 0 or hessian_damping > 1:
@@ -176,6 +187,7 @@ class GPTQConfig(QuantizationConfig):
         self.dataset = dataset
         self.tokenizer = tokenizer
         self.num_samples = num_samples
+        self.calibration_batch_size = calibration_batch_size
         self.per_channel = per_channel
         self.sequence_length = sequence_length
         self.hessian_damping = hessian_damping
@@ -196,6 +208,7 @@ class GPTQConfig(QuantizationConfig):
             "quantization_layer_structure": None,
             "weight_bits": self.weight_bits,
             "num_samples": self.num_samples,
+            "calibration_batch_size": self.calibration_batch_size,
             "per_channel": self.per_channel,
             "sequence_length": self.sequence_length,
             "hessian_damping": self.hessian_damping,

--- a/keras/src/quantizers/gptq_config_test.py
+++ b/keras/src/quantizers/gptq_config_test.py
@@ -20,6 +20,28 @@ class TestGPTQConfig(testing.TestCase):
         ):
             GPTQConfig(dataset=None, tokenizer=None, num_samples=-1)
 
+    def test_invalid_calibration_batch_size(self):
+        with self.assertRaisesRegex(
+            ValueError, "calibration_batch_size must be a positive"
+        ):
+            GPTQConfig(dataset=None, tokenizer=None, calibration_batch_size=0)
+        with self.assertRaisesRegex(
+            ValueError, "calibration_batch_size must be a positive"
+        ):
+            GPTQConfig(dataset=None, tokenizer=None, calibration_batch_size=-4)
+
+    def test_calibration_batch_size_default_and_serialization(self):
+        config = GPTQConfig(dataset=None, tokenizer=None)
+        self.assertEqual(config.calibration_batch_size, 8)
+
+        config = GPTQConfig(
+            dataset=None, tokenizer=None, calibration_batch_size=16
+        )
+        serialized_config = config.get_config()
+        self.assertEqual(serialized_config["calibration_batch_size"], 16)
+        deserialized_config = GPTQConfig.from_config(serialized_config)
+        self.assertEqual(deserialized_config.calibration_batch_size, 16)
+
     def test_invalid_sequence_length(self):
         with self.assertRaisesRegex(
             ValueError, "sequence_length must be a positive"

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -193,6 +193,31 @@ def get_dataloader(
     return samples.astype(np.int32)[:, None, :]
 
 
+def _stack_calibration_batch(samples):
+    """Stacks a list of per-sample calibration activations into a single batch.
+
+    Each element may be a 2D `[sequence, features]` or 3D
+    `[1, sequence, features]` tensor. Every element is normalized to a leading
+    batch axis of size 1 and concatenated along axis 0, producing a
+    `[batch, sequence, features]` tensor that can be run through a block in a
+    single forward pass.
+
+    Args:
+        samples: List of per-sample activation tensors.
+
+    Returns:
+        A single `[batch, sequence, features]` tensor.
+    """
+    normalized = []
+    for sample in samples:
+        if len(sample.shape) == 2:
+            sample = ops.expand_dims(sample, axis=0)
+        normalized.append(sample)
+    if len(normalized) == 1:
+        return normalized[0]
+    return ops.concatenate(normalized, axis=0)
+
+
 def find_layers_in_block(block):
     """
     Finds all Dense and EinsumDense layers in a transformer block.
@@ -264,6 +289,13 @@ def apply_gptq_layerwise(dataloader, config, structure, filters=None):
         inputs.append(batch)
 
     num_samples = min(num_samples, len(inputs))
+    inputs = inputs[:num_samples]
+
+    # Run calibration forward passes at this batch size. Because the Hessian is
+    # accumulated over the flattened `[-1, features]` activations, batching is
+    # mathematically identical to running one sample at a time; it only reduces
+    # the number of (expensive) forward passes through each block.
+    batch_size = max(1, int(config.calibration_batch_size))
 
     progbar = keras_utils.Progbar(target=len(transformer_blocks))
 
@@ -293,11 +325,11 @@ def apply_gptq_layerwise(dataloader, config, structure, filters=None):
             }
 
             with stream_hessians(sub_layers_map, gptq_objects):
-                for sample_idx in range(num_samples):
-                    current_input = inputs[sample_idx]
-                    if len(current_input.shape) == 2:
-                        current_input = ops.expand_dims(current_input, axis=0)
-                    _ = block(current_input)
+                for start in range(0, num_samples, batch_size):
+                    batch = _stack_calibration_batch(
+                        inputs[start : start + batch_size]
+                    )
+                    _ = block(batch)
 
             for name, gptq_object in gptq_objects.items():
                 logging.info(f"Quantizing {name}...")
@@ -309,12 +341,13 @@ def apply_gptq_layerwise(dataloader, config, structure, filters=None):
         if block_idx < len(transformer_blocks) - 1:
             logging.info(f"Generating inputs for block {block_idx + 1}...")
             next_block_inputs = []
-            for sample_idx in range(num_samples):
-                current_input = inputs[sample_idx]
-                if len(current_input.shape) == 2:
-                    current_input = ops.expand_dims(current_input, axis=0)
-                output = block(current_input)[0]
-                next_block_inputs.append(output)
+            for start in range(0, num_samples, batch_size):
+                chunk = inputs[start : start + batch_size]
+                output = block(_stack_calibration_batch(chunk))
+                # Split the batched output back into per-sample activations so
+                # the next block can be calibrated identically.
+                for sample_idx in range(len(chunk)):
+                    next_block_inputs.append(output[sample_idx])
             inputs = next_block_inputs
         progbar.update(current=block_idx + 1)
 

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -210,7 +210,7 @@ def _stack_calibration_batch(samples):
     """
     normalized = []
     for sample in samples:
-        if len(sample.shape) == 2:
+        if ops.ndim(sample) == 2:
             sample = ops.expand_dims(sample, axis=0)
         normalized.append(sample)
     if len(normalized) == 1:

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -344,6 +344,8 @@ def apply_gptq_layerwise(dataloader, config, structure, filters=None):
             for start in range(0, num_samples, batch_size):
                 chunk = inputs[start : start + batch_size]
                 output = block(_stack_calibration_batch(chunk))
+                if isinstance(output, (list, tuple)):
+                    output = output[0]
                 # Split the batched output back into per-sample activations so
                 # the next block can be calibrated identically.
                 for sample_idx in range(len(chunk)):

--- a/keras/src/quantizers/gptq_core_test.py
+++ b/keras/src/quantizers/gptq_core_test.py
@@ -6,9 +6,13 @@ from keras.src import layers
 from keras.src import models
 from keras.src import ops
 from keras.src import testing
+from keras.src.quantizers.gptq import GPTQ
 from keras.src.quantizers.gptq_config import GPTQConfig
+from keras.src.quantizers.gptq_core import _stack_calibration_batch
+from keras.src.quantizers.gptq_core import find_layers_in_block
 from keras.src.quantizers.gptq_core import get_dataloader
 from keras.src.quantizers.gptq_core import gptq_quantize
+from keras.src.quantizers.gptq_core import stream_hessians
 
 VOCAB_SIZE = 100
 
@@ -258,6 +262,51 @@ class TestGPTQCore(testing.TestCase):
                 sequence_length=10,
                 dataset="wikitext2",
                 num_samples=10,
+            )
+
+    def test_calibration_batching_produces_identical_hessian(self):
+        """The Hessian accumulated during calibration must be identical
+        whether calibration samples are streamed one at a time or in
+        batches. `update_hessian_with_batch` flattens activations to
+        `[-1, features]`, so batching only changes the number of forward
+        passes, not the math."""
+        d_model = 16
+        seq_len = 8
+        num_samples = 8
+
+        block = TransformerBlock()  # contains a single Dense(128) layer.
+        # Trigger a build so the inner Dense layer's kernel exists.
+        _ = block(ops.zeros((1, seq_len, d_model)))
+
+        rng = np.random.default_rng(0)
+        samples = [
+            ops.convert_to_tensor(
+                rng.standard_normal((1, seq_len, d_model)).astype("float32")
+            )
+            for _ in range(num_samples)
+        ]
+
+        def accumulate(batch_size):
+            layers_map = find_layers_in_block(block)
+            gptq_objects = {
+                name: GPTQ(layer) for name, layer in layers_map.items()
+            }
+            with stream_hessians(layers_map, gptq_objects):
+                for start in range(0, num_samples, batch_size):
+                    batch = _stack_calibration_batch(
+                        samples[start : start + batch_size]
+                    )
+                    _ = block(batch)
+            return {name: obj.hessian for name, obj in gptq_objects.items()}
+
+        unbatched = accumulate(batch_size=1)
+        batched = accumulate(batch_size=4)
+
+        self.assertEqual(set(unbatched.keys()), set(batched.keys()))
+        self.assertGreater(len(unbatched), 0)
+        for name in unbatched:
+            self.assertAllClose(
+                unbatched[name], batched[name], rtol=1e-5, atol=1e-5
             )
 
     def test_apply_gptq_on_multi_block_model(self):

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -389,7 +389,7 @@ class GPTQTest(testing.TestCase):
 
         self.assertAllClose(g1.hessian, g2.hessian, rtol=1e-6, atol=1e-6)
 
-    def test_identity_inv_hessian_matches_direct_quantization(self):
+    def test_identity_hessian_matches_direct_quantization(self):
         """Tests that the matrix quantization without error correction
         matches the direct implementation."""
         in_features, out_features = 16, 8
@@ -401,14 +401,14 @@ class GPTQTest(testing.TestCase):
         )
         weights_transpose = ops.transpose(weights)
 
-        # inverse_hessian = identity; no cross-feature correction
-        # (since all off-diagonal elements are zero), which means
-        # there is no interaction between different features
-        inverse_hessian = ops.eye(in_features, dtype="float32")
+        # hessian = identity => inverse Hessian is identity; no cross-feature
+        # correction (since all off-diagonal elements are zero), which means
+        # there is no interaction between different features.
+        hessian = ops.eye(in_features, dtype="float32")
 
         quantized_weights, scale_map, zero_map, g_idx = gptq_quantize_matrix(
             weights_transpose,
-            inverse_hessian,
+            hessian,
             blocksize=128,
             group_size=1,  # per-column quantization
             activation_order=False,


### PR DESCRIPTION
## Description

GPTQ calibration is a slow process: `apply_gptq_layerwise` runs every calibration sample through each block at batch size 1, twice per block (once to capture Hessians, once to regenerate the next block's inputs). With N samples and B blocks that is 2*N*B forward passes of shape `[1, seq, d]`, which badly underutilizes the accelerator.

Separately, `quantize_and_correct_layer` formed a full dense `linalg.inv(H)` and indexed its rows for error propagation. That is neither the reference GPTQ/AutoGPTQ formulation nor numerically ideal: on ill-conditioned Hessians the dense-inverse update is materially worse than the Cholesky-factor update the algorithm is supposed to use.

### Fixes

#### Batched calibration forwards

Added `GPTQConfig.calibration_batch_size` (default 8, validated > 0, serialized in get_config/from_config). Both the Hessian-capture pass and the next-block-input regeneration pass in `apply_gptq_layerwise` now run `calibration_batch_size` samples per forward via a new `_stack_calibration_batch` helper. `update_hessian_with_batch` already flattens activations to `[-1, features]`, so the accumulated Hessian is mathematically identical to the per-sample path; only the number of forward passes changes.

#### Cholesky inverse-Hessian path

`gptq_quantize_matrix` now takes the dampened Hessian and derives the error-propagation matrix the way AutoGPTQ does: `L = cholesky(H)`, `Hinv = cholesky_inverse(L)` (cho-solve against the identity via triangular solves, without dense `inv`), then the UPPER Cholesky factor `cholesky(Hinv, upper=True)` is indexed by the existing loop.

When `activation_order=True` the Hessian is permuted BEFORE factorization (Cholesky does not commute with permutation). The stored g_idx/scale/zero layout and the loop semantics are unchanged.

## Evidence

### Quality

dense-inverse (OLD) vs Cholesky (NEW) math on fixed random int4 layers (in=256, out=128), sharing one quantizer so only the error-propagation math differs.

Metric: `tr((W-Wq) H (W-Wq)^T)` with the undamped `H`. Requirement `new <= old*1.02` met on every case:

```
  well_conditioned  (cond ~8):     new/old ~= 0.984-0.990
  ill_conditioned   (cond 1e6):    new/old ~= 0.291-0.321  (~3x lower error)
```

### Benchmark

calibration forward wall-time on a synthetic 4-block transformer (d_model=512, ffn=2048, EinsumDense Q/K/V/O projections, 128 sequences x 128 tokens, no downloads), batch_size=1 (old) vs 8 (new), best of 3 after warm-up:

```
  JAX GPU (RTX 4070 Ti SUPER):  4.638 s -> 0.698 s   = 6.64x
  JAX CPU:                      8.470 s -> 3.179 s   = 2.66x
```

Scripts:
https://gist.github.com/JyotinderSingh/9fef231ca674a6b383b248715af01a74

## Caveats / Non-goals

- Larger `calibration_batch_size` raises peak activation memory; the default of 8 is a conservative trade-off and can be lowered for large models.
- The benchmark isolates calibration forward time. The per-layer column-wise quantization loop (unchanged here) dominates end-to-end `model.quantize` wall-time on GPU due to many tiny kernel launches; speeding that up is out of scope for this change.
- Batched vs unbatched results are identical up to float reassociation; this does not change quantization quality (and the Cholesky path improves it).

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.