### PR TITLE
Add sparse categorical focal crossentropy

### DIFF
--- a/keras/api/_tf_keras/keras/losses/__init__.py
+++ b/keras/api/_tf_keras/keras/losses/__init__.py
@@ -43,6 +43,9 @@ from keras.src.losses.losses import Poisson as Poisson
 from keras.src.losses.losses import (
     SparseCategoricalCrossentropy as SparseCategoricalCrossentropy,
 )
+from keras.src.losses.losses import (
+    SparseCategoricalFocalCrossentropy as SparseCategoricalFocalCrossentropy,
+)
 from keras.src.losses.losses import SquaredHinge as SquaredHinge
 from keras.src.losses.losses import Tversky as Tversky
 from keras.src.losses.losses import binary_crossentropy as binary_crossentropy
@@ -80,6 +83,9 @@ from keras.src.losses.losses import mean_squared_logarithmic_error as msle
 from keras.src.losses.losses import poisson as poisson
 from keras.src.losses.losses import (
     sparse_categorical_crossentropy as sparse_categorical_crossentropy,
+)
+from keras.src.losses.losses import (
+    sparse_categorical_focal_crossentropy as sparse_categorical_focal_crossentropy,
 )
 from keras.src.losses.losses import squared_hinge as squared_hinge
 from keras.src.losses.losses import tversky as tversky

--- a/keras/api/losses/__init__.py
+++ b/keras/api/losses/__init__.py
@@ -42,6 +42,9 @@ from keras.src.losses.losses import Poisson as Poisson
 from keras.src.losses.losses import (
     SparseCategoricalCrossentropy as SparseCategoricalCrossentropy,
 )
+from keras.src.losses.losses import (
+    SparseCategoricalFocalCrossentropy as SparseCategoricalFocalCrossentropy,
+)
 from keras.src.losses.losses import SquaredHinge as SquaredHinge
 from keras.src.losses.losses import Tversky as Tversky
 from keras.src.losses.losses import binary_crossentropy as binary_crossentropy
