### PR TITLE
Update remaining backend.is_tensor usages to ops.is_tensor

### DIFF
--- a/keras/src/callbacks/model_checkpoint.py
+++ b/keras/src/callbacks/model_checkpoint.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 
-from keras.src import backend
+from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.callbacks.monitor_callback import MonitorCallback
 from keras.src.utils import file_utils
@@ -281,7 +281,7 @@ class ModelCheckpoint(MonitorCallback):
                 )
                 return True
             elif (
-                isinstance(current, np.ndarray) or backend.is_tensor(current)
+                isinstance(current, np.ndarray) or ops.is_tensor(current)
             ) and len(current.shape) > 0:
                 warnings.warn(
                     "Can save best model only when `monitor` is "

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -156,7 +156,7 @@ class DTypePolicy:
         """
 
         dtype = backend.standardize_dtype(dtype)
-        if backend.is_tensor(x):
+        if ops.is_tensor(x):
             if self._should_cast(x, autocast, dtype):
                 x = backend.cast(x, dtype=dtype)
             return x

--- a/keras/src/export/export_utils.py
+++ b/keras/src/export/export_utils.py
@@ -90,7 +90,7 @@ def make_input_spec(x):
         shape = (None,) + backend.standardize_shape(x.shape)[1:]
         dtype = backend.standardize_dtype(x.dtype)
         input_spec = layers.InputSpec(dtype=dtype, shape=shape, name=x.name)
-    elif backend.is_tensor(x):
+    elif ops.is_tensor(x):
         shape = (None,) + backend.standardize_shape(x.shape)[1:]
         dtype = backend.standardize_dtype(x.dtype)
         input_spec = layers.InputSpec(dtype=dtype, shape=shape, name=None)

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1018,7 +1018,7 @@ class Layer(BackendLayer, Operation):
                 # Record activity regularizer loss.
                 if self.activity_regularizer is not None:
                     for output in tree.flatten(outputs):
-                        if backend.is_tensor(output):
+                        if ops.is_tensor(output):
                             loss = self.activity_regularizer(output)
                             if output.ndim > 0:
                                 # Normalize by batch size to ensure consistent
@@ -1288,7 +1288,7 @@ class Layer(BackendLayer, Operation):
         # Eager only.
         losses = tree.flatten(loss)
         for x in losses:
-            if not backend.is_tensor(x):
+            if not ops.is_tensor(x):
                 raise ValueError(
                     "`add_loss()` can only be called from inside `build()` or "
                     f"`call()`, on a tensor input. Received invalid value: {x}"
@@ -1891,7 +1891,7 @@ class Layer(BackendLayer, Operation):
 def is_backend_tensor_or_symbolic(x, allow_none=False):
     if allow_none and x is None:
         return True
-    return backend.is_tensor(x) or isinstance(x, backend.KerasTensor)
+    return ops.is_tensor(x) or isinstance(x, backend.KerasTensor)
 
 
 class CallSpec:
@@ -1947,9 +1947,7 @@ class CallSpec:
         self.tensor_arguments_names = tensor_arg_names
         self.nested_tensor_argument_names = nested_tensor_arg_names
         self.first_arg = arg_dict[arg_names[0]]
-        if all(
-            backend.is_tensor(x) for x in self.tensor_arguments_dict.values()
-        ):
+        if all(ops.is_tensor(x) for x in self.tensor_arguments_dict.values()):
             self.eager = True
         else:
             self.eager = False

--- a/keras/src/layers/preprocessing/discretization.py
+++ b/keras/src/layers/preprocessing/discretization.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from keras.src import backend
+from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.preprocessing.data_layer import DataLayer
 from keras.src.utils import argument_validation
@@ -207,7 +208,7 @@ class Discretization(DataLayer):
             progbar.update(steps if steps is not None else i + 1, finalize=True)
         elif hasattr(data, "__iter__") and not (
             isinstance(data, np.ndarray)
-            or backend.is_tensor(data)
+            or ops.is_tensor(data)
             or tf.is_tensor(data)
         ):
             progbar = Progbar(target=steps, unit_name="step")

--- a/keras/src/layers/preprocessing/discretization_test.py
+++ b/keras/src/layers/preprocessing/discretization_test.py
@@ -9,6 +9,7 @@ from tensorflow import data as tf_data
 from keras.src import backend
 from keras.src import layers
 from keras.src import models
+from keras.src import ops
 from keras.src import testing
 from keras.src.saving import saving_api
 from keras.src.testing.test_utils import named_product
@@ -152,7 +153,7 @@ class DiscretizationTest(testing.TestCase):
         )
         output = layer(input_array)
         self.assertSparse(output, sparse)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, expected_output)
 
     def test_tf_data_compatibility(self):

--- a/keras/src/layers/preprocessing/hashing_test.py
+++ b/keras/src/layers/preprocessing/hashing_test.py
@@ -8,6 +8,7 @@ from absl.testing import parameterized
 from keras.src import backend
 from keras.src import layers
 from keras.src import models
+from keras.src import ops
 from keras.src import testing
 from keras.src.saving import load_model
 from keras.src.testing.test_utils import named_product
@@ -36,25 +37,25 @@ class HashingTest(testing.TestCase):
         layer = layers.Hashing(num_bins=3)
         inp = [["A"], ["B"], ["C"], ["D"], ["E"]]
         output = layer(inp)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[1], [0], [1], [1], [2]]))
 
         layer = layers.Hashing(num_bins=3, mask_value="")
         inp = [["A"], ["B"], [""], ["C"], ["D"]]
         output = layer(inp)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[1], [1], [0], [2], [2]]))
 
         layer = layers.Hashing(num_bins=3, salt=[133, 137])
         inp = [["A"], ["B"], ["C"], ["D"], ["E"]]
         output = layer(inp)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[1], [2], [1], [0], [2]]))
 
         layer = layers.Hashing(num_bins=3, salt=133)
         inp = [["A"], ["B"], ["C"], ["D"], ["E"]]
         output = layer(inp)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[0], [0], [2], [1], [0]]))
 
     def test_tf_data_compatibility(self):

--- a/keras/src/layers/preprocessing/image_preprocessing/resizing_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/resizing_test.py
@@ -7,6 +7,7 @@ from tensorflow import data as tf_data
 from keras.src import Sequential
 from keras.src import backend
 from keras.src import layers
+from keras.src import ops
 from keras.src import testing
 from keras.src.testing.test_utils import named_product
 
@@ -181,7 +182,7 @@ class ResizingTest(testing.TestCase):
         output_np = backend.convert_to_numpy(output)
 
         self.assertEqual(tuple(output_np.shape), output_shape)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         # Ensure the device of the data is on CPU.
         if backend.backend() == "tensorflow":
             self.assertIn("CPU", str(output.device).upper())

--- a/keras/src/layers/preprocessing/index_lookup.py
+++ b/keras/src/layers/preprocessing/index_lookup.py
@@ -3,6 +3,7 @@ import collections
 import numpy as np
 
 from keras.src import backend
+from keras.src import ops
 from keras.src.layers.layer import Layer
 from keras.src.saving import serialization_lib
 from keras.src.utils import argument_validation
@@ -663,7 +664,7 @@ class IndexLookup(Layer):
             progbar.update(steps if steps is not None else i + 1, finalize=True)
         elif hasattr(data, "__iter__") and not (
             isinstance(data, (list, tuple, np.ndarray))
-            or backend.is_tensor(data)
+            or ops.is_tensor(data)
             or tf.is_tensor(data)
         ):
             progbar = Progbar(target=steps, unit_name="step")

--- a/keras/src/layers/preprocessing/integer_lookup_test.py
+++ b/keras/src/layers/preprocessing/integer_lookup_test.py
@@ -6,6 +6,7 @@ from tensorflow import data as tf_data
 
 from keras.src import backend
 from keras.src import layers
+from keras.src import ops
 from keras.src import testing
 
 
@@ -30,10 +31,10 @@ class IntegerLookupTest(testing.TestCase):
         )
         layer.adapt(adapt_data)
         output = layer(single_sample_input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([1, 2, 0]))
         output = layer(batch_input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[1, 2, 0], [2, 3, 0]]))
 
         # one_hot mode
@@ -42,7 +43,7 @@ class IntegerLookupTest(testing.TestCase):
         )
         layer.adapt(adapt_data)
         output = layer(single_sample_input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(
             output, np.array([[0, 1, 0, 0], [0, 0, 1, 0], [1, 0, 0, 0]])
         )
@@ -53,7 +54,7 @@ class IntegerLookupTest(testing.TestCase):
         )
         layer.adapt(adapt_data)
         output = layer(single_sample_input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([1, 1, 1, 0]))
 
         # tf_idf mode
@@ -62,7 +63,7 @@ class IntegerLookupTest(testing.TestCase):
         )
         layer.adapt(adapt_data)
         output = layer(single_sample_input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(
             output, np.array([1.133732, 0.916291, 1.098612, 0.0])
         )
@@ -73,7 +74,7 @@ class IntegerLookupTest(testing.TestCase):
         )
         layer.adapt(adapt_data)
         output = layer([1, 2, 3, 4, 1, 2, 1])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([1, 3, 2, 1]))
 
     def test_fixed_vocabulary(self):
@@ -83,7 +84,7 @@ class IntegerLookupTest(testing.TestCase):
         )
         input_data = [2, 3, 4, 5]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([2, 3, 4, 0]))
 
     def test_set_vocabulary(self):
@@ -93,7 +94,7 @@ class IntegerLookupTest(testing.TestCase):
         layer.set_vocabulary([1, 2, 3, 4])
         input_data = [2, 3, 4, 5]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([2, 3, 4, 0]))
 
     def test_tf_data_compatibility(self):

--- a/keras/src/layers/preprocessing/normalization.py
+++ b/keras/src/layers/preprocessing/normalization.py
@@ -272,7 +272,7 @@ class Normalization(DataLayer):
                 mean and variance may be incorrectly computed.
         """
         data_is_iterable = False
-        if isinstance(data, np.ndarray) or backend.is_tensor(data):
+        if isinstance(data, np.ndarray) or ops.is_tensor(data):
             input_shape = data.shape
         elif isinstance(data, tf.data.Dataset):
 
@@ -339,7 +339,7 @@ class Normalization(DataLayer):
         if isinstance(data, np.ndarray):
             total_mean = np.mean(data, axis=self._reduce_axis)
             total_var = np.var(data, axis=self._reduce_axis)
-        elif backend.is_tensor(data):
+        elif ops.is_tensor(data):
             total_mean = ops.mean(data, axis=self._reduce_axis)
             total_var = ops.var(data, axis=self._reduce_axis)
         elif isinstance(data, (tf.data.Dataset, PyDataset)) or data_is_iterable:

--- a/keras/src/layers/preprocessing/rescaling_test.py
+++ b/keras/src/layers/preprocessing/rescaling_test.py
@@ -4,6 +4,7 @@ from tensorflow import data as tf_data
 
 from keras.src import backend
 from keras.src import layers
+from keras.src import ops
 from keras.src import testing
 
 
@@ -78,7 +79,7 @@ class RescalingTest(testing.TestCase):
         ds = grain.MapDataset.source(x).to_iter_dataset().batch(3).map(layer)
         output = next(iter(ds))
 
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         # Ensure the device of the data is on CPU.
         if backend.backend() == "tensorflow":
             self.assertIn("CPU", str(output.device).upper())

--- a/keras/src/layers/preprocessing/string_lookup_test.py
+++ b/keras/src/layers/preprocessing/string_lookup_test.py
@@ -9,6 +9,7 @@ from tensorflow import data as tf_data
 from keras.src import backend
 from keras.src import layers
 from keras.src import models
+from keras.src import ops
 from keras.src import saving
 from keras.src import testing
 from keras.src.ops import convert_to_tensor
@@ -67,7 +68,7 @@ class StringLookupTest(testing.TestCase):
         layer.adapt(["a", "a", "a", "b", "b", "c"])
         input_data = ["b", "c", "d"]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([2, 3, 0]))
         self.assertIn("a", [str(v) for v in layer.get_vocabulary()])
 
