### PR TITLE
Add float_power to keras.ops.numpy

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -208,6 +208,7 @@ from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud
+from keras.src.ops.numpy import float_power as float_power
 from keras.src.ops.numpy import floor as floor
 from keras.src.ops.numpy import floor_divide as floor_divide
 from keras.src.ops.numpy import fmax as fmax

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -80,6 +80,7 @@ from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud
+from keras.src.ops.numpy import float_power as float_power
 from keras.src.ops.numpy import floor as floor
 from keras.src.ops.numpy import floor_divide as floor_divide
 from keras.src.ops.numpy import fmax as fmax

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -208,6 +208,7 @@ from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud
+from keras.src.ops.numpy import float_power as float_power
 from keras.src.ops.numpy import floor as floor
 from keras.src.ops.numpy import floor_divide as floor_divide
 from keras.src.ops.numpy import fmax as fmax

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -80,6 +80,7 @@ from keras.src.ops.numpy import fabs as fabs
 from keras.src.ops.numpy import flip as flip
 from keras.src.ops.numpy import fliplr as fliplr
 from keras.src.ops.numpy import flipud as flipud
+from keras.src.ops.numpy import float_power as float_power
 from keras.src.ops.numpy import floor as floor
 from keras.src.ops.numpy import floor_divide as floor_divide
 from keras.src.ops.numpy import fmax as fmax

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -1522,6 +1522,12 @@ def power(x1, x2):
     return jnp.power(x1, x2)
 
 