@@ -77,6 +80,9 @@ from keras.src.losses.losses import (
 from keras.src.losses.losses import poisson as poisson
 from keras.src.losses.losses import (
     sparse_categorical_crossentropy as sparse_categorical_crossentropy,
+)
+from keras.src.losses.losses import (
+    sparse_categorical_focal_crossentropy as sparse_categorical_focal_crossentropy,
 )
 from keras.src.losses.losses import squared_hinge as squared_hinge
 from keras.src.losses.losses import tversky as tversky

--- a/keras/src/losses/__init__.py
+++ b/keras/src/losses/__init__.py
@@ -22,6 +22,7 @@ from keras.src.losses.losses import MeanSquaredError
 from keras.src.losses.losses import MeanSquaredLogarithmicError
 from keras.src.losses.losses import Poisson
 from keras.src.losses.losses import SparseCategoricalCrossentropy
+from keras.src.losses.losses import SparseCategoricalFocalCrossentropy
 from keras.src.losses.losses import SquaredHinge
 from keras.src.losses.losses import Tversky
 from keras.src.losses.losses import binary_crossentropy
@@ -43,6 +44,7 @@ from keras.src.losses.losses import mean_squared_error
 from keras.src.losses.losses import mean_squared_logarithmic_error
 from keras.src.losses.losses import poisson
 from keras.src.losses.losses import sparse_categorical_crossentropy
+from keras.src.losses.losses import sparse_categorical_focal_crossentropy
 from keras.src.losses.losses import squared_hinge
 from keras.src.losses.losses import tversky
 from keras.src.saving import serialization_lib
@@ -59,6 +61,7 @@ ALL_OBJECTS = {
     CategoricalCrossentropy,
     CategoricalFocalCrossentropy,
     SparseCategoricalCrossentropy,
+    SparseCategoricalFocalCrossentropy,
     # Regression
     MeanSquaredError,
     MeanAbsoluteError,
@@ -86,6 +89,7 @@ ALL_OBJECTS = {
     categorical_crossentropy,
     categorical_focal_crossentropy,
     sparse_categorical_crossentropy,
+    sparse_categorical_focal_crossentropy,
     # Regression
     mean_squared_error,
     mean_absolute_error,

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -6,6 +6,7 @@ from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.losses.loss import Loss
+from keras.src.losses.loss import reduce_weighted_values
 from keras.src.losses.loss import squeeze_or_expand_to_same_rank
 from keras.src.saving import serialization_lib
 from keras.src.utils.numerical_utils import build_pos_neg_masks
@@ -1174,6 +1175,149 @@ class CategoricalFocalCrossentropy(LossFunctionWrapper):
         return config
 
 
+@keras_export("keras.losses.SparseCategoricalFocalCrossentropy")
+class SparseCategoricalFocalCrossentropy(LossFunctionWrapper):
+    """Computes the sparse categorical focal crossentropy loss.
+
+    Use this crossentropy loss function when there are two or more label
+    classes and labels are provided as integers. If you want to provide labels
+    using a `one-hot` representation, please use
+    `CategoricalFocalCrossentropy` loss.
+
+    Focal loss applies a modulating factor to down-weight easy examples and
+    focus more on hard examples. For each example, the loss is:
+
+    `FL(p_t) = -alpha_t * (1 - p_t) ** gamma * log(p_t)`
+
+    where `p_t` is the predicted probability of the true class, `gamma` is the
+    focusing parameter, and `alpha_t` is the weight for the true class. When
+    `gamma=0`, there is no focal effect on the crossentropy loss.
+
+    Args:
+        alpha: A weight balancing factor for all classes. Defaults to `0.25`.
+            It can be a list of floats or a scalar. If a list is provided, it
+            must have the same length as the number of classes.
+        gamma: A focusing parameter. Defaults to `2.0`. It gradually reduces
+            the importance given to easy examples.
+        from_logits: Whether `y_pred` is expected to be a logits tensor. By
+            default, `y_pred` is expected to encode a probability distribution.
+        ignore_class: Optional integer. The ID of a class to be ignored during
+            loss computation. This is useful, for example, in segmentation
+            problems featuring a "void" class (commonly -1 or 255). By default
+            (`ignore_class=None`), all classes are considered.
+        axis: The axis along which to compute crossentropy (the features axis).
+            Defaults to `-1`.
+        reduction: Type of reduction to apply to the loss. In almost all cases
+            this should be `"sum_over_batch_size"`. Supported options are
+            `"sum"`, `"sum_over_batch_size"`, `"mean"`,
+            `"mean_with_sample_weight"` or `None`. `"sum"` sums the loss,
+            `"sum_over_batch_size"` and `"mean"` sum the loss and divide by the
+            sample size, and `"mean_with_sample_weight"` sums the loss and
+            divides by the sum of the sample weights. `"none"` and `None`
+            perform no aggregation. Defaults to `"sum_over_batch_size"`.
+        name: Optional name for the loss instance.
+        dtype: The dtype of the loss's computations. Defaults to `None`, which
+            means using `keras.backend.floatx()`. `keras.backend.floatx()` is a
+            `"float32"` unless set to a different value (via
+            `keras.backend.set_floatx()`). If a `keras.DTypePolicy` is provided,
+            then the `compute_dtype` will be utilized.
+
+    Examples:
+
+    >>> y_true = np.array([1, 2])
+    >>> y_pred = np.array([[0.05, 0.95, 0], [0.1, 0.8, 0.1]])
+    >>> loss = keras.losses.SparseCategoricalFocalCrossentropy(
+    ...     reduction=None
+    ... )
+    >>> loss(y_true, y_pred)
+    array([3.2058e-05, 4.6627e-01], dtype=float32)
+
+    Usage with the `compile()` API:
+
+    ```python
+    model.compile(
+        optimizer="adam",
+        loss=keras.losses.SparseCategoricalFocalCrossentropy(),
+    )
+    ```
+
+    An out-of-range, non-ignored label produces a `NaN` loss value. An `alpha`
+    vector with a statically known wrong length raises `ValueError`; if its
+    length or the class dimension is only known at runtime, a mismatch produces
+    `NaN` loss values. This prevents backend-dependent index selection in
+    compiled and symbolic execution, where Keras does not have a portable
+    runtime assertion primitive.
+    """
+
+    def __init__(
+        self,
+        alpha=0.25,
+        gamma=2.0,
+        from_logits=False,
+        ignore_class=None,
+        axis=-1,
+        reduction="sum_over_batch_size",
+        name="sparse_categorical_focal_crossentropy",
+        dtype=None,
+    ):
+        super().__init__(
+            sparse_categorical_focal_crossentropy,
+            name=name,
+            reduction=reduction,
+            dtype=dtype,
+            alpha=alpha,
+            gamma=gamma,
+            from_logits=from_logits,
+            ignore_class=ignore_class,
+            axis=axis,
+        )
+
+    def __call__(self, y_true, y_pred, sample_weight=None):
+        # Sparse labels must retain their integer dtype until the loss validates
+        # and gathers them. In particular, bfloat16 cannot represent every
+        # integer above 256. The generic Loss.__call__ casts both arguments to
+        # the compute dtype, which can silently change a valid class ID or an
+        # out-of-range ignore sentinel.
+        in_mask = backend.get_keras_mask(y_pred)
+
+        with ops.name_scope(self.name):
+            y_pred = tree.map_structure(
+                lambda x: ops.convert_to_tensor(x, dtype=self.dtype), y_pred
+            )
+            y_true = tree.map_structure(ops.convert_to_tensor, y_true)
+
+            loss_values = self.call(y_true, y_pred)
+            out_mask = backend.get_keras_mask(loss_values)
+
+            if in_mask is not None and out_mask is not None:
+                mask = in_mask & out_mask
+            elif in_mask is not None:
+                mask = in_mask
+            elif out_mask is not None:
+                mask = out_mask
+            else:
+                mask = None
+
+            return reduce_weighted_values(
+                loss_values,
+                sample_weight=sample_weight,
+                mask=mask,
+                reduction=self.reduction,
+                dtype=self.dtype,
+            )
+
+    def call(self, y_true, y_pred):
+        # Shape handling for this loss is relative to its configurable class
+        # axis. Bypass LossFunctionWrapper's last-axis rank adjustment and let
+        # the focal loss perform its axis-aware validation and squeeze.
+        return self.fn(y_true, y_pred, **self._fn_kwargs)
+
+    def get_config(self):
+        config = super().get_config()
+        config.pop("fn")
+        return config
+
+
 @keras_export("keras.losses.SparseCategoricalCrossentropy")
 class SparseCategoricalCrossentropy(LossFunctionWrapper):
     """Computes the crossentropy loss between the labels and predictions.
@@ -2305,6 +2449,189 @@ def categorical_focal_crossentropy(
     focal_cce = ops.multiply(weighting_factor, cce)
     focal_cce = ops.sum(focal_cce, axis=axis)
     return focal_cce
+
+
+@keras_export("keras.losses.sparse_categorical_focal_crossentropy")
+def sparse_categorical_focal_crossentropy(
+    y_true,
+    y_pred,
+    alpha=0.25,
+    gamma=2.0,
+    from_logits=False,
+    ignore_class=None,
+    axis=-1,
+):
+    """Computes the sparse categorical focal crossentropy loss.
+
+    Args:
+        y_true: Tensor of integer true targets.
+        y_pred: Tensor of predicted targets.
+        alpha: A weight balancing factor for all classes. Defaults to `0.25`.
+            It can be a list of floats or a scalar. If a list is provided, it
+            must have the same length as the number of classes.
+        gamma: A focusing parameter. Defaults to `2.0`. It gradually reduces
+            the importance given to easy examples. When `gamma=0`, there is no
+            focal effect on the crossentropy loss.
+        from_logits: Whether `y_pred` is expected to be a logits tensor. By
+            default, `y_pred` is expected to encode a probability distribution.
+        ignore_class: Optional integer. The ID of a class to be ignored during
+            loss computation. This is useful, for example, in segmentation
+            problems featuring a "void" class (commonly -1 or 255). By default
+            (`ignore_class=None`), all classes are considered.
+        axis: The axis along which to compute crossentropy (the features axis).
+            Defaults to `-1`.
+
+    Returns:
+        Sparse categorical focal crossentropy loss value.
+
+        An out-of-range, non-ignored label produces a `NaN` loss value. An
+        `alpha` vector with a statically known wrong length raises `ValueError`;
+        if its length or the class dimension is only known at runtime, a
+        mismatch produces `NaN` loss values. This prevents backend-dependent
+        index selection in compiled and symbolic execution, where Keras does
+        not have a portable runtime assertion primitive.
+
+    Example:
+
+    >>> y_true = [1, 2]
+    >>> y_pred = [[0.05, 0.95, 0], [0.1, 0.8, 0.1]]
+    >>> loss = keras.losses.sparse_categorical_focal_crossentropy(
+    ...     y_true, y_pred
+    ... )
+    >>> assert loss.shape == (2,)
+    >>> loss
+    array([3.2058e-05, 4.6627e-01], dtype=float32)
+    """
+    if isinstance(axis, bool):
+        raise ValueError(
+            "`axis` must be of type `int`. "
+            f"Received: axis={axis} of type {type(axis)}"
+        )
+
+    y_pred = ops.convert_to_tensor(y_pred)
+    y_true = ops.convert_to_tensor(y_true)
+    if len(y_pred.shape) < 1:
+        raise ValueError(
+            "Argument `y_pred` must be at least rank 1. "
+            f"Received: y_pred.shape={y_pred.shape}"
+        )
+
+    axis = canonicalize_axis(axis, len(y_pred.shape))
+    if len(y_true.shape) == len(y_pred.shape) and y_true.shape[axis] == 1:
+        y_true = ops.squeeze(y_true, axis=axis)
+
+    expected_y_true_shape = y_pred.shape[:axis] + y_pred.shape[axis + 1 :]
+    if len(y_true.shape) != len(expected_y_true_shape) or any(
+        true_dim is not None and pred_dim is not None and true_dim != pred_dim
+        for true_dim, pred_dim in zip(y_true.shape, expected_y_true_shape)
+    ):
+        raise ValueError(
+            "Arguments `y_true` and `y_pred` must have the same shape up "
+            "until the class dimension: "
+            f"y_true.shape={y_true.shape}, y_pred.shape={y_pred.shape}"
+        )
+
+    # Promote narrow labels before range checks. Casting the class count or an
+    # arbitrary `ignore_class` to the original dtype can overflow at valid
+    # boundaries such as 256 classes with uint8 labels. Preserve int64 inputs
+    # so very large invalid labels are identified before the gather, while using
+    # int32 otherwise to remain compatible with JAX's default dtype mode.
+    if backend.standardize_dtype(y_true.dtype) != "int64":
+        y_true = ops.cast(y_true, "int32")
+
+    valid_mask = None
+    if ignore_class is not None:
+        valid_mask = ops.not_equal(y_true, ignore_class)
+
+    static_num_classes = y_pred.shape[axis]
+    if static_num_classes is None:
+        # `ops.shape()` returns the static shape for a KerasTensor, including
+        # `None` dimensions. Derive the runtime class count from tensor sizes
+        # instead so symbolic inputs with an unknown class dimension work.
+        target_size = ops.maximum(ops.size(y_true), 1)
+        num_classes = ops.floor_divide(ops.size(y_pred), target_size)
+    else:
+        num_classes = static_num_classes
+    num_classes = ops.cast(num_classes, dtype=y_true.dtype)
+    in_range = ops.logical_and(
+        ops.greater_equal(y_true, 0), ops.less(y_true, num_classes)
+    )
+    if valid_mask is None:
+        labels_valid = in_range
+    else:
+        labels_valid = ops.logical_or(ops.logical_not(valid_mask), in_range)
+
+    # Gather only from valid indices. Invalid, non-ignored labels are changed
+    # to NaN below. This ops-only behavior is consistent in eager, symbolic,
+    # and compiled execution and avoids backend-specific assertions or host
+    # synchronization in the loss hot path.
+    safe_y_true = ops.where(in_range, y_true, 0)
+    safe_y_true = ops.cast(safe_y_true, "int32")
+    if from_logits:
+        y_pred = ops.softmax(y_pred, axis=axis)
+
+    output = y_pred / ops.sum(y_pred, axis=axis, keepdims=True)
+    output = ops.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
+    true_class_prob = ops.take_along_axis(
+        output, ops.expand_dims(safe_y_true, axis=axis), axis=axis
+    )
+    true_class_prob = ops.squeeze(true_class_prob, axis=axis)
+
+    alpha = ops.convert_to_tensor(alpha, dtype=output.dtype)
+    alpha_rank = len(alpha.shape)
+    if alpha_rank not in (0, 1):
+        raise ValueError(
+            "`alpha` must be a scalar or a rank-1 tensor. "
+            f"Received: alpha.shape={alpha.shape}"
+        )
+
+    alpha_length_valid = None
+    if alpha_rank == 1:
+        alpha_length = alpha.shape[0]
+        if alpha_length is not None and static_num_classes is not None:
+            if alpha_length != static_num_classes:
+                raise ValueError(
+                    "When `alpha` is a list or rank-1 tensor, it must contain "
+                    "one value per class. "
+                    f"Received: alpha.shape={alpha.shape} and "
+                    f"y_pred.shape={y_pred.shape}"
+                )
+        else:
+            alpha_length_valid = ops.equal(ops.size(alpha), num_classes)
+
+    if alpha_rank == 0:
+        alpha_t = alpha
+    else:
+        alpha_indices = safe_y_true
+        if alpha_length_valid is not None:
+            alpha_length = ops.size(alpha)
+            alpha = ops.concatenate(
+                [alpha, ops.zeros((1,), dtype=alpha.dtype)], axis=0
+            )
+            alpha_indices = ops.minimum(
+                alpha_indices, ops.cast(alpha_length, dtype=alpha_indices.dtype)
+            )
+        alpha_t = ops.take(alpha, alpha_indices, axis=0)
+
+    loss = ops.negative(
+        ops.multiply(
+            alpha_t,
+            ops.multiply(
+                ops.power(1.0 - true_class_prob, gamma),
+                ops.log(true_class_prob),
+            ),
+        )
+    )
+    nan = ops.cast(float("nan"), dtype=loss.dtype)
+    loss = ops.where(labels_valid, loss, nan)
+    if alpha_length_valid is not None:
+        loss = ops.where(alpha_length_valid, loss, nan)
+
+    if valid_mask is not None:
+        loss = ops.where(valid_mask, loss, 0.0)
+        backend.set_keras_mask(loss, mask=valid_mask)
+
+    return loss
 
 
 @keras_export(

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1271,6 +1271,11 @@ class SparseCategoricalFocalCrossentropy(LossFunctionWrapper):
             ignore_class=ignore_class,
             axis=axis,
         )
+        self.alpha = alpha
+        self.gamma = gamma
+        self.from_logits = from_logits
+        self.ignore_class = ignore_class
+        self.axis = axis
 
     def __call__(self, y_true, y_pred, sample_weight=None):
         # Sparse labels must retain their integer dtype until the loss validates
@@ -1313,8 +1318,16 @@ class SparseCategoricalFocalCrossentropy(LossFunctionWrapper):
         return self.fn(y_true, y_pred, **self._fn_kwargs)
 
     def get_config(self):
-        config = super().get_config()
-        config.pop("fn")
+        config = Loss.get_config(self)
+        config.update(
+            {
+                "alpha": self.alpha,
+                "gamma": self.gamma,
+                "from_logits": self.from_logits,
+                "ignore_class": self.ignore_class,
+                "axis": self.axis,
+            }
+        )
         return config
 
 

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 import pytest
+from absl.testing import parameterized
 
 from keras.src import backend
 from keras.src import testing
@@ -2017,50 +2018,53 @@ class SparseCategoricalFocalCrossentropyTest(testing.TestCase):
         self.assertEqual(config["axis"], 1)
         self.run_class_serialization_test(loss_obj)
 
-    def test_matches_categorical_focal_crossentropy(self):
+    @parameterized.named_parameters(
+        ("probabilities_scalar_alpha", False, 0.25),
+        ("probabilities_per_class_alpha", False, [0.1, 0.3, 0.6]),
+        ("logits_scalar_alpha", True, 0.25),
+        ("logits_per_class_alpha", True, [0.1, 0.3, 0.6]),
+    )
+    def test_matches_categorical_focal_crossentropy(self, from_logits, alpha):
         y_true = np.array([0, 1, 2])
         y_true_one_hot = np.eye(3)[y_true]
-        for from_logits in (False, True):
-            for alpha in (0.25, [0.1, 0.3, 0.6]):
-                with self.subTest(from_logits=from_logits, alpha=alpha):
-                    if from_logits:
-                        y_pred = np.array(
-                            [
-                                [8.0, 1.0, 1.0],
-                                [0.0, 9.0, 1.0],
-                                [2.0, 3.0, 5.0],
-                            ]
-                        )
-                    else:
-                        y_pred = np.array(
-                            [
-                                [0.9, 0.05, 0.05],
-                                [0.5, 0.89, 0.6],
-                                [0.05, 0.01, 0.94],
-                            ],
-                            dtype="float32",
-                        )
+        if from_logits:
+            y_pred = np.array(
+                [
+                    [8.0, 1.0, 1.0],
+                    [0.0, 9.0, 1.0],
+                    [2.0, 3.0, 5.0],
+                ]
+            )
+        else:
+            y_pred = np.array(
+                [
+                    [0.9, 0.05, 0.05],
+                    [0.5, 0.89, 0.6],
+                    [0.05, 0.01, 0.94],
+                ],
+                dtype="float32",
+            )
 
-                    categorical_alpha = (
-                        alpha
-                        if np.ndim(alpha) == 0
-                        else backend.convert_to_tensor(alpha, dtype="float32")
-                    )
-                    expected = losses.categorical_focal_crossentropy(
-                        y_true_one_hot,
-                        y_pred,
-                        alpha=categorical_alpha,
-                        gamma=1.5,
-                        from_logits=from_logits,
-                    )
-                    result = losses.sparse_categorical_focal_crossentropy(
-                        y_true,
-                        y_pred,
-                        alpha=alpha,
-                        gamma=1.5,
-                        from_logits=from_logits,
-                    )
-                    self.assertAllClose(result, expected)
+        categorical_alpha = (
+            alpha
+            if np.ndim(alpha) == 0
+            else backend.convert_to_tensor(alpha, dtype="float32")
+        )
+        expected = losses.categorical_focal_crossentropy(
+            y_true_one_hot,
+            y_pred,
+            alpha=categorical_alpha,
+            gamma=1.5,
+            from_logits=from_logits,
+        )
+        result = losses.sparse_categorical_focal_crossentropy(
+            y_true,
+            y_pred,
+            alpha=alpha,
+            gamma=1.5,
+            from_logits=from_logits,
+        )
+        self.assertAllClose(result, expected)
 
     def test_gamma_zero_matches_weighted_sparse_crossentropy(self):
         y_true = np.array([0, 1, 2])
@@ -2118,6 +2122,25 @@ class SparseCategoricalFocalCrossentropyTest(testing.TestCase):
         )(np.array([255, 255]), y_pred[:2])
         self.assertAllClose(all_ignored_result, 0.0)
 
+    def test_ignore_class_combines_with_y_pred_mask(self):
+        y_true = np.array([0, 255, 2])
+        y_pred_values = np.array(
+            [[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.2, 0.7]],
+            dtype="float32",
+        )
+        y_pred = backend.convert_to_tensor(y_pred_values)
+        backend.set_keras_mask(
+            y_pred, backend.convert_to_tensor([False, True, True])
+        )
+
+        result = losses.SparseCategoricalFocalCrossentropy(
+            ignore_class=255, reduction=None
+        )(y_true, y_pred)
+        expected = losses.sparse_categorical_focal_crossentropy(
+            np.array([2]), y_pred_values[2:]
+        )
+        self.assertAllClose(result, [0.0, 0.0, expected[0]])
+
     def test_custom_axis(self):
         y_true = np.array([[0, 1], [2, 0]])
         y_true_one_hot = np.moveaxis(np.eye(3)[y_true], -1, 1)
@@ -2162,85 +2185,98 @@ class SparseCategoricalFocalCrossentropyTest(testing.TestCase):
         self.assertEqual(result.shape, (2, 2, 1))
         self.assertAllClose(result, expected)
 
-    def test_out_of_range_labels_produce_nan(self):
+    @parameterized.named_parameters(
+        ("negative", -1),
+        ("equal_to_num_classes", 3),
+        ("int64_max", np.iinfo("int64").max),
+    )
+    def test_out_of_range_labels_produce_nan(self, invalid_label):
         y_pred = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1]], dtype="float32")
-        invalid_labels = (-1, 3, np.iinfo("int64").max)
-        for invalid_label in invalid_labels:
-            with self.subTest(invalid_label=invalid_label):
-                y_true = np.array([0, invalid_label], dtype="int64")
-                result = losses.sparse_categorical_focal_crossentropy(
-                    y_true, y_pred
-                )
-                result = backend.convert_to_numpy(result)
-                self.assertTrue(np.isfinite(result[0]))
-                self.assertTrue(np.isnan(result[1]))
+        y_true = np.array([0, invalid_label], dtype="int64")
+        result = losses.sparse_categorical_focal_crossentropy(y_true, y_pred)
+        result = backend.convert_to_numpy(result)
+        self.assertTrue(np.isfinite(result[0]))
+        self.assertTrue(np.isnan(result[1]))
 
-    def test_out_of_range_ignore_class(self):
+    # JAX and NumPy standardize int64 label arrays to int32 before the loss
+    # sees them, so int64.max cannot remain a distinct sentinel.
+    @parameterized.named_parameters(
+        ("negative", -1),
+        ("equal_to_num_classes", 3),
+        ("int32_max", np.iinfo("int32").max),
+        *(
+            ()
+            if backend.backend() in ("jax", "numpy")
+            else (("int64_max", np.iinfo("int64").max),)
+        ),
+    )
+    def test_out_of_range_ignore_class(self, ignored_label):
         y_pred = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1]], dtype="float32")
-        ignored_labels = (-1, 3, np.iinfo("int32").max)
-        # JAX and NumPy standardize int64 label arrays to int32 before the
-        # loss sees them, so int64.max cannot remain a distinct sentinel.
-        if backend.backend() not in ("jax", "numpy"):
-            ignored_labels += (np.iinfo("int64").max,)
-        for ignored_label in ignored_labels:
-            with self.subTest(ignored_label=ignored_label):
-                y_true = np.array([0, ignored_label], dtype="int64")
-                result = losses.sparse_categorical_focal_crossentropy(
-                    y_true, y_pred, ignore_class=ignored_label
-                )
-                self.assertAllClose(result[1], 0.0)
+        y_true = np.array([0, ignored_label], dtype="int64")
+        result = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, ignore_class=ignored_label
+        )
+        self.assertAllClose(result[1], 0.0)
 
-    def test_alpha_shape_validation(self):
+    @parameterized.named_parameters(
+        ("too_short", [0.1, 0.2]),
+        ("too_long", [0.1, 0.2, 0.3, 0.4]),
+        ("rank_two", np.ones((3, 1))),
+    )
+    def test_alpha_shape_validation(self, alpha):
         y_true = np.array([0, 1])
         y_pred = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1]], dtype="float32")
-        for alpha in ([0.1, 0.2], [0.1, 0.2, 0.3, 0.4], np.ones((3, 1))):
-            with self.subTest(alpha_shape=np.shape(alpha)):
-                with self.assertRaisesRegex(
-                    ValueError, "`alpha` must|one value"
-                ):
-                    losses.sparse_categorical_focal_crossentropy(
-                        y_true, y_pred, alpha=alpha
-                    )
+        with self.assertRaisesRegex(ValueError, "`alpha` must|one value"):
+            losses.sparse_categorical_focal_crossentropy(
+                y_true, y_pred, alpha=alpha
+            )
 
-    def test_narrow_integer_labels(self):
-        for dtype, num_classes, label in (
-            ("uint8", 256, 255),
-            ("int8", 128, 127),
-        ):
-            with self.subTest(dtype=dtype, num_classes=num_classes):
-                y_true = np.array([label], dtype=dtype)
-                y_pred = np.full(
-                    (1, num_classes),
-                    0.1 / (num_classes - 1),
-                    dtype="float32",
-                )
-                y_pred[0, label] = 0.9
-                y_true_one_hot = np.eye(num_classes)[y_true.astype("int32")]
-                expected = losses.categorical_focal_crossentropy(
-                    y_true_one_hot, y_pred
-                )
-                result = losses.sparse_categorical_focal_crossentropy(
-                    y_true,
-                    y_pred,
-                    # This value is intentionally outside the label dtype.
-                    ignore_class=num_classes,
-                )
-                self.assertAllClose(result, expected)
+    @parameterized.named_parameters(
+        ("uint8", "uint8", 256, 255),
+        ("int8", "int8", 128, 127),
+    )
+    def test_narrow_integer_labels(self, dtype, num_classes, label):
+        y_true = np.array([label], dtype=dtype)
+        y_pred = np.full(
+            (1, num_classes),
+            0.1 / (num_classes - 1),
+            dtype="float32",
+        )
+        y_pred[0, label] = 0.9
+        y_true_one_hot = np.eye(num_classes)[y_true.astype("int32")]
+        expected = losses.categorical_focal_crossentropy(y_true_one_hot, y_pred)
+        result = losses.sparse_categorical_focal_crossentropy(
+            y_true,
+            y_pred,
+            # This value is intentionally outside the label dtype.
+            ignore_class=num_classes,
+        )
+        self.assertAllClose(result, expected)
 
-                loss_obj = losses.SparseCategoricalFocalCrossentropy(
-                    dtype="float16", ignore_class=num_classes, reduction=None
-                )
-                mixed_precision_result = loss_obj(y_true, y_pred)
-                self.assertDType(mixed_precision_result, "float16")
-                self.assertTrue(
-                    np.all(
-                        np.isfinite(
-                            backend.convert_to_numpy(mixed_precision_result)
-                        )
-                    )
-                )
+        loss_obj = losses.SparseCategoricalFocalCrossentropy(
+            dtype="float16", ignore_class=num_classes, reduction=None
+        )
+        mixed_precision_result = loss_obj(y_true, y_pred)
+        self.assertDType(mixed_precision_result, "float16")
+        self.assertTrue(
+            np.all(
+                np.isfinite(backend.convert_to_numpy(mixed_precision_result))
+            )
+        )
 
-    def test_class_preserves_labels_with_low_precision_dtype(self):
+    # JAX and NumPy standardize int64 label arrays to int32 before the loss
+    # sees them, so int64.max cannot remain a distinct sentinel.
+    @parameterized.named_parameters(
+        ("int32_max", np.iinfo("int32").max),
+        *(
+            ()
+            if backend.backend() in ("jax", "numpy")
+            else (("int64_max", np.iinfo("int64").max),)
+        ),
+    )
+    def test_class_preserves_labels_with_low_precision_dtype(
+        self, ignored_label
+    ):
         num_classes = 300
         label = 257
         y_true = np.array([label], dtype="int64")
@@ -2260,21 +2296,15 @@ class SparseCategoricalFocalCrossentropyTest(testing.TestCase):
         self.assertDType(result, "bfloat16")
         self.assertAllClose(result, expected)
 
-        ignored_labels = (np.iinfo("int32").max,)
-        # JAX and NumPy standardize int64 arrays before the loss sees them.
-        if backend.backend() not in ("jax", "numpy"):
-            ignored_labels += (np.iinfo("int64").max,)
-        for ignored_label in ignored_labels:
-            with self.subTest(ignored_label=ignored_label):
-                ignored_result = losses.SparseCategoricalFocalCrossentropy(
-                    dtype="bfloat16",
-                    ignore_class=ignored_label,
-                    reduction=None,
-                )(
-                    np.array([ignored_label], dtype="int64"),
-                    np.full((1, 3), 1 / 3, dtype="float32"),
-                )
-                self.assertAllClose(ignored_result, 0.0)
+        ignored_result = losses.SparseCategoricalFocalCrossentropy(
+            dtype="bfloat16",
+            ignore_class=ignored_label,
+            reduction=None,
+        )(
+            np.array([ignored_label], dtype="int64"),
+            np.full((1, 3), 1 / 3, dtype="float32"),
+        )
+        self.assertAllClose(ignored_result, 0.0)
 
     def test_symbolic_inputs(self):
         y_true = Input(shape=(), dtype="int32", name="y_true")

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -6,7 +6,9 @@ import pytest
 
 from keras.src import backend
 from keras.src import testing
+from keras.src.layers import Input
 from keras.src.losses import losses
+from keras.src.models import Functional
 
 
 class MeanSquaredErrorTest(testing.TestCase):
@@ -1991,6 +1993,424 @@ class CategoricalFocalCrossentropyTest(testing.TestCase):
         )
         loss = cce_obj(y_true, logits)
         self.assertDType(loss, "bfloat16")
+
+
+class SparseCategoricalFocalCrossentropyTest(testing.TestCase):
+    def test_config(self):
+        self.run_class_serialization_test(
+            losses.SparseCategoricalFocalCrossentropy(name="scfce")
+        )
+        loss_obj = losses.SparseCategoricalFocalCrossentropy(
+            alpha=[0.1, 0.2, 0.7],
+            gamma=1.5,
+            from_logits=True,
+            ignore_class=255,
+            axis=1,
+            reduction="sum",
+            name="scfce",
+        )
+        config = loss_obj.get_config()
+        self.assertEqual(config["alpha"], [0.1, 0.2, 0.7])
+        self.assertEqual(config["gamma"], 1.5)
+        self.assertEqual(config["from_logits"], True)
+        self.assertEqual(config["ignore_class"], 255)
+        self.assertEqual(config["axis"], 1)
+        self.run_class_serialization_test(loss_obj)
+
+    def test_matches_categorical_focal_crossentropy(self):
+        y_true = np.array([0, 1, 2])
+        y_true_one_hot = np.eye(3)[y_true]
+        for from_logits in (False, True):
+            for alpha in (0.25, [0.1, 0.3, 0.6]):
+                with self.subTest(from_logits=from_logits, alpha=alpha):
+                    if from_logits:
+                        y_pred = np.array(
+                            [
+                                [8.0, 1.0, 1.0],
+                                [0.0, 9.0, 1.0],
+                                [2.0, 3.0, 5.0],
+                            ]
+                        )
+                    else:
+                        y_pred = np.array(
+                            [
+                                [0.9, 0.05, 0.05],
+                                [0.5, 0.89, 0.6],
+                                [0.05, 0.01, 0.94],
+                            ],
+                            dtype="float32",
+                        )
+
+                    categorical_alpha = (
+                        alpha
+                        if np.ndim(alpha) == 0
+                        else backend.convert_to_tensor(alpha, dtype="float32")
+                    )
+                    expected = losses.categorical_focal_crossentropy(
+                        y_true_one_hot,
+                        y_pred,
+                        alpha=categorical_alpha,
+                        gamma=1.5,
+                        from_logits=from_logits,
+                    )
+                    result = losses.sparse_categorical_focal_crossentropy(
+                        y_true,
+                        y_pred,
+                        alpha=alpha,
+                        gamma=1.5,
+                        from_logits=from_logits,
+                    )
+                    self.assertAllClose(result, expected)
+
+    def test_gamma_zero_matches_weighted_sparse_crossentropy(self):
+        y_true = np.array([0, 1, 2])
+        y_pred = np.array(
+            [[0.8, 0.1, 0.1], [0.2, 0.7, 0.1], [0.1, 0.2, 0.7]],
+            dtype="float32",
+        )
+        alpha = np.array([0.2, 0.3, 0.5], dtype="float32")
+        expected = losses.sparse_categorical_crossentropy(
+            y_true, y_pred
+        ) * backend.convert_to_tensor(alpha[y_true])
+        result = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, alpha=alpha, gamma=0.0
+        )
+        self.assertAllClose(result, expected)
+
+    def test_ignore_class(self):
+        y_true = np.array([0, 255, 2])
+        y_pred = np.array(
+            [[0.8, 0.1, 0.1], [0.1, 0.8, 0.1], [0.1, 0.2, 0.7]],
+            dtype="float32",
+        )
+        loss_obj = losses.SparseCategoricalFocalCrossentropy(
+            ignore_class=255, reduction=None
+        )
+        function_result = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, ignore_class=255
+        )
+        self.assertAllEqual(
+            backend.get_keras_mask(function_result), [True, False, True]
+        )
+        result = loss_obj(y_true, y_pred)
+        expected_valid = losses.sparse_categorical_focal_crossentropy(
+            y_true[[0, 2]], y_pred[[0, 2]]
+        )
+        self.assertAllClose(result, [expected_valid[0], 0.0, expected_valid[1]])
+
+        weighted_result = loss_obj(
+            y_true, y_pred, sample_weight=np.array([2.0, 100.0, 3.0])
+        )
+        self.assertAllClose(
+            weighted_result,
+            [expected_valid[0] * 2.0, 0.0, expected_valid[1] * 3.0],
+        )
+
+        reduced_result = losses.SparseCategoricalFocalCrossentropy(
+            ignore_class=255
+        )(y_true, y_pred)
+        self.assertAllClose(
+            reduced_result, np.mean(backend.convert_to_numpy(expected_valid))
+        )
+
+        all_ignored_result = losses.SparseCategoricalFocalCrossentropy(
+            ignore_class=255
+        )(np.array([255, 255]), y_pred[:2])
+        self.assertAllClose(all_ignored_result, 0.0)
+
+    def test_custom_axis(self):
+        y_true = np.array([[0, 1], [2, 0]])
+        y_true_one_hot = np.moveaxis(np.eye(3)[y_true], -1, 1)
+        y_pred = np.array(
+            [
+                [[0.8, 0.1], [0.1, 0.7], [0.1, 0.2]],
+                [[0.1, 0.6], [0.2, 0.2], [0.7, 0.2]],
+            ],
+            dtype="float32",
+        )
+        expected = losses.categorical_focal_crossentropy(
+            y_true_one_hot, y_pred, gamma=1.5, axis=1
+        )
+        result = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, gamma=1.5, axis=1
+        )
+        self.assertAllClose(result, expected)
+
+    def test_class_custom_axis_with_trailing_singleton_dimension(self):
+        y_true = np.array([[[0], [1]], [[2], [0]]], dtype="int32")
+        y_pred = np.array(
+            [
+                [
+                    [[0.8], [0.1]],
+                    [[0.1], [0.7]],
+                    [[0.1], [0.2]],
+                ],
+                [
+                    [[0.1], [0.6]],
+                    [[0.2], [0.2]],
+                    [[0.7], [0.2]],
+                ],
+            ],
+            dtype="float32",
+        )
+        expected = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, axis=1
+        )
+        result = losses.SparseCategoricalFocalCrossentropy(
+            axis=1, reduction=None
+        )(y_true, y_pred)
+        self.assertEqual(result.shape, (2, 2, 1))
+        self.assertAllClose(result, expected)
+
+    def test_out_of_range_labels_produce_nan(self):
+        y_pred = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1]], dtype="float32")
+        invalid_labels = (-1, 3, np.iinfo("int64").max)
+        for invalid_label in invalid_labels:
+            with self.subTest(invalid_label=invalid_label):
+                y_true = np.array([0, invalid_label], dtype="int64")
+                result = losses.sparse_categorical_focal_crossentropy(
+                    y_true, y_pred
+                )
+                result = backend.convert_to_numpy(result)
+                self.assertTrue(np.isfinite(result[0]))
+                self.assertTrue(np.isnan(result[1]))
+
+    def test_out_of_range_ignore_class(self):
+        y_pred = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1]], dtype="float32")
+        ignored_labels = (-1, 3, np.iinfo("int32").max)
+        # JAX and NumPy standardize int64 label arrays to int32 before the
+        # loss sees them, so int64.max cannot remain a distinct sentinel.
+        if backend.backend() not in ("jax", "numpy"):
+            ignored_labels += (np.iinfo("int64").max,)
+        for ignored_label in ignored_labels:
+            with self.subTest(ignored_label=ignored_label):
+                y_true = np.array([0, ignored_label], dtype="int64")
+                result = losses.sparse_categorical_focal_crossentropy(
+                    y_true, y_pred, ignore_class=ignored_label
+                )
+                self.assertAllClose(result[1], 0.0)
+
+    def test_alpha_shape_validation(self):
+        y_true = np.array([0, 1])
+        y_pred = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1]], dtype="float32")
+        for alpha in ([0.1, 0.2], [0.1, 0.2, 0.3, 0.4], np.ones((3, 1))):
+            with self.subTest(alpha_shape=np.shape(alpha)):
+                with self.assertRaisesRegex(
+                    ValueError, "`alpha` must|one value"
+                ):
+                    losses.sparse_categorical_focal_crossentropy(
+                        y_true, y_pred, alpha=alpha
+                    )
+
+    def test_narrow_integer_labels(self):
+        for dtype, num_classes, label in (
+            ("uint8", 256, 255),
+            ("int8", 128, 127),
+        ):
+            with self.subTest(dtype=dtype, num_classes=num_classes):
+                y_true = np.array([label], dtype=dtype)
+                y_pred = np.full(
+                    (1, num_classes),
+                    0.1 / (num_classes - 1),
+                    dtype="float32",
+                )
+                y_pred[0, label] = 0.9
+                y_true_one_hot = np.eye(num_classes)[y_true.astype("int32")]
+                expected = losses.categorical_focal_crossentropy(
+                    y_true_one_hot, y_pred
+                )
+                result = losses.sparse_categorical_focal_crossentropy(
+                    y_true,
+                    y_pred,
+                    # This value is intentionally outside the label dtype.
+                    ignore_class=num_classes,
+                )
+                self.assertAllClose(result, expected)
+
+                loss_obj = losses.SparseCategoricalFocalCrossentropy(
+                    dtype="float16", ignore_class=num_classes, reduction=None
+                )
+                mixed_precision_result = loss_obj(y_true, y_pred)
+                self.assertDType(mixed_precision_result, "float16")
+                self.assertTrue(
+                    np.all(
+                        np.isfinite(
+                            backend.convert_to_numpy(mixed_precision_result)
+                        )
+                    )
+                )
+
+    def test_class_preserves_labels_with_low_precision_dtype(self):
+        num_classes = 300
+        label = 257
+        y_true = np.array([label], dtype="int64")
+        y_pred = np.full(
+            (1, num_classes), 0.1 / (num_classes - 1), dtype="float32"
+        )
+        y_pred[0, label] = 0.9
+        low_precision_y_pred = backend.convert_to_tensor(
+            y_pred, dtype="bfloat16"
+        )
+        expected = losses.sparse_categorical_focal_crossentropy(
+            y_true, low_precision_y_pred
+        )
+        result = losses.SparseCategoricalFocalCrossentropy(
+            dtype="bfloat16", reduction=None
+        )(y_true, y_pred)
+        self.assertDType(result, "bfloat16")
+        self.assertAllClose(result, expected)
+
+        ignored_labels = (np.iinfo("int32").max,)
+        # JAX and NumPy standardize int64 arrays before the loss sees them.
+        if backend.backend() not in ("jax", "numpy"):
+            ignored_labels += (np.iinfo("int64").max,)
+        for ignored_label in ignored_labels:
+            with self.subTest(ignored_label=ignored_label):
+                ignored_result = losses.SparseCategoricalFocalCrossentropy(
+                    dtype="bfloat16",
+                    ignore_class=ignored_label,
+                    reduction=None,
+                )(
+                    np.array([ignored_label], dtype="int64"),
+                    np.full((1, 3), 1 / 3, dtype="float32"),
+                )
+                self.assertAllClose(ignored_result, 0.0)
+
+    def test_symbolic_inputs(self):
+        y_true = Input(shape=(), dtype="int32", name="y_true")
+        y_pred = Input(shape=(3,), name="y_pred")
+        result = losses.sparse_categorical_focal_crossentropy(y_true, y_pred)
+        self.assertEqual(result.shape, (None,))
+
+        class_result = losses.SparseCategoricalFocalCrossentropy(
+            reduction=None
+        )(y_true, y_pred)
+        self.assertEqual(class_result.shape, (None,))
+
+        model = Functional([y_true, y_pred], result)
+        class_model = Functional([y_true, y_pred], class_result)
+        input_values = [
+            np.array([0, 2], dtype="int32"),
+            np.array([[0.8, 0.1, 0.1], [0.1, 0.2, 0.7]], dtype="float32"),
+        ]
+        actual = model(input_values)
+        expected = losses.sparse_categorical_focal_crossentropy(
+            input_values[0], input_values[1]
+        )
+        self.assertAllClose(actual, expected)
+        self.assertAllClose(class_model(input_values), expected)
+
+        invalid = model(
+            [
+                np.array([0, 3], dtype="int32"),
+                np.array([[0.8, 0.1, 0.1], [0.1, 0.2, 0.7]], dtype="float32"),
+            ]
+        )
+        invalid = backend.convert_to_numpy(invalid)
+        self.assertTrue(np.isfinite(invalid[0]))
+        self.assertTrue(np.isnan(invalid[1]))
+
+    def test_symbolic_dynamic_class_dimension(self):
+        y_true = Input(shape=(), dtype="int32")
+        y_pred = Input(shape=(None,))
+        result = losses.sparse_categorical_focal_crossentropy(y_true, y_pred)
+        self.assertEqual(result.shape, (None,))
+        model = Functional([y_true, y_pred], result)
+        actual = model(
+            [
+                np.array([0, 2], dtype="int32"),
+                np.array([[0.8, 0.1, 0.1], [0.1, 0.2, 0.7]], dtype="float32"),
+            ]
+        )
+        expected = losses.sparse_categorical_focal_crossentropy(
+            np.array([0, 2], dtype="int32"),
+            np.array([[0.8, 0.1, 0.1], [0.1, 0.2, 0.7]], dtype="float32"),
+        )
+        self.assertAllClose(actual, expected)
+
+        weighted_result = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, alpha=[0.1, 0.2, 0.7]
+        )
+        weighted_model = Functional([y_true, y_pred], weighted_result)
+        actual = weighted_model(
+            [
+                np.array([0, 2], dtype="int32"),
+                np.array([[0.8, 0.1, 0.1], [0.1, 0.2, 0.7]], dtype="float32"),
+            ]
+        )
+        expected = losses.sparse_categorical_focal_crossentropy(
+            np.array([0, 2], dtype="int32"),
+            np.array([[0.8, 0.1, 0.1], [0.1, 0.2, 0.7]], dtype="float32"),
+            alpha=[0.1, 0.2, 0.7],
+        )
+        self.assertAllClose(actual, expected)
+
+        invalid_alpha_result = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, alpha=[0.1, 0.2]
+        )
+        invalid_alpha_model = Functional([y_true, y_pred], invalid_alpha_result)
+        invalid_alpha = invalid_alpha_model(
+            [
+                np.array([0, 2], dtype="int32"),
+                np.array([[0.8, 0.1, 0.1], [0.1, 0.2, 0.7]], dtype="float32"),
+            ]
+        )
+        self.assertTrue(
+            np.all(np.isnan(backend.convert_to_numpy(invalid_alpha)))
+        )
+
+        y_true = Input(shape=(2,), dtype="int32")
+        y_pred = Input(shape=(None, 2))
+        result = losses.sparse_categorical_focal_crossentropy(
+            y_true, y_pred, axis=1
+        )
+        self.assertEqual(result.shape, (None, 2))
+        model = Functional([y_true, y_pred], result)
+        y_true_value = np.array([[0, 1], [2, 0]], dtype="int32")
+        y_pred_value = np.array(
+            [
+                [[0.8, 0.1], [0.1, 0.7], [0.1, 0.2]],
+                [[0.1, 0.6], [0.2, 0.2], [0.7, 0.2]],
+            ],
+            dtype="float32",
+        )
+        actual = model([y_true_value, y_pred_value])
+        expected = losses.sparse_categorical_focal_crossentropy(
+            y_true_value, y_pred_value, axis=1
+        )
+        self.assertAllClose(actual, expected)
+
+    def test_integer_predictions(self):
+        y_true = np.array([0, 1])
+        y_true_one_hot = np.eye(3, dtype="int32")[y_true]
+        y_pred = np.array([[2, 1, 1], [1, 3, 1]], dtype="int32")
+        expected = losses.categorical_focal_crossentropy(
+            y_true_one_hot, y_pred.astype("float32")
+        )
+        result = losses.sparse_categorical_focal_crossentropy(y_true, y_pred)
+        self.assertAllClose(result, expected)
+
+    def test_singleton_class_dimension_in_targets(self):
+        y_true = np.array([[0], [1], [2]])
+        y_pred = np.array(
+            [[0.8, 0.1, 0.1], [0.2, 0.7, 0.1], [0.1, 0.2, 0.7]],
+            dtype="float32",
+        )
+        result = losses.sparse_categorical_focal_crossentropy(y_true, y_pred)
+        expected = losses.sparse_categorical_focal_crossentropy(
+            np.squeeze(y_true, axis=-1), y_pred
+        )
+        self.assertAllClose(result, expected)
+
+    def test_dtype_arg(self):
+        y_true = np.array([0, 1, 2])
+        y_pred = np.array(
+            [[0.8, 0.1, 0.1], [0.2, 0.7, 0.1], [0.1, 0.2, 0.7]],
+            dtype="float32",
+        )
+        loss_obj = losses.SparseCategoricalFocalCrossentropy(dtype="bfloat16")
+        result = loss_obj(y_true, y_pred)
+        self.assertDType(result, "bfloat16")
 
 
 class CTCTest(testing.TestCase):


### PR DESCRIPTION
## Description

Adds sparse-label support for categorical focal crossentropy through:

- `keras.losses.sparse_categorical_focal_crossentropy`
- `keras.losses.SparseCategoricalFocalCrossentropy`

The implementation supports logits, scalar or per-class `alpha`, configurable `gamma`, `ignore_class`, arbitrary class axes, mixed precision, masking, symbolic tensors, and compiled execution across Keras backends.

It includes public API exports, serialization support, and comprehensive tests covering correctness, invalid labels, ignored classes, dtype boundaries, dynamic shapes, and custom axes.

Fixes #23442.

### Testing

- TensorFlow, JAX, NumPy, and Torch loss test suites
- TensorFlow XLA, JAX `jit`, and Torch `fullgraph`
- Public API and serialization checks
- Ruff lint and formatting checks

### AI-assisted contribution disclosure

I used an AI coding assistant during testing and review. I manually wrote, reviewed and tested the complete patch, understand its behavior, and accept responsibility for this contribution.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.