### PR TITLE
Unskip distribution tests for PyTorch backend

### DIFF
--- a/keras/src/distribution/distribution_lib_test.py
+++ b/keras/src/distribution/distribution_lib_test.py
@@ -312,7 +312,7 @@ class DataParallelDistributionTest(testing.TestCase):
 
 
 @pytest.mark.skipif(
-    backend.backend() != "jax",
+    backend.backend() not in ("jax", "torch"),
     reason="Only JAX has the proper backend distribution lib",
 )
 class ModelParallelDistributionTest(testing.TestCase):
@@ -334,9 +334,15 @@ class ModelParallelDistributionTest(testing.TestCase):
         distribution = distribution_lib.ModelParallel(
             layout_map=layout_map, batch_dim_name="data"
         )
-        kernel = backend.Variable(initializer=np.arange(8, 4), name="kernel")
-        bias = backend.Variable(initializer=np.arange(4), name="bias")
-        rng_seed = backend.Variable(initializer=[0, 1], name="seed")
+        kernel = backend.Variable(
+            initializer=np.ones((8, 4), dtype="float32"), name="kernel"
+        )
+        bias = backend.Variable(
+            initializer=np.ones((4,), dtype="float32"), name="bias"
+        )
+        rng_seed = backend.Variable(
+            initializer=[0, 1], trainable=False, name="seed"
+        )
 
         kernel_layout = distribution.get_variable_layout(kernel)
         self.assertIs(kernel_layout.device_mesh, self.device_mesh)
@@ -386,7 +392,7 @@ class ModelParallelDistributionTest(testing.TestCase):
 
         explicit_mesh = distribution_lib.DeviceMesh((8,), ["x"], self.devices)
         explicit_layout = distribution_lib.TensorLayout(["x"], explicit_mesh)
-        variable = backend.Variable(initializer=[1, 2, 3], name="kernel")
+        variable = backend.Variable(initializer=[1.0, 2.0, 3.0], name="kernel")
         variable._layout = explicit_layout
         variable_layout = distribution.get_variable_layout(variable)
         self.assertIs(variable_layout.device_mesh, explicit_mesh)
@@ -541,7 +547,7 @@ class LayoutMapTest(testing.TestCase):
 
 
 @pytest.mark.skipif(
-    backend.backend() != "jax",
+    backend.backend() not in ("jax", "torch"),
     reason="Only JAX has the proper backend distribution lib",
 )
 @pytest.mark.multi_device


### PR DESCRIPTION
## Description
This PR enables ModelParallelDistributionTest and DataShardingIntegrationTest to run on the PyTorch backend. Previously, these tests were skipped for any backend other than JAX. With the ongoing integration of DTensor and Model Parallelism support in PyTorch, these tests are now relevant and should be executed to ensure cross-backend consistency in Keras 3's distribution API.


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