@@ -116,7 +117,7 @@ class StringLookupTest(testing.TestCase):
         )
         input_data = ["b", "c", "d"]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([2, 3, 0]))
 
     @pytest.mark.skipif(
@@ -144,7 +145,7 @@ class StringLookupTest(testing.TestCase):
         layer.set_vocabulary(["a", "b", "c"])
         input_data = ["b", "c", "d"]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([2, 3, 0]))
 
     def test_tf_data_compatibility(self):

--- a/keras/src/layers/preprocessing/text_vectorization.py
+++ b/keras/src/layers/preprocessing/text_vectorization.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from keras.src import backend
+from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.layers.layer import Layer
 from keras.src.layers.preprocessing.index_lookup import listify_tensors
@@ -440,7 +441,7 @@ class TextVectorization(Layer):
             progbar.update(steps if steps is not None else i + 1, finalize=True)
         elif hasattr(data, "__iter__") and not (
             isinstance(data, (list, tuple, np.ndarray))
-            or backend.is_tensor(data)
+            or ops.is_tensor(data)
             or tf.is_tensor(data)
         ):
             progbar = Progbar(target=steps, unit_name="step")
@@ -556,7 +557,7 @@ class TextVectorization(Layer):
         """
         if isinstance(inputs, np.ndarray):
             np_inputs = inputs
-        elif backend.is_tensor(inputs):
+        elif ops.is_tensor(inputs):
             np_inputs = backend.convert_to_numpy(inputs)
         else:
             np_inputs = np.asarray(inputs)
@@ -578,7 +579,7 @@ class TextVectorization(Layer):
     def _preprocess(self, inputs):
         if not isinstance(
             inputs, (tf.Tensor, tf.RaggedTensor, np.ndarray, list, tuple)
-        ) and backend.is_tensor(inputs):
+        ) and ops.is_tensor(inputs):
             inputs = backend.convert_to_numpy(inputs)
         with tf.device("CPU:0"):
             if (

--- a/keras/src/layers/preprocessing/text_vectorization_test.py
+++ b/keras/src/layers/preprocessing/text_vectorization_test.py
@@ -11,6 +11,7 @@ from keras.src import Sequential
 from keras.src import backend
 from keras.src import layers
 from keras.src import models
+from keras.src import ops
 from keras.src import saving
 from keras.src import testing
 
@@ -37,7 +38,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         layer.adapt(["foo bar", "bar baz", "baz bada boom"])
         input_data = [["foo qux bar"], ["qux baz"]]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[4, 1, 3, 0], [1, 2, 0, 0]]))
         self.assertIn("foo", [str(v) for v in layer.get_vocabulary()])
 
@@ -89,7 +90,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         )
         input_data = [["foo qux bar"], ["qux baz"]]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[4, 1, 3, 0], [1, 2, 0, 0]]))
 
     def test_set_vocabulary(self):
@@ -103,7 +104,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         layer.set_vocabulary(["baz", "bar", "foo"])
         input_data = [["foo qux bar"], ["qux baz"]]
         output = layer(input_data)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, np.array([[4, 1, 3, 0], [1, 2, 0, 0]]))
 
     @pytest.mark.skipif(
@@ -310,7 +311,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
             vocabulary=["hello", "world", "this", "is", "nice", "test"],
         )
         output = layer(["Hello, World!. This is just a nice test!"])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
 
         # test output sequence length, taking first batch.
         self.assertEqual(len(output[0]), 8)
@@ -331,7 +332,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
             ],
         )
         output = layer(["Hello, World!. This is just a nice test!"])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertEqual(len(output[0]), 8)
         """
         The input is lowercased and tokenized into words. The vocab is:
@@ -352,7 +353,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
             split="character", vocabulary=list("abcde"), output_mode="int"
         )
         output = layer(["abcf"])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertEqual(len(output[0]), 4)
         self.assertAllClose(output, [[2, 3, 4, 1]])
 
@@ -366,7 +367,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
             output_mode="int",
         )
         output = layer(["foo|bar"])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
 
         # after custom split, the outputted index should be the last
         # token in the vocab.
@@ -378,7 +379,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
             vocabulary=["Hello", "World", "Test"],
         )
         output = layer(["Hello, World! Test."])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         # Case is preserved, punctuation stripped
         self.assertAllClose(output, [[2, 3, 4]])
 
@@ -389,7 +390,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         )
         # "Hello" matches, "hello" does not (case-sensitive)
         output = layer(["Hello hello"])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, [[2, 1]])
 
     def test_custom_standardize_callable(self):
@@ -402,7 +403,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
             vocabulary=["foo", "bar"],
         )
         output = layer(["foo-bar"])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, [[2, 3]])
 
     def test_python_standardize_callable_non_tf_backend(self):
@@ -433,7 +434,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         self.assertIn("hello", vocab)
         self.assertIn("world.", vocab)
         output = layer(["Hello, world."])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
 
     def test_no_split(self):
         layer = layers.TextVectorization(
@@ -443,7 +444,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
         )
         # Each element is looked up as a whole string (no splitting)
         output = layer([["foo"], ["bar"], ["unknown"]])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         self.assertAllClose(output, [[2], [3], [1]])
 
     def test_ngrams_integer(self):
