### PR TITLE
Validate label smoothing range in loss functions

### DIFF
--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1,6 +1,8 @@
 import numbers
 import warnings
 
+import numpy as np
+
 from keras.src import backend
 from keras.src import ops
 from keras.src import tree
@@ -2185,8 +2187,8 @@ def categorical_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if not ops.is_tensor(label_smoothing):
-        if isinstance(label_smoothing, bool) or not isinstance(
+    if not ops.is_tensor(label_smoothing) or np.isscalar(label_smoothing):
+        if isinstance(label_smoothing, (bool, np.bool_)) or not isinstance(
             label_smoothing, numbers.Real
         ):
             raise ValueError(
@@ -2427,8 +2429,8 @@ def binary_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if not ops.is_tensor(label_smoothing):
-        if isinstance(label_smoothing, bool) or not isinstance(
+    if not ops.is_tensor(label_smoothing) or np.isscalar(label_smoothing):
+        if isinstance(label_smoothing, (bool, np.bool_)) or not isinstance(
             label_smoothing, numbers.Real
         ):
             raise ValueError(

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2184,6 +2184,15 @@ def categorical_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
+    if (
+        isinstance(label_smoothing, (int, float))
+        and not 0 <= label_smoothing <= 1
+    ):
+        raise ValueError(
+            "`label_smoothing` must be in the range [0, 1]. "
+            f"Received: label_smoothing={label_smoothing}"
+        )
+
     if y_pred.shape is not None:
         axis = canonicalize_axis(axis, len(y_pred.shape))
         if y_pred.shape[axis] == 1:
@@ -2410,6 +2419,15 @@ def binary_crossentropy(
     """
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
+
+    if (
+        isinstance(label_smoothing, (int, float))
+        and not 0 <= label_smoothing <= 1
+    ):
+        raise ValueError(
+            "`label_smoothing` must be in the range [0, 1]. "
+            f"Received: label_smoothing={label_smoothing}"
+        )
 
     if label_smoothing:
         y_true = y_true * (1.0 - label_smoothing) + 0.5 * label_smoothing

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -1,3 +1,4 @@
+import numbers
 import warnings
 
 from keras.src import backend
@@ -2184,22 +2185,20 @@ def categorical_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if isinstance(label_smoothing, bool):
-        raise ValueError(
-            "`label_smoothing` must be a float or int. "
-            f"Received: label_smoothing={label_smoothing}"
-        )
     if not ops.is_tensor(label_smoothing):
-        if isinstance(label_smoothing, (int, float)) or (
-            hasattr(label_smoothing, "__float__")
-            and not isinstance(label_smoothing, (str, bytes))
+        if isinstance(label_smoothing, bool) or not isinstance(
+            label_smoothing, numbers.Real
         ):
-            value = float(label_smoothing)
-            if not 0 <= value <= 1:
-                raise ValueError(
-                    "`label_smoothing` must be in the range [0, 1]. "
-                    f"Received: label_smoothing={label_smoothing}"
-                )
+            raise ValueError(
+                "`label_smoothing` must be a float or int. "
+                f"Received: label_smoothing={label_smoothing}"
+            )
+        value = float(label_smoothing)
+        if not 0 <= value <= 1:
+            raise ValueError(
+                "`label_smoothing` must be in the range [0, 1]. "
+                f"Received: label_smoothing={label_smoothing}"
+            )
 
     if y_pred.shape is not None:
         axis = canonicalize_axis(axis, len(y_pred.shape))
@@ -2428,22 +2427,20 @@ def binary_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if isinstance(label_smoothing, bool):
-        raise ValueError(
-            "`label_smoothing` must be a float or int. "
-            f"Received: label_smoothing={label_smoothing}"
-        )
     if not ops.is_tensor(label_smoothing):
-        if isinstance(label_smoothing, (int, float)) or (
-            hasattr(label_smoothing, "__float__")
-            and not isinstance(label_smoothing, (str, bytes))
+        if isinstance(label_smoothing, bool) or not isinstance(
+            label_smoothing, numbers.Real
         ):
-            value = float(label_smoothing)
-            if not 0 <= value <= 1:
-                raise ValueError(
-                    "`label_smoothing` must be in the range [0, 1]. "
-                    f"Received: label_smoothing={label_smoothing}"
-                )
+            raise ValueError(
+                "`label_smoothing` must be a float or int. "
+                f"Received: label_smoothing={label_smoothing}"
+            )
+        value = float(label_smoothing)
+        if not 0 <= value <= 1:
+            raise ValueError(
+                "`label_smoothing` must be in the range [0, 1]. "
+                f"Received: label_smoothing={label_smoothing}"
+            )
 
     if label_smoothing:
         y_true = y_true * (1.0 - label_smoothing) + 0.5 * label_smoothing

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2184,14 +2184,22 @@ def categorical_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if (
-        isinstance(label_smoothing, (int, float))
-        and not 0 <= label_smoothing <= 1
-    ):
+    if isinstance(label_smoothing, bool):
         raise ValueError(
-            "`label_smoothing` must be in the range [0, 1]. "
+            "`label_smoothing` must be a float or int. "
             f"Received: label_smoothing={label_smoothing}"
         )
+    if not ops.is_tensor(label_smoothing):
+        if isinstance(label_smoothing, (int, float)) or (
+            hasattr(label_smoothing, "__float__")
+            and not isinstance(label_smoothing, (str, bytes))
+        ):
+            value = float(label_smoothing)
+            if not 0 <= value <= 1:
+                raise ValueError(
+                    "`label_smoothing` must be in the range [0, 1]. "
+                    f"Received: label_smoothing={label_smoothing}"
+                )
 
     if y_pred.shape is not None:
         axis = canonicalize_axis(axis, len(y_pred.shape))
@@ -2420,14 +2428,22 @@ def binary_crossentropy(
     y_pred = ops.convert_to_tensor(y_pred)
     y_true = ops.cast(y_true, y_pred.dtype)
 
-    if (
-        isinstance(label_smoothing, (int, float))
-        and not 0 <= label_smoothing <= 1
-    ):
+    if isinstance(label_smoothing, bool):
         raise ValueError(
-            "`label_smoothing` must be in the range [0, 1]. "
+            "`label_smoothing` must be a float or int. "
             f"Received: label_smoothing={label_smoothing}"
         )
+    if not ops.is_tensor(label_smoothing):
+        if isinstance(label_smoothing, (int, float)) or (
+            hasattr(label_smoothing, "__float__")
+            and not isinstance(label_smoothing, (str, bytes))
+        ):
+            value = float(label_smoothing)
+            if not 0 <= value <= 1:
+                raise ValueError(
+                    "`label_smoothing` must be in the range [0, 1]. "
+                    f"Received: label_smoothing={label_smoothing}"
+                )
 
     if label_smoothing:
         y_true = y_true * (1.0 - label_smoothing) + 0.5 * label_smoothing

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1085,6 +1085,14 @@ class BinaryCrossentropyTest(testing.TestCase):
             losses.BinaryCrossentropy(label_smoothing=1.1)(
                 [[0.0, 1.0]], [[0.6, 0.4]]
             )
+        with self.assertRaisesRegex(ValueError, "must be a float or int"):
+            losses.binary_crossentropy(
+                [[0.0, 1.0]], [[0.6, 0.4]], label_smoothing=True
+            )
+        with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
+            losses.binary_crossentropy(
+                [[0.0, 1.0]], [[0.6, 0.4]], label_smoothing=np.float32(-0.1)
+            )
 
     def test_label_smoothing(self):
         logits = np.array([[10.0, -10.0, -10.0]])
@@ -1243,6 +1251,16 @@ class CategoricalCrossentropyTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
             losses.CategoricalCrossentropy(label_smoothing=1.1)(
                 [[1.0, 0.0, 0.0]], [[0.8, 0.1, 0.1]]
+            )
+        with self.assertRaisesRegex(ValueError, "must be a float or int"):
+            losses.categorical_crossentropy(
+                [[1.0, 0.0, 0.0]], [[0.8, 0.1, 0.1]], label_smoothing=True
+            )
+        with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
+            losses.categorical_crossentropy(
+                [[1.0, 0.0, 0.0]],
+                [[0.8, 0.1, 0.1]],
+                label_smoothing=np.float32(-0.1),
             )
 
     def test_label_smoothing(self):

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1089,6 +1089,10 @@ class BinaryCrossentropyTest(testing.TestCase):
             losses.binary_crossentropy(
                 [[0.0, 1.0]], [[0.6, 0.4]], label_smoothing=True
             )
+        with self.assertRaisesRegex(ValueError, "must be a float or int"):
+            losses.binary_crossentropy(
+                [[0.0, 1.0]], [[0.6, 0.4]], label_smoothing=np.bool_(True)
+            )
         with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
             losses.binary_crossentropy(
                 [[0.0, 1.0]], [[0.6, 0.4]], label_smoothing=np.float32(-0.1)
@@ -1255,6 +1259,12 @@ class CategoricalCrossentropyTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "must be a float or int"):
             losses.categorical_crossentropy(
                 [[1.0, 0.0, 0.0]], [[0.8, 0.1, 0.1]], label_smoothing=True
+            )
+        with self.assertRaisesRegex(ValueError, "must be a float or int"):
+            losses.categorical_crossentropy(
+                [[1.0, 0.0, 0.0]],
+                [[0.8, 0.1, 0.1]],
+                label_smoothing=np.bool_(True),
             )
         with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
             losses.categorical_crossentropy(

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -1076,6 +1076,16 @@ class BinaryCrossentropyTest(testing.TestCase):
         loss = bce_obj(y_true, logits)
         self.assertAllClose(loss, [0.0, 6.666], atol=1e-3)
 
+    def test_invalid_label_smoothing(self):
+        with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
+            losses.binary_crossentropy(
+                [[0.0, 1.0]], [[0.6, 0.4]], label_smoothing=-0.1
+            )
+        with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
+            losses.BinaryCrossentropy(label_smoothing=1.1)(
+                [[0.0, 1.0]], [[0.6, 0.4]]
+            )
+
     def test_label_smoothing(self):
         logits = np.array([[10.0, -10.0, -10.0]])
         y_true = np.array([[1, 0, 1]])
@@ -1222,6 +1232,18 @@ class CategoricalCrossentropyTest(testing.TestCase):
         )
         loss = cce_obj(y_true, logits)
         self.assertAllClose(loss, (0.001822, 0.000459, 0.169846))
+
+    def test_invalid_label_smoothing(self):
+        with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
+            losses.categorical_crossentropy(
+                [[1.0, 0.0, 0.0]],
+                [[0.8, 0.1, 0.1]],
+                label_smoothing=-0.1,
+            )
+        with self.assertRaisesRegex(ValueError, "label_smoothing.*range"):
+            losses.CategoricalCrossentropy(label_smoothing=1.1)(
+                [[1.0, 0.0, 0.0]], [[0.8, 0.1, 0.1]]
+            )
 
     def test_label_smoothing(self):
         logits = np.array([[100.0, -100.0, -100.0]])


### PR DESCRIPTION
Fixes tensorflow/tensorflow#122717

Port the label_smoothing validation from the deprecated TensorFlow Keras
implementation to Keras 3.

Functional and class-based categorical_crossentropy and
binary_crossentropy now raise ValueError when a numeric label_smoothing
value is outside [0, 1]. Added regression tests for both APIs.

Validation completed:
- Ruff passes
- Python syntax compilation passes
- Diff checks pass
- Focused pytest is blocked locally because optree is not installed

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.