+def float_power(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    return jnp.float_power(x1, x2)
+
+
 @sparse.elementwise_unary(linear=True)
 def negative(x):
     x = convert_to_tensor(x)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -1635,6 +1635,13 @@ def power(x1, x2):
     return np.power(x1, x2)
 
 
+def float_power(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    return np.float_power(x1, x2).astype(dtype)
+
+
 def negative(x):
     return np.negative(x)
 

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -4935,6 +4935,19 @@ def power(x1, x2):
     return OpenVINOKerasTensor(ov_opset.power(x1, x2).output(0))
 
 
+def float_power(x1, x2):
+    x1 = get_ov_output(x1)
+    x2 = get_ov_output(x2)
+    x1, x2 = _align_operand_types(x1, x2, "float_power()")
+    x1_keras = ov_to_keras_type(x1.get_element_type())
+    x2_keras = ov_to_keras_type(x2.get_element_type())
+    dtype = dtypes.result_type(x1_keras, x2_keras, float)
+    ov_dtype = OPENVINO_DTYPES[dtype]
+    x1 = ov_opset.convert(x1, ov_dtype).output(0)
+    x2 = ov_opset.convert(x2, ov_dtype).output(0)
+    return OpenVINOKerasTensor(ov_opset.power(x1, x2).output(0))
+
+
 def negative(x):
     x = get_ov_output(x)
     return OpenVINOKerasTensor(ov_opset.negative(x).output(0))

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -3527,6 +3527,15 @@ def power(x1, x2):
     return tf.pow(x1, x2)
 
 
+def float_power(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = tf.cast(x1, dtype)
+    x2 = tf.cast(x2, dtype)
+    return tf.pow(x1, x2)
+
+
 @sparse.elementwise_unary
 def negative(x):
     return tf.negative(x)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -2175,6 +2175,17 @@ def power(x1, x2):
     return torch.pow(x1, x2)
 
 
+def float_power(x1, x2):
+    x1 = convert_to_tensor(x1)
+    x2 = convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    # `torch.float_power` always computes in float64, which the MPS device
+    # does not support, so raise the operands to a float dtype instead.
+    x1 = cast(x1, dtype)
+    x2 = cast(x2, dtype)
+    return torch.pow(x1, x2)
+
+
 def negative(x):
     x = convert_to_tensor(x)
     return torch.negative(x)

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -8857,7 +8857,7 @@ def power(x1, x2):
 
 class FloatPower(Operation):
     def call(self, x1, x2):
-        return backend.numpy.float_power(x1, x2)
+        return _float_power(x1, x2)
 
     def compute_output_spec(self, x1, x2):
         x1_shape = getattr(x1, "shape", [])
@@ -8893,7 +8893,20 @@ def float_power(x1, x2):
     """
     if any_symbolic_tensors((x1, x2)):
         return FloatPower().symbolic_call(x1, x2)
-    return backend.numpy.float_power(x1, x2)
+    return _float_power(x1, x2)
+
+
+def _float_power(x1, x2):
+    if not config._use_backend_agnostic_ops() and hasattr(
+        backend.numpy, "float_power"
+    ):
+        return backend.numpy.float_power(x1, x2)
+    x1 = backend.convert_to_tensor(x1)
+    x2 = backend.convert_to_tensor(x2)
+    dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
+    x1 = backend.cast(x1, dtype)
+    x2 = backend.cast(x2, dtype)
+    return backend.numpy.power(x1, x2)
 
 
 class Negative(Operation):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -8855,6 +8855,47 @@ def power(x1, x2):
     return backend.numpy.power(x1, x2)
 
 
+class FloatPower(Operation):
+    def call(self, x1, x2):
+        return backend.numpy.float_power(x1, x2)
+
+    def compute_output_spec(self, x1, x2):
+        x1_shape = getattr(x1, "shape", [])
+        x2_shape = getattr(x2, "shape", [])
+        output_shape = broadcast_shapes(x1_shape, x2_shape)
+
+        x1_type = backend.standardize_dtype(getattr(x1, "dtype", type(x1)))
+        x2_type = backend.standardize_dtype(getattr(x2, "dtype", type(x2)))
+        dtype = dtypes.result_type(x1_type, x2_type, float)
+        return KerasTensor(output_shape, dtype=dtype)
+
+
+@keras_export(["keras.ops.float_power", "keras.ops.numpy.float_power"])
+def float_power(x1, x2):
+    """First tensor elements raised to powers from second tensor, in floats.
+
+    This is `power` with the operands promoted to a float dtype first, so a
+    negative exponent has a well defined result for integer inputs, where
+    `power` either raises an error or returns an integer.
+
+    Args:
+        x1: The bases.
+        x2: The exponents.
+
+    Returns:
+        Output tensor, the bases in `x1` raised to the exponents in `x2`.
+
+    Example:
+    >>> x1 = keras.ops.convert_to_tensor([2, 3, 4])
+    >>> x2 = keras.ops.convert_to_tensor([-1, -2, 2])
+    >>> keras.ops.float_power(x1, x2)
+    array([ 0.5       ,  0.11111111, 16.        ], dtype=float32)
+    """
+    if any_symbolic_tensors((x1, x2)):
+        return FloatPower().symbolic_call(x1, x2)
+    return backend.numpy.float_power(x1, x2)
+
+
 class Negative(Operation):
     def call(self, x):
         return backend.numpy.negative(x)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -121,6 +121,11 @@ class NumpyTwoInputOpsDynamicShapeTest(testing.TestCase):
         y = KerasTensor((3, None, 4, 5))
         self.assertEqual(knp.matmul(x, y).shape, (3, None, 3, 5))
 
+    def test_float_power(self):
+        x = KerasTensor((None, 3))
+        y = KerasTensor((2, None))
+        self.assertEqual(knp.float_power(x, y).shape, (2, 3))
+
     def test_power(self):
         x = KerasTensor((None, 3))
         y = KerasTensor((2, None))
@@ -749,6 +754,15 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
         result = knp.matmul(x, y)
         self.assertEqual(result.shape, (2, 2))
         self.assertTrue(result.sparse)
+
+    def test_float_power(self):
+        x = KerasTensor((2, 3))
+        y = KerasTensor((2, 3))
+        self.assertEqual(knp.float_power(x, y).shape, (2, 3))
+
+        x = KerasTensor((2, 3))
+        y = KerasTensor((1, 3))
+        self.assertEqual(knp.float_power(x, y).shape, (2, 3))
 
     def test_power(self):
         x = KerasTensor((2, 3))
@@ -3647,6 +3661,17 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
             tpu_rtol=tpu_atol,
         )
         self.assertSparse(knp.matmul(x, y), x_sparse and y_sparse)
+
+    def test_float_power(self):
+        x = np.array([[1, 2, 3], [3, 2, 1]])
+        y = np.array([[4, 5, 6], [3, 2, 1]])
+        self.assertAllClose(knp.float_power(x, y), np.float_power(x, y))
+        self.assertAllClose(knp.FloatPower()(x, y), np.float_power(x, y))
+
+        # Negative exponents, which integer `power` cannot represent.
+        y = np.array([[-1, -2, -3], [-1, -2, -3]])
+        self.assertAllClose(knp.float_power(x, y), np.float_power(x, y))
+        self.assertAllClose(knp.FloatPower()(x, y), np.float_power(x, y))
 
     def test_power(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -11992,6 +12017,31 @@ class NumpyDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Percentile().symbolic_call(x, 50).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(
+        named_product(
+            dtypes=list(itertools.product(BINARY_DTYPES, BINARY_DTYPES))
+        )
+    )
+    def test_float_power(self, dtypes):
+        import jax.numpy as jnp
+
+        dtype1, dtype2 = dtypes
+        x1 = knp.ones((), dtype=dtype1)
+        x2 = knp.ones((), dtype=dtype2)
+        x1_jax = jnp.ones((), dtype=dtype1)
+        x2_jax = jnp.ones((), dtype=dtype2)
+        expected_dtype = standardize_dtype(
+            jnp.float_power(x1_jax, x2_jax).dtype
+        )
+
+        self.assertEqual(
+            standardize_dtype(knp.float_power(x1, x2).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(knp.FloatPower().symbolic_call(x1, x2).dtype),
             expected_dtype,
         )
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -18,6 +18,11 @@ from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.ops import numpy as knp
 from keras.src.testing.test_utils import named_product
 
+BACKEND_AGNOSTIC_OPS = [
+    {"testcase_name": "backend_specific", "backend_agnostic_ops": False},
+    {"testcase_name": "backend_agnostic", "backend_agnostic_ops": True},
+]
+
 
 class NumPyTestRot90(testing.TestCase):
     def test_basic_rotation(self):
@@ -3662,16 +3667,21 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         )
         self.assertSparse(knp.matmul(x, y), x_sparse and y_sparse)
 
-    def test_float_power(self):
-        x = np.array([[1, 2, 3], [3, 2, 1]])
-        y = np.array([[4, 5, 6], [3, 2, 1]])
-        self.assertAllClose(knp.float_power(x, y), np.float_power(x, y))
-        self.assertAllClose(knp.FloatPower()(x, y), np.float_power(x, y))
+    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
+    def test_float_power(self, backend_agnostic_ops):
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
+        try:
+            x = np.array([[1, 2, 3], [3, 2, 1]])
+            y = np.array([[4, 5, 6], [3, 2, 1]])
+            self.assertAllClose(knp.float_power(x, y), np.float_power(x, y))
+            self.assertAllClose(knp.FloatPower()(x, y), np.float_power(x, y))
 
-        # Negative exponents, which integer `power` cannot represent.
-        y = np.array([[-1, -2, -3], [-1, -2, -3]])
-        self.assertAllClose(knp.float_power(x, y), np.float_power(x, y))
-        self.assertAllClose(knp.FloatPower()(x, y), np.float_power(x, y))
+            # Negative exponents, which integer `power` cannot represent.
+            y = np.array([[-1, -2, -3], [-1, -2, -3]])
+            self.assertAllClose(knp.float_power(x, y), np.float_power(x, y))
+            self.assertAllClose(knp.FloatPower()(x, y), np.float_power(x, y))
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     def test_power(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -5252,12 +5262,6 @@ class NumpyTwoInputOpsCorrectnessTest(testing.TestCase):
         self.assertTrue(
             standardize_dtype(knp.Digitize()(x, bins).dtype) == "int32"
         )
-
-
-BACKEND_AGNOSTIC_OPS = [
-    {"testcase_name": "backend_specific", "backend_agnostic_ops": False},
-    {"testcase_name": "backend_agnostic", "backend_agnostic_ops": True},
-]
 
 
 class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
@@ -12022,28 +12026,34 @@ class NumpyDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(
         named_product(
-            dtypes=list(itertools.product(BINARY_DTYPES, BINARY_DTYPES))
+            BACKEND_AGNOSTIC_OPS,
+            dtypes=list(itertools.product(BINARY_DTYPES, BINARY_DTYPES)),
         )
     )
-    def test_float_power(self, dtypes):
+    def test_float_power(self, backend_agnostic_ops, dtypes):
         import jax.numpy as jnp
 
-        dtype1, dtype2 = dtypes
-        x1 = knp.ones((), dtype=dtype1)
-        x2 = knp.ones((), dtype=dtype2)
-        x1_jax = jnp.ones((), dtype=dtype1)
-        x2_jax = jnp.ones((), dtype=dtype2)
-        expected_dtype = standardize_dtype(
-            jnp.float_power(x1_jax, x2_jax).dtype
-        )
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
+        try:
+            dtype1, dtype2 = dtypes
+            x1 = knp.ones((), dtype=dtype1)
+            x2 = knp.ones((), dtype=dtype2)
+            x1_jax = jnp.ones((), dtype=dtype1)
+            x2_jax = jnp.ones((), dtype=dtype2)
+            expected_dtype = standardize_dtype(
+                jnp.float_power(x1_jax, x2_jax).dtype
+            )
 
-        self.assertEqual(
-            standardize_dtype(knp.float_power(x1, x2).dtype), expected_dtype
-        )
-        self.assertEqual(
-            standardize_dtype(knp.FloatPower().symbolic_call(x1, x2).dtype),
-            expected_dtype,
-        )
+            self.assertEqual(
+                standardize_dtype(knp.float_power(x1, x2).dtype),
+                expected_dtype,
+            )
+            self.assertEqual(
+                standardize_dtype(knp.FloatPower().symbolic_call(x1, x2).dtype),
+                expected_dtype,
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     @parameterized.named_parameters(
         named_product(dtypes=itertools.combinations(BINARY_DTYPES, 2))


### PR DESCRIPTION
## Description

`keras.ops` has `power` but no `float_power`.

The gap shows up as a backend split. On an integer base with a negative integer exponent, `ops.power` does something different on each backend:

| backend | `ops.power(int32[2, 3], int32[-1, -2])` |
|---|---|
| numpy | raises `ValueError` |
| tensorflow | raises `InvalidArgumentError` |
| jax | `array([0, 703701817], dtype=int32)` |
| torch | `array([0, 0], dtype=int32)` |
| openvino | `array([0, 0], dtype=int32)` |

`float_power` is the numpy op for this case. It is `power` with the operands promoted to a float dtype first, so `float_power([2, 3], [-1, -2])` is `[0.5, 0.111...]` on every backend.

numpy, jax and torch have a native `float_power`. TensorFlow has none, so it composes from `tf.pow` after casting both operands, and OpenVINO does the same with its `power`. The torch backend composes as well rather than calling `torch.float_power`, which always computes in float64 and so cannot run on MPS.

Promotion follows `nextafter`, the closest existing op: `result_type(x1, x2, float)`. That matches `jax.numpy.float_power` on all 121 ordered pairs of the dtype matrix, so the dtype test compares against JAX like the other two-input ops.

`_float_power` also provides a backend-agnostic fallback, following the shape `cbrt`, `hsplit` and `vsplit` use. When a backend does not implement `float_power`, it promotes both operands and defers to `power`, which is the same composition the TensorFlow and OpenVINO backends use.

Fixes #23499

### Testing

Adds the four blocks a two-input op normally gets (dynamic shape, static shape, correctness, and the JAX-referenced dtype matrix), placed next to `power`. The correctness test covers negative exponents, which is the case integer `power` cannot represent.

The correctness and dtype tests run under both settings of the backend-agnostic flag, so the fallback is covered too. `BACKEND_AGNOSTIC_OPS` moves to module scope because it was defined after `NumpyTwoInputOpsCorrectnessTest`, which is where the `float_power` correctness test lives.

`pytest keras/src/ops/numpy_test.py -k float_power` passes on all five backends, and the full `numpy_test.py` run shows no regressions.

I also checked the five implementations against `np.float_power` over 100 base and exponent combinations, including negative bases with fractional exponents, a zero base with a negative exponent, and `0 ** 0`. They agree on the finite values and on where the result is `nan` or `inf`.

Only the four `float_power` export lines are included under `keras/api/`. Running `api_gen.py` locally rewrites about 130 other files, but that same churn appears on an unmodified `master`, so it is local tooling drift.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
