### PR TITLE
Add copysign to keras.ops.numpy

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -176,6 +176,7 @@ from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate
 from keras.src.ops.numpy import copy as copy
+from keras.src.ops.numpy import copysign as copysign
 from keras.src.ops.numpy import corrcoef as corrcoef
 from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -48,6 +48,7 @@ from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate
 from keras.src.ops.numpy import copy as copy
+from keras.src.ops.numpy import copysign as copysign
 from keras.src.ops.numpy import corrcoef as corrcoef
 from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -176,6 +176,7 @@ from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate
 from keras.src.ops.numpy import copy as copy
+from keras.src.ops.numpy import copysign as copysign
 from keras.src.ops.numpy import corrcoef as corrcoef
 from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -48,6 +48,7 @@ from keras.src.ops.numpy import concatenate as concatenate
 from keras.src.ops.numpy import conj as conj
 from keras.src.ops.numpy import conjugate as conjugate
 from keras.src.ops.numpy import copy as copy
+from keras.src.ops.numpy import copysign as copysign
 from keras.src.ops.numpy import corrcoef as corrcoef
 from keras.src.ops.numpy import correlate as correlate
 from keras.src.ops.numpy import cos as cos

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -595,6 +595,12 @@ def copy(x):
     return jnp.copy(x)
 
 