@@ -541,7 +542,7 @@ class TextVectorizationTest(testing.TestCase, parameterized.TestCase):
             vocabulary=["foo", "bar", "baz"],
         )
         output = layer(["foo bar"])
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(ops.is_tensor(output))
         # one_hot on a split sentence produces shape (1, num_tokens, vocab_size)
         self.assertEqual(output.shape[-1], 4)
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5608,8 +5608,8 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.array(x), np.array(x))
         self.assertAllClose(knp.Array()(x), np.array(x))
-        self.assertTrue(backend.is_tensor(knp.array(x)))
-        self.assertTrue(backend.is_tensor(knp.Array()(x)))
+        self.assertTrue(ops.is_tensor(knp.array(x)))
+        self.assertTrue(ops.is_tensor(knp.Array()(x)))
 
         # Check dtype conversion.
         x = [[1, 0, 1], [1, 1, 0]]

--- a/keras/src/ops/operation_test.py
+++ b/keras/src/ops/operation_test.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from conftest import skip_if_backend
 from keras.src import backend
+from keras.src import ops
 from keras.src import testing
 from keras.src.backend.common import keras_tensor
 from keras.src.ops import numpy as knp
@@ -185,25 +186,25 @@ class OperationTest(testing.TestCase):
 
         # Positional arguments
         out = op(x, y, z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Keyword arguments
         out = op(x=x, y=y, z=z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Mixed arguments
         out = op(x, y=y, z=z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Test multiple outputs
         op = OpWithMultipleOutputs()
         out = op(x)
         self.assertEqual(len(out), 2)
-        self.assertTrue(backend.is_tensor(out[0]))
-        self.assertTrue(backend.is_tensor(out[1]))
+        self.assertTrue(ops.is_tensor(out[0]))
+        self.assertTrue(ops.is_tensor(out[1]))
         self.assertAllClose(out[0], np.ones((2, 3)))
         self.assertAllClose(out[1], np.ones((2, 3)) + 1)
 
@@ -216,7 +217,7 @@ class OperationTest(testing.TestCase):
         with RematScope(mode="full"):
             op = OpWithMultipleInputs(name="test_op")
         out = op(x, x, x)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Test quantized rematerialized call
@@ -224,7 +225,7 @@ class OperationTest(testing.TestCase):
             op_q = OpWithQuantizedCall(name="test_op_q")
         op_q.quantization_mode = object()
         out = op_q(x)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(ops.is_tensor(out))
         self.assertAllClose(out, 2 * np.ones((2, 3)))
 
         # Test traceback filtering branch
@@ -235,7 +236,7 @@ class OperationTest(testing.TestCase):
             with RematScope(mode="full"):
                 op = OpWithMultipleInputs(name="test_op_traceback")
             out = op(x, x, x)
-            self.assertTrue(backend.is_tensor(out))
+            self.assertTrue(ops.is_tensor(out))
             self.assertAllClose(out, 6 * np.ones((2, 3)))
 
             # Quantized rematerialized
@@ -243,7 +244,7 @@ class OperationTest(testing.TestCase):
                 op_q = OpWithQuantizedCall(name="test_op_q_traceback")
             op_q.quantization_mode = object()
             out = op_q(x)
-            self.assertTrue(backend.is_tensor(out))
+            self.assertTrue(ops.is_tensor(out))
             self.assertAllClose(out, 2 * np.ones((2, 3)))
         finally:
             if not was_enabled:
@@ -375,7 +376,7 @@ class OperationTest(testing.TestCase):
             z = z.cpu()
         op = OpWithMultipleInputs()
         out = op(x, y, z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2,)))
 
     def test_valid_naming(self):

--- a/keras/src/random/seed_generator_test.py
+++ b/keras/src/random/seed_generator_test.py
@@ -50,11 +50,11 @@ class SeedGeneratorTest(testing.TestCase):
     def test_draw_seed_from_seed_generator(self):
         gen = seed_generator.SeedGenerator(seed=42)
         seed1 = seed_generator.draw_seed(gen)
-        self.assertTrue(backend.is_tensor(seed1))
+        self.assertTrue(ops.is_tensor(seed1))
 
     def test_draw_seed_from_integer(self):
         seed2 = seed_generator.draw_seed(12345)
-        self.assertTrue(backend.is_tensor(seed2))
+        self.assertTrue(ops.is_tensor(seed2))
         self.assertEqual(
             backend.standardize_dtype(seed2.dtype), backend.random_seed_dtype()
         )
@@ -64,7 +64,7 @@ class SeedGeneratorTest(testing.TestCase):
         # 2**31 is where signed-int32 wraps; 2**32 - 1 is the max uint32 value.
         for s in [2**31 - 1, 2**31, 2**32 - 1]:
             seed = seed_generator.draw_seed(s)
-            self.assertTrue(backend.is_tensor(seed))
+            self.assertTrue(ops.is_tensor(seed))
             self.assertEqual(
                 backend.standardize_dtype(seed.dtype),
                 backend.random_seed_dtype(),
@@ -75,7 +75,7 @@ class SeedGeneratorTest(testing.TestCase):
 
     def test_draw_seed_from_none(self):
         seed3 = seed_generator.draw_seed(None)
-        self.assertTrue(backend.is_tensor(seed3))
+        self.assertTrue(ops.is_tensor(seed3))
 
     def test_draw_seed_invalid(self):
         with self.assertRaisesRegex(

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from keras.src import api_export
 from keras.src import backend
+from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.backend.common import global_state
 from keras.src.saving import object_registration
@@ -216,7 +217,7 @@ def serialize_keras_object(obj):
         }
     if tf.available and isinstance(obj, tf.TensorShape):
         return obj.as_list() if obj._dims is not None else None
-    if backend.is_tensor(obj):
+    if ops.is_tensor(obj):
         return {
             "class_name": "__tensor__",
             "config": {

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -41,7 +41,7 @@ class TestCase(parameterized.TestCase):
     def convert_to_numpy(self, x):
         if isinstance(x, np.ndarray):
             return x
-        elif backend.is_tensor(x) or isinstance(x, backend.Variable):
+        elif ops.is_tensor(x) or isinstance(x, backend.Variable):
             return backend.convert_to_numpy(x)
         return np.array(x)
 

--- a/keras/src/utils/jax_layer.py
+++ b/keras/src/utils/jax_layer.py
@@ -6,6 +6,7 @@ import string
 import numpy as np
 
 from keras.src import backend
+from keras.src import ops
 from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.backend.common.variables import is_float_dtype
@@ -419,7 +420,7 @@ class JaxLayer(Layer):
         """
 
         def create_variable(value):
-            if backend.is_tensor(value) or isinstance(
+            if ops.is_tensor(value) or isinstance(
                 value, (np.ndarray, np.generic, jax.Array)
             ):
                 dtype = value.dtype

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -74,7 +74,9 @@ def to_categorical(x, num_classes=None):
     >>> print(np.around(loss, 5))
     [0. 0. 0. 0.]
     """
-    if backend.is_tensor(x):
+    from keras.src import ops
+
+    if ops.is_tensor(x):
         input_shape = backend.core.shape(x)
         # Shrink the last dimension if the shape is (..., 1).
         if (

--- a/keras/src/utils/numerical_utils_test.py
+++ b/keras/src/utils/numerical_utils_test.py
@@ -2,6 +2,7 @@ import numpy as np
 from absl.testing import parameterized
 
 from keras.src import backend
+from keras.src import ops
 from keras.src import testing
 from keras.src.utils import numerical_utils
 
@@ -50,7 +51,7 @@ class TestNumericalUtils(testing.TestCase):
             )
         )
         one_hot = numerical_utils.to_categorical(label, NUM_CLASSES)
-        self.assertTrue(backend.is_tensor(one_hot))
+        self.assertTrue(ops.is_tensor(one_hot))
         self.assertAllClose(one_hot, expected)
 
     @parameterized.parameters([1, 2, 3])
@@ -70,7 +71,7 @@ class TestNumericalUtils(testing.TestCase):
 
         # Test backend
         out = numerical_utils.normalize(xb, axis=-1, order=order)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(ops.is_tensor(out))
         self.assertAllClose(backend.convert_to_numpy(out), expected)
 
     def test_normalize_numpy_axis_zero(self):

--- a/keras/src/utils/python_utils.py
+++ b/keras/src/utils/python_utils.py
@@ -176,6 +176,7 @@ def pythonify_logs(logs):
         possible.
     """
     from keras.src import backend
+    from keras.src import ops
 
     logs = logs or {}
     result = {}
@@ -185,7 +186,7 @@ def pythonify_logs(logs):
         else:
             try:
                 # Prevent torch compiler from breaking the graph.
-                if backend.is_tensor(value):
+                if ops.is_tensor(value):
                     value = backend.convert_to_numpy(value)
                 value = float(value)
             except:

--- a/keras/src/utils/tf_utils.py
+++ b/keras/src/utils/tf_utils.py
@@ -30,8 +30,10 @@ def get_tensor_spec(t, dynamic_batch=False, name=None):
 
 def ensure_tensor(inputs, dtype=None):
     """Ensures the input is a Tensor, SparseTensor or RaggedTensor."""
+    from keras.src import ops
+
     if not isinstance(inputs, (tf.Tensor, tf.SparseTensor, tf.RaggedTensor)):
-        if backend.backend() == "torch" and backend.is_tensor(inputs):
+        if backend.backend() == "torch" and ops.is_tensor(inputs):
             # Plain `np.asarray()` conversion fails with PyTorch.
             inputs = backend.convert_to_numpy(inputs)
         inputs = tf.convert_to_tensor(inputs, dtype)

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -5,6 +5,7 @@ import types
 from functools import wraps
 
 from keras.src import backend
+from keras.src import ops
 from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.backend.common import global_state
@@ -269,7 +270,7 @@ def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
 
 
 def format_argument_value(value):
-    if backend.is_tensor(value):
+    if ops.is_tensor(value):
         # Simplified representation for eager / graph tensors
         # to keep messages readable
         if backend.backend() == "tensorflow":


### PR DESCRIPTION
Fixes #23485.

One thing to flag. The issue title says `backend.ops.is_tensor`, but that namespace is not on master after the pluggable backend rewind, so `hasattr(backend, "ops")` is `False` today. I followed #23480 and used `ops.is_tensor`. Happy to redo it against `backend.ops` once that lands.

Three things are left alone on purpose. `operation_utils.py` and `index_lookup_test.py` are already in #23480, so this stays out of its way. `random_crop.py` calls `self.backend.is_tensor`, where `self.backend` is a `DynamicBackend` instance rather than the module. The bare `is_tensor` calls in the torch and openvino backends are those backends using their own local definition.

`numerical_utils.py`, `tf_utils.py` and `python_utils.py` import `ops` inside the function, since a module level import is circular in the first two and there is no import block for it in the third.


### AI-assisted contribution disclosure

I used an AI coding assistant during testing and review, & ran the tests locally. I take full responsibility for this contribution, and I will be answering review comments myself.

---

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
