### PR TITLE
Implement cov function in keras.ops

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -181,6 +181,7 @@ from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos
 from keras.src.ops.numpy import cosh as cosh
 from keras.src.ops.numpy import count_nonzero as count_nonzero
+from keras.src.ops.numpy import cov as cov
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -53,6 +53,7 @@ from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos
 from keras.src.ops.numpy import cosh as cosh
 from keras.src.ops.numpy import count_nonzero as count_nonzero
+from keras.src.ops.numpy import cov as cov
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -181,6 +181,7 @@ from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos
 from keras.src.ops.numpy import cosh as cosh
 from keras.src.ops.numpy import count_nonzero as count_nonzero
+from keras.src.ops.numpy import cov as cov
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -53,6 +53,7 @@ from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos
 from keras.src.ops.numpy import cosh as cosh
 from keras.src.ops.numpy import count_nonzero as count_nonzero
+from keras.src.ops.numpy import cov as cov
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1703,3 +1703,8 @@ def dsplit(x, indices_or_sections):
 def column_stack(xs):
     xs = [convert_to_tensor(x) for x in xs]
     return jnp.column_stack(xs)
+
+
+def cov(x):
+    x = convert_to_tensor(x)
+    return jnp.cov(x)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1854,3 +1854,16 @@ def column_stack(xs):
         dtype = dtypes.result_type(*dtype_set)
         xs = [x.astype(dtype) for x in xs]
     return np.column_stack(xs)
+
+
+def cov(x):
+    x = convert_to_tensor(x)
+
+    if x.dtype in ["int64", "float64"]:
+        dtype = "float64"
+    elif x.dtype in ["bfloat16", "float16"]:
+        dtype = x.dtype
+    else:
+        dtype = config.floatx()
+
+    return np.cov(x).astype(dtype)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -6064,3 +6064,49 @@ def column_stack(xs):
     processed_elems[0] = base
 
     return OpenVINOKerasTensor(ov_opset.concat(processed_elems, 1).output(0))
+
+
+def cov(x):
+    x_ov = get_ov_output(x)
+    if len(x_ov.get_partial_shape()) > 2:
+        raise ValueError(
+            "Input tensor must have at most 2 dimensions. "
+            f"Received: x.shape={x_ov.get_partial_shape()}"
+        )
+    x_type = x_ov.get_element_type()
+    ov_type = x_type
+
+    if x_type.is_integral():
+        ov_type = OPENVINO_DTYPES[config.floatx()]
+        x_ov = ov_opset.convert(x_ov, ov_type).output(0)
+
+    # `matmul` needs rank 2. A 1D input, or a single variable, yields a scalar
+    # variance, matching `np.cov`.
+    shape = x_ov.get_partial_shape()
+    rank = len(shape)
+    is_scalar = rank < 2 or (shape[0].is_static and shape[0].get_length() == 1)
+    if rank == 1:
+        x_ov = ov_opset.reshape(
+            x_ov, ov_opset.constant([1, -1], Type.i32).output(0), False
+        ).output(0)
+
+    const_zero = ov_opset.constant(0, dtype=Type.i32).output(0)
+    const_one = ov_opset.constant(1, dtype=Type.i32).output(0)
+
+    mean = ov_opset.reduce_mean(x_ov, const_one, True).output(0)
+    x_centered = ov_opset.subtract(x_ov, mean).output(0)
+
+    x_shape = ov_opset.shape_of(x_ov, Type.i32).output(0)
+    num_samples = ov_opset.gather(x_shape, const_one, const_zero).output(0)
+    num_samples = ov_opset.convert(num_samples, ov_type).output(0)
+    ddof = ov_opset.subtract(
+        num_samples, ov_opset.constant(1, dtype=ov_type).output(0)
+    ).output(0)
+
+    result = ov_opset.matmul(x_centered, x_centered, False, True).output(0)
+    result = ov_opset.divide(result, ddof).output(0)
+    if is_scalar:
+        result = ov_opset.reshape(
+            result, ov_opset.constant([], Type.i32).output(0), False
+        ).output(0)
+    return OpenVINOKerasTensor(result)

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -6080,10 +6080,15 @@ def cov(x):
         ov_type = OPENVINO_DTYPES[config.floatx()]
         x_ov = ov_opset.convert(x_ov, ov_type).output(0)
 
-    # `matmul` needs rank 2. A 1D input, or a single variable, yields a scalar
-    # variance, matching `np.cov`.
     shape = x_ov.get_partial_shape()
     rank = len(shape)
+    # A 0D input has no observations to vary over, as in `np.cov`. The constant
+    # is built as float32 because `bfloat16` rejects a Python float `nan`.
+    if rank == 0:
+        nan = ov_opset.constant(np.array(np.nan, dtype=np.float32)).output(0)
+        return OpenVINOKerasTensor(ov_opset.convert(nan, ov_type).output(0))
+
+    # `np.cov` squeezes the result when there is only one variable.
     is_scalar = rank < 2 or (shape[0].is_static and shape[0].get_length() == 1)
     if rank == 1:
         x_ov = ov_opset.reshape(

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -4056,8 +4056,11 @@ def cov(x):
         dtype = "float64"
     x = cast(x, dtype)
 
-    # `tf.matmul` requires rank 2. A 1D input, or a single variable, yields a
-    # scalar variance, matching `np.cov`.
+    # A 0D input has no observations to vary over, as in `np.cov`.
+    if len(x.shape) == 0:
+        return tf.constant(float("nan"), dtype=x.dtype)
+
+    # `np.cov` squeezes the result when there is only one variable.
     is_scalar = len(x.shape) < 2 or x.shape[0] == 1
     if len(x.shape) == 1:
         x = tf.reshape(x, (1, -1))

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -4039,3 +4039,34 @@ def column_stack(xs):
         xs = [tf.cast(x, dtype) for x in xs]
     xs = [tf.expand_dims(x, axis=-1) if len(x.shape) == 1 else x for x in xs]
     return tf.concat(xs, axis=1)
+
+
+def cov(x):
+    x = convert_to_tensor(x)
+    if len(x.shape) > 2:
+        raise ValueError(
+            "Input tensor must have at most 2 dimensions. "
+            f"Received: x.shape={x.shape}"
+        )
+
+    dtype = standardize_dtype(x.dtype)
+    if dtype in ["bool", "int8", "int16", "int32", "uint8", "uint16", "uint32"]:
+        dtype = config.floatx()
+    elif dtype == "int64":
+        dtype = "float64"
+    x = cast(x, dtype)
+
+    # `tf.matmul` requires rank 2. A 1D input, or a single variable, yields a
+    # scalar variance, matching `np.cov`.
+    is_scalar = len(x.shape) < 2 or x.shape[0] == 1
+    if len(x.shape) == 1:
+        x = tf.reshape(x, (1, -1))
+
+    mean = tf.reduce_mean(x, axis=-1, keepdims=True)
+    x_centered = x - mean
+
+    num_samples = tf.cast(tf.shape(x)[-1], x.dtype)
+    result = tf.matmul(x_centered, x_centered, adjoint_b=True) / (
+        num_samples - 1
+    )
+    return tf.reshape(result, ()) if is_scalar else result

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2499,6 +2499,11 @@ def column_stack(xs):
 
 def cov(x):
     x = convert_to_tensor(x)
+    if len(x.shape) > 2:
+        raise ValueError(
+            "Input tensor must have at most 2 dimensions. "
+            f"Received: x.shape={tuple(x.shape)}"
+        )
 
     if standardize_dtype(x.dtype) == "bool":
         x = cast(x, config.floatx())

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2495,3 +2495,14 @@ def column_stack(xs):
     dtype = dtypes.result_type(*(x.dtype for x in xs))
     xs = [cast(x, dtype) for x in xs]
     return torch.column_stack(xs)
+
+
+def cov(x):
+    x = convert_to_tensor(x)
+
+    if standardize_dtype(x.dtype) == "bool":
+        x = cast(x, config.floatx())
+    elif standardize_dtype(x.dtype) == "int64":
+        x = cast(x, "float64")
+
+    return torch.cov(x)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -10199,7 +10199,7 @@ def column_stack(xs):
 
 class Cov(Operation):
     def call(self, x):
-        return backend.numpy.cov(x)
+        return _cov(x)
 
     def compute_output_spec(self, x):
         dtype = backend.standardize_dtype(getattr(x, "dtype", backend.floatx()))
@@ -10237,4 +10237,36 @@ def cov(x):
     """
     if any_symbolic_tensors((x,)):
         return Cov().symbolic_call(x)
-    return backend.numpy.cov(x)
+    return _cov(x)
+
+
+def _cov(x):
+    if not config._use_backend_agnostic_ops() and hasattr(backend.numpy, "cov"):
+        return backend.numpy.cov(x)
+    x = backend.convert_to_tensor(x)
+    if len(x.shape) > 2:
+        raise ValueError(
+            "Input tensor must have at most 2 dimensions. "
+            f"Received: x.shape={x.shape}"
+        )
+    dtype = backend.standardize_dtype(x.dtype)
+    if dtype == "int64":
+        dtype = "float64"
+    else:
+        dtype = dtypes.result_type(dtype, float)
+    x = backend.cast(x, dtype)
+    # A 0D input has no observations to vary over, as in `np.cov`.
+    if len(x.shape) == 0:
+        return backend.numpy.full((), float("nan"), dtype=dtype)
+    # `np.cov` squeezes the result when there is only one variable.
+    is_scalar = len(x.shape) < 2 or x.shape[0] == 1
+    if len(x.shape) == 1:
+        x = backend.numpy.reshape(x, (1, -1))
+    mean = backend.numpy.mean(x, axis=-1, keepdims=True)
+    x_centered = backend.numpy.subtract(x, mean)
+    num_samples = backend.cast(backend.shape(x)[-1], dtype)
+    result = backend.numpy.divide(
+        backend.numpy.matmul(x_centered, backend.numpy.transpose(x_centered)),
+        backend.numpy.subtract(num_samples, 1),
+    )
+    return backend.numpy.reshape(result, ()) if is_scalar else result

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -10195,3 +10195,46 @@ def column_stack(xs):
     if any_symbolic_tensors((xs,)):
         return ColumnStack().symbolic_call(xs)
     return backend.numpy.column_stack(xs)
+
+
+class Cov(Operation):
+    def call(self, x):
+        return backend.numpy.cov(x)
+
+    def compute_output_spec(self, x):
+        dtype = backend.standardize_dtype(getattr(x, "dtype", backend.floatx()))
+        if dtype == "int64":
+            dtype = "float64"
+        else:
+            dtype = dtypes.result_type(dtype, float)
+        if len(x.shape) > 2:
+            raise ValueError(
+                "Input tensor must have at most 2 dimensions. "
+                f"Received: x.shape={x.shape}"
+            )
+        # The covariance matrix of a 2D input of shape `(N, D)` has shape
+        # `(N, N)`. A 1D input, or a single variable, yields a scalar.
+        if len(x.shape) == 2 and x.shape[0] != 1:
+            output_shape = (x.shape[0], x.shape[0])
+        else:
+            output_shape = ()
+        return KerasTensor(output_shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.cov", "keras.ops.numpy.cov"])
+def cov(x):
+    """Estimate the covariance matrix of the variables in `x`.
+
+    The covariance is normalized by `D - 1`, where `D` is the number of
+    observations.
+
+    Args:
+        x: A 2D tensor of shape `(N, D)`, where N is the number of variables
+           and D is the number of observations.
+
+    Returns:
+        A tensor of shape `(N, N)` representing the covariance matrix.
+    """
+    if any_symbolic_tensors((x,)):
+        return Cov().symbolic_call(x)
+    return backend.numpy.cov(x)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1771,6 +1771,9 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.cov(x).shape, (None, None))
 
+        with self.assertRaises(ValueError):
+            knp.cov(KerasTensor((2, 3, 4)))
+
     def test_cos(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.cos(x).shape, (None, 3))
@@ -6102,6 +6105,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([1.0, 4.0, 2.0, 8.0])
         self.assertAllClose(knp.cov(x), np.cov(x))
         self.assertAllClose(knp.cov(x[None, :]), np.cov(x[None, :]))
+
+        self.assertTrue(np.isnan(backend.convert_to_numpy(knp.cov(3.0))))
+
+        with self.assertRaises(ValueError):
+            knp.cov(np.ones((2, 3, 4)))
 
     def test_cos(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6096,20 +6096,26 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         with self.assertRaises(ValueError):
             knp.Corrcoef().symbolic_call(KerasTensor((2, 3, 5)))
 
-    def test_cov(self):
-        x = np.array([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
-        self.assertAllClose(knp.cov(x), np.cov(x))
-        self.assertAllClose(knp.Cov()(x), np.cov(x))
+    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
+    def test_cov(self, backend_agnostic_ops):
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
+        try:
+            x = np.array([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
+            self.assertAllClose(knp.cov(x), np.cov(x))
+            self.assertAllClose(knp.Cov()(x), np.cov(x))
 
-        # A 1D input, or a single variable, reduces to the sample variance.
-        x = np.array([1.0, 4.0, 2.0, 8.0])
-        self.assertAllClose(knp.cov(x), np.cov(x))
-        self.assertAllClose(knp.cov(x[None, :]), np.cov(x[None, :]))
+            # A 1D input, or a single variable, reduces to the sample
+            # variance.
+            x = np.array([1.0, 4.0, 2.0, 8.0])
+            self.assertAllClose(knp.cov(x), np.cov(x))
+            self.assertAllClose(knp.cov(x[None, :]), np.cov(x[None, :]))
 
-        self.assertTrue(np.isnan(backend.convert_to_numpy(knp.cov(3.0))))
+            self.assertTrue(np.isnan(backend.convert_to_numpy(knp.cov(3.0))))
 
-        with self.assertRaises(ValueError):
-            knp.cov(np.ones((2, 3, 4)))
+            with self.assertRaises(ValueError):
+                knp.cov(np.ones((2, 3, 4)))
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     def test_cos(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -10000,19 +10006,27 @@ class NumpyDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
-    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
-    def test_cov(self, dtype):
+    @parameterized.named_parameters(
+        named_product(BACKEND_AGNOSTIC_OPS, dtype=ALL_DTYPES)
+    )
+    def test_cov(self, backend_agnostic_ops, dtype):
         import jax.numpy as jnp
 
-        x = knp.ones((2, 4), dtype=dtype)
-        x_jax = jnp.ones((2, 4), dtype=dtype)
-        expected_dtype = standardize_dtype(jnp.cov(x_jax).dtype)
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
+        try:
+            x = knp.ones((2, 4), dtype=dtype)
+            x_jax = jnp.ones((2, 4), dtype=dtype)
+            expected_dtype = standardize_dtype(jnp.cov(x_jax).dtype)
 
-        self.assertEqual(standardize_dtype(knp.cov(x).dtype), expected_dtype)
-        self.assertEqual(
-            standardize_dtype(knp.Cov().symbolic_call(x).dtype),
-            expected_dtype,
-        )
+            self.assertEqual(
+                standardize_dtype(knp.cov(x).dtype), expected_dtype
+            )
+            self.assertEqual(
+                standardize_dtype(knp.Cov().symbolic_call(x).dtype),
+                expected_dtype,
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1764,6 +1764,13 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.corrcoef(x).shape, (None, None))
 
+    def test_cov(self):
+        x = KerasTensor((3, None))
+        self.assertEqual(knp.cov(x).shape, (3, 3))
+
+        x = KerasTensor((None, 3))
+        self.assertEqual(knp.cov(x).shape, (None, None))
+
     def test_cos(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.cos(x).shape, (None, 3))
@@ -6086,6 +6093,16 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         with self.assertRaises(ValueError):
             knp.Corrcoef().symbolic_call(KerasTensor((2, 3, 5)))
 
+    def test_cov(self):
+        x = np.array([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
+        self.assertAllClose(knp.cov(x), np.cov(x))
+        self.assertAllClose(knp.Cov()(x), np.cov(x))
+
+        # A 1D input, or a single variable, reduces to the sample variance.
+        x = np.array([1.0, 4.0, 2.0, 8.0])
+        self.assertAllClose(knp.cov(x), np.cov(x))
+        self.assertAllClose(knp.cov(x[None, :]), np.cov(x[None, :]))
+
     def test_cos(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.cos(x), np.cos(x))
@@ -9972,6 +9989,20 @@ class NumpyDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Corrcoef().symbolic_call(x).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
+    def test_cov(self, dtype):
+        import jax.numpy as jnp
+
+        x = knp.ones((2, 4), dtype=dtype)
+        x_jax = jnp.ones((2, 4), dtype=dtype)
+        expected_dtype = standardize_dtype(jnp.cov(x_jax).dtype)
+
+        self.assertEqual(standardize_dtype(knp.cov(x).dtype), expected_dtype)
+        self.assertEqual(
+            standardize_dtype(knp.Cov().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
## Description

Adds `keras.ops.cov`, which estimates the covariance matrix of the variables in a 2D input of shape `(N, D)`, normalized by `D - 1`. Matches `np.cov`, including the scalar result for a 1D input or a single variable.

Supported across the NumPy, TensorFlow, PyTorch, JAX and OpenVINO backends.

There is also a backend-agnostic fallback, following the shape `cbrt`, `hsplit` and `vsplit` use, so a backend without its own `cov` still gets the op. The correctness and dtype tests run under both settings of the flag, so that path is covered too.

Fixes #23493 


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.