+def copysign(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return jnp.copysign(x1, x2)
+
+
 @sparse.densifying_unary
 def cos(x):
     x = convert_to_tensor(x)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -520,6 +520,13 @@ def copy(x):
     return np.copy(x)
 
 
+def copysign(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    return np.copysign(x1, x2).astype(dtype)
+
+
 def cos(x):
     x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1363,7 +1363,9 @@ def copysign(x1, x2):
 
     def sign_bit(x):
         # `less` alone misses -0.0, so also test the sign of 1 / x, which
-        # is -inf for -0.0 and +inf for +0.0, as `signbit` does.
+        # is -inf for -0.0 and +inf for +0.0, as `signbit` does. Neither
+        # test fires for a NaN, so a NaN counts as positive here, the same
+        # way `signbit` treats it on this backend.
         is_negative = ov_opset.less(x, zero).output(0)
         is_negative_zero = ov_opset.logical_and(
             ov_opset.equal(x, zero).output(0),

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -1347,6 +1347,36 @@ def copy(x):
     return x
 
 
+def copysign(x1, x2):
+    x1 = get_ov_output(x1)
+    x2 = get_ov_output(x2)
+    x1, x2 = _align_operand_types(x1, x2, "copysign()")
+    x1_keras = ov_to_keras_type(x1.get_element_type())
+    x2_keras = ov_to_keras_type(x2.get_element_type())
+    dtype = dtypes.result_type(x1_keras, x2_keras, float)
+    ov_dtype = OPENVINO_DTYPES[dtype]
+    x1 = ov_opset.convert(x1, ov_dtype).output(0)
+    x2 = ov_opset.convert(x2, ov_dtype).output(0)
+
+    zero = ov_opset.constant(0, ov_dtype).output(0)
+    one = ov_opset.constant(1, ov_dtype).output(0)
+
+    def sign_bit(x):
+        # `less` alone misses -0.0, so also test the sign of 1 / x, which
+        # is -inf for -0.0 and +inf for +0.0, as `signbit` does.
+        is_negative = ov_opset.less(x, zero).output(0)
+        is_negative_zero = ov_opset.logical_and(
+            ov_opset.equal(x, zero).output(0),
+            ov_opset.less(ov_opset.divide(one, x).output(0), zero).output(0),
+        ).output(0)
+        return ov_opset.logical_or(is_negative, is_negative_zero).output(0)
+
+    # Negate `x1` exactly when its sign differs from the sign of `x2`.
+    flip = ov_opset.logical_xor(sign_bit(x1), sign_bit(x2)).output(0)
+    negated = ov_opset.negative(x1).output(0)
+    return OpenVINOKerasTensor(ov_opset.select(flip, negated, x1).output(0))
+
+
 def cos(x):
     x = get_ov_output(x)
     x_type = x.get_element_type()

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1253,6 +1253,16 @@ def copy(x):
     return tf.identity(x)
 
 
+def copysign(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
+    magnitude = tf.abs(x1)
+    return tf.where(signbit(x2), -magnitude, magnitude)
+
+
 @sparse.densifying_unary(1)
 def cos(x):
     x = convert_to_tensor(x)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -688,6 +688,15 @@ def copy(x):
     return torch.clone(x)
 
 
+def copysign(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = cast(x1, dtype)
+    x2 = cast(x2, dtype)
+    return torch.copysign(x1, x2)
+
+
 def cos(x):
     x = convert_to_tensor(x)
     return torch.cos(x)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2223,7 +2223,7 @@ def copy(x):
 
 class Copysign(Operation):
     def call(self, x1, x2):
-        return backend.numpy.copysign(x1, x2)
+        return _copysign(x1, x2)
 
     def compute_output_spec(self, x1, x2):
         x1_shape = getattr(x1, "shape", [])
@@ -2258,7 +2258,24 @@ def copysign(x1, x2):
     """
     if any_symbolic_tensors((x1, x2)):
         return Copysign().symbolic_call(x1, x2)
-    return backend.numpy.copysign(x1, x2)
+    return _copysign(x1, x2)
+
+
+def _copysign(x1, x2):
+    if not config._use_backend_agnostic_ops() and hasattr(
+        backend.numpy, "copysign"
+    ):
+        return backend.numpy.copysign(x1, x2)
+    x1 = backend.convert_to_tensor(x1)
+    x2 = backend.convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = backend.cast(x1, dtype)
+    x2 = backend.cast(x2, dtype)
+    # Negate `x1` exactly when its sign differs from the sign of `x2`.
+    flip = backend.numpy.logical_xor(
+        backend.numpy.signbit(x1), backend.numpy.signbit(x2)
+    )
+    return backend.numpy.where(flip, backend.numpy.negative(x1), x1)
 
 
 class Cos(Operation):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -2221,6 +2221,46 @@ def copy(x):
     return backend.numpy.copy(x)
 
 
+class Copysign(Operation):
+    def call(self, x1, x2):
+        return backend.numpy.copysign(x1, x2)
+
+    def compute_output_spec(self, x1, x2):
+        x1_shape = getattr(x1, "shape", [])
+        x2_shape = getattr(x2, "shape", [])
+        output_shape = broadcast_shapes(x1_shape, x2_shape)
+
+        x1_type = backend.standardize_dtype(getattr(x1, "dtype", type(x1)))
+        x2_type = backend.standardize_dtype(getattr(x2, "dtype", type(x2)))
+        dtype = dtypes.result_type(x1_type, x2_type, float)
+        return KerasTensor(output_shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.copysign", "keras.ops.numpy.copysign"])
+def copysign(x1, x2):
+    """Compose a value from the magnitude of `x1` and the sign of `x2`.
+
+    The sign of zero is taken into account, so an `x2` of `-0.0` gives a
+    negative result and an `x2` of `0.0` gives a positive one.
+
+    Args:
+        x1: Input tensor providing the magnitude.
+        x2: Input tensor providing the sign.
+
+    Returns:
+        Output tensor with the magnitude of `x1` and the sign of `x2`.
+
+    Example:
+    >>> x1 = keras.ops.convert_to_tensor([-1.0, 2.0, -3.0])
+    >>> x2 = keras.ops.convert_to_tensor([1.0, -1.0, -0.0])
+    >>> keras.ops.copysign(x1, x2)
+    array([ 1., -2., -3.], dtype=float32)
+    """
+    if any_symbolic_tensors((x1, x2)):
+        return Copysign().symbolic_call(x1, x2)
+    return backend.numpy.copysign(x1, x2)
+
+
 class Cos(Operation):
     def call(self, x):
         return backend.numpy.cos(x)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -18,6 +18,11 @@ from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.ops import numpy as knp
 from keras.src.testing.test_utils import named_product
 
+BACKEND_AGNOSTIC_OPS = [
+    {"testcase_name": "backend_specific", "backend_agnostic_ops": False},
+    {"testcase_name": "backend_agnostic", "backend_agnostic_ops": True},
+]
+
 
 class NumPyTestRot90(testing.TestCase):
     def test_basic_rotation(self):
@@ -4826,22 +4831,27 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
             np.nanquantile(x4, 0.5, axis=(1, 2)),
         )
 
-    def test_copysign(self):
-        x = np.array([[1, -2, 3], [-3, 2, -1]])
-        y = np.array([[-4, 5, -6], [3, -2, 1]])
-        self.assertAllClose(knp.copysign(x, y), np.copysign(x, y))
-        self.assertAllClose(knp.Copysign()(x, y), np.copysign(x, y))
+    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
+    def test_copysign(self, backend_agnostic_ops):
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
+        try:
+            x = np.array([[1, -2, 3], [-3, 2, -1]])
+            y = np.array([[-4, 5, -6], [3, -2, 1]])
+            self.assertAllClose(knp.copysign(x, y), np.copysign(x, y))
+            self.assertAllClose(knp.Copysign()(x, y), np.copysign(x, y))
 
-        # Signed zeros and infinities. `assertAllClose` cannot tell -0.0
-        # apart from 0.0, so compare the sign bits directly as well.
-        x = np.array([1.0, -1.0, 0.0, -0.0, np.inf, -np.inf], "float32")
-        y = np.array([-0.0, 0.0, -np.inf, np.inf, 1.0, -1.0], "float32")
-        expected = np.copysign(x, y)
-        self.assertAllClose(knp.copysign(x, y), expected)
-        self.assertAllEqual(
-            np.signbit(self.convert_to_numpy(knp.copysign(x, y))),
-            np.signbit(expected),
-        )
+            # Signed zeros and infinities. `assertAllClose` cannot tell -0.0
+            # apart from 0.0, so compare the sign bits directly as well.
+            x = np.array([1.0, -1.0, 0.0, -0.0, np.inf, -np.inf], "float32")
+            y = np.array([-0.0, 0.0, -np.inf, np.inf, 1.0, -1.0], "float32")
+            expected = np.copysign(x, y)
+            self.assertAllClose(knp.copysign(x, y), expected)
+            self.assertAllEqual(
+                np.signbit(self.convert_to_numpy(knp.copysign(x, y))),
+                np.signbit(expected),
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     def test_nextafter(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -5258,12 +5268,6 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertTrue(
             standardize_dtype(knp.Digitize()(x, bins).dtype) == "int32"
         )
-
-
-BACKEND_AGNOSTIC_OPS = [
-    {"testcase_name": "backend_specific", "backend_agnostic_ops": False},
-    {"testcase_name": "backend_agnostic", "backend_agnostic_ops": True},
-]
 
 
 class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
@@ -11887,29 +11891,38 @@ class NumpyDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(
         named_product(
-            dtypes=list(itertools.product(BINARY_DTYPES, BINARY_DTYPES))
+            BACKEND_AGNOSTIC_OPS,
+            dtypes=list(itertools.product(BINARY_DTYPES, BINARY_DTYPES)),
         )
     )
-    def test_copysign(self, dtypes):
+    def test_copysign(self, backend_agnostic_ops, dtypes):
         import jax.numpy as jnp
 
-        dtype1, dtype2 = dtypes
-        x1 = knp.ones((), dtype=dtype1)
-        x2 = knp.ones((), dtype=dtype2)
-        x1_jax = jnp.ones((), dtype=dtype1)
-        x2_jax = jnp.ones((), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.copysign(x1_jax, x2_jax).dtype)
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
+        try:
+            dtype1, dtype2 = dtypes
+            x1 = knp.ones((), dtype=dtype1)
+            x2 = knp.ones((), dtype=dtype2)
+            x1_jax = jnp.ones((), dtype=dtype1)
+            x2_jax = jnp.ones((), dtype=dtype2)
+            expected_dtype = standardize_dtype(
+                jnp.copysign(x1_jax, x2_jax).dtype
+            )
 
-        self.assertEqual(
-            standardize_dtype(knp.copysign(x1, x2).dtype), expected_dtype
-        )
-        self.assertEqual(
-            standardize_dtype(knp.Copysign().symbolic_call(x1, x2).dtype),
-            expected_dtype,
-        )
+            self.assertEqual(
+                standardize_dtype(knp.copysign(x1, x2).dtype), expected_dtype
+            )
+            self.assertEqual(
+                standardize_dtype(knp.Copysign().symbolic_call(x1, x2).dtype),
+                expected_dtype,
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     @parameterized.named_parameters(
-        named_product(dtypes=list(itertools.product(ALL_DTYPES, ALL_DTYPES)))
+        named_product(
+            dtypes=list(itertools.product(BINARY_DTYPES, BINARY_DTYPES))
+        )
     )
     def test_nextafter(self, dtypes):
         import jax.numpy as jnp

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -421,6 +421,11 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
             knp.nanquantile(x, q, axis=1, keepdims=True).shape, (2, None, 1)
         )
 
+    def test_copysign(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((1, 3))
+        self.assertEqual(knp.copysign(x, y).shape, (None, 3))
+
     def test_nextafter(self):
         x = KerasTensor((None, 3))
         y = KerasTensor((1, 3))
@@ -1218,6 +1223,15 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(
             knp.nanquantile(x, q, axis=1, keepdims=True).shape, (2, 3, 1)
         )
+
+    def test_copysign(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.copysign(x, y).shape, (2, 3))
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((1, 3))
+        self.assertEqual(knp.copysign(x, y).shape, (2, 3))
 
     def test_nextafter(self):
         x = KerasTensor((2, 3))
@@ -4811,6 +4825,12 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
             knp.nanquantile(x4, 0.5, axis=(1, 2)),
             np.nanquantile(x4, 0.5, axis=(1, 2)),
         )
+
+    def test_copysign(self):
+        x = np.array([[1, -2, 3], [-3, 2, -1]])
+        y = np.array([[-4, 5, -6], [3, -2, 1]])
+        self.assertAllClose(knp.copysign(x, y), np.copysign(x, y))
+        self.assertAllClose(knp.Copysign()(x, y), np.copysign(x, y))
 
     def test_nextafter(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -11858,6 +11878,27 @@ class NumpyDtypeTest(testing.TestCase):
         named_product(
             dtypes=list(itertools.product(BINARY_DTYPES, BINARY_DTYPES))
         )
+    )
+    def test_copysign(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(jnp.copysign(x1_jax, x2_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(knp.copysign(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.Copysign().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(dtypes=list(itertools.product(ALL_DTYPES, ALL_DTYPES)))
     )
     def test_nextafter(self, dtypes):
         import jax.numpy as jnp

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -4832,6 +4832,17 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.copysign(x, y), np.copysign(x, y))
         self.assertAllClose(knp.Copysign()(x, y), np.copysign(x, y))
 
+        # Signed zeros and infinities. `assertAllClose` cannot tell -0.0
+        # apart from 0.0, so compare the sign bits directly as well.
+        x = np.array([1.0, -1.0, 0.0, -0.0, np.inf, -np.inf], "float32")
+        y = np.array([-0.0, 0.0, -np.inf, np.inf, 1.0, -1.0], "float32")
+        expected = np.copysign(x, y)
+        self.assertAllClose(knp.copysign(x, y), expected)
+        self.assertAllEqual(
+            np.signbit(self.convert_to_numpy(knp.copysign(x, y))),
+            np.signbit(expected),
+        )
+
     def test_nextafter(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         y = np.array([[4, 5, 6], [3, 2, 1]])


### PR DESCRIPTION
## Description

`keras.ops` already has most of the IEEE-754 sign and exponent family (`signbit`, `nextafter`, `ldexp`, `hypot`, `heaviside`, `logaddexp`, `logaddexp2`), but `copysign` was missing. It exists as `numpy.copysign`, `jax.numpy.copysign`, `torch.copysign` and `math.copysign`, and it is part of the [Python Array API standard](https://data-apis.org/array-api/latest/API_specification/generated/array_api.copysign.html) (2023.12).

Without it the usual workaround is `abs(x1) * sign(x2)`, which returns zero wherever `x2` is zero and can never produce a negative result from `-0.0`. Users end up hand-rolling it, and the hand-rolled version behaves differently per backend around zero. This adds one definition shared by all five.

NumPy, JAX and PyTorch delegate to their native `copysign`. TensorFlow has no `tf.math.copysign`, so it composes one from the `signbit` already in that backend. OpenVINO negates `x1` when the two sign bits differ, reusing the same `-0.0` test its own `signbit` uses.

Dtype promotion follows `nextafter`, the closest existing op: `result_type(x1, x2, float)`. I checked that against `jax.numpy.copysign` over all 121 ordered pairs of `ALL_DTYPES` and it agrees on every one, so the new dtype test compares against JAX the way the other two-input dtype tests do.

`_copysign` also provides a backend-agnostic fallback, following the shape `cbrt`, `hsplit` and `vsplit` use. When a backend does not implement `copysign`, it promotes both operands and negates `x1` wherever the two sign bits differ, which is the same shape the OpenVINO backend uses.

Fixes #23497

### Testing

Adds the four blocks a two-input op normally gets (dynamic shape, static shape, correctness, and the JAX-referenced dtype matrix), placed next to `nextafter`.

The correctness and dtype tests run under both settings of the backend-agnostic flag, so the fallback is covered too. `BACKEND_AGNOSTIC_OPS` moves to module scope because it was defined after `NumpyTwoInputOpsCorrectnessTest`, which is where the `copysign` correctness test lives.

`pytest keras/src/ops/numpy_test.py -k copysign` passes on all five backends, and the full `numpy_test.py` run shows no regressions on any of them.

I also compared each backend against `np.copysign` bit for bit over roughly 5.8k value pairs per dtype in float64, float32 and float16, including `±0.0`, `±inf`, `±NaN` and subnormals. Sign bits, NaN placement and values all match exactly.

> [!NOTE]
> One note on the API files. Only the four `copysign` export lines are included here. Running `api_gen.py` locally also rewrites about 130 unrelated files, but that same churn shows up on an unmodified `master`, so it is local tooling drift rather than something this PR introduces.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.


