### PR TITLE
fix: guard GPTQ error correction against zero influence

### DIFF
--- a/keras/src/quantizers/gptq.py
+++ b/keras/src/quantizers/gptq.py
@@ -202,6 +202,10 @@ def gptq_quantize_matrix(
             current_block_influence = block_inv_hessian[block_idx, block_idx]
             # We divide by current_block_influence to get the
             # correct scaling of the error term.
+            current_block_influence = ops.maximum(
+                current_block_influence,
+                ops.cast(1e-12, current_block_influence.dtype),
+            )
             err = ops.divide(
                 ops.subtract(weight_column, dequantized_col),
                 current_block_influence,


### PR DESCRIPTION
Closes #23413

GPTQ error feedback now clamps the inverse-Hessian diagonal influence to a small positive epsilon before division. This prevents zero or underflowed influence values from propagating NaN/Inf through later weight updates.

Validation:
- `python3 -m compileall -q keras/src/quantizers/gptq.py keras/src/quantizers/gptq_test.py`
- `git diff --check`