### PR TITLE
Fix docstring argument names that don't match function signatures

### DIFF
--- a/keras/src/backend/config.py
+++ b/keras/src/backend/config.py
@@ -420,8 +420,8 @@ def set_max_steps_per_epoch(max_steps_per_epoch):
     a scrip without modifying its source.
 
     Args:
-        max_epochs: The integer limit on the number of epochs or `None`. If
-            `None`, no limit is applied.
+        max_steps_per_epoch: The integer limit on the number of steps per
+            epoch or `None`. If `None`, no limit is applied.
     """
     global _MAX_STEPS_PER_EPOCH
     _MAX_STEPS_PER_EPOCH = max_steps_per_epoch
@@ -446,13 +446,13 @@ def max_epochs():
 def max_steps_per_epoch():
     """Get the maximum number of steps for any call to fit/evaluate/predict.
 
-    Retrieves the limit on the number of epochs set by
+    Retrieves the limit on the number of steps per epoch set by
     `keras.config.set_max_steps_per_epoch` or the `KERAS_MAX_STEPS_PER_EPOCH`
     environment variable.
 
-    Args:
-        max_epochs: The integer limit on the number of epochs or `None`. If
-            `None`, no limit is applied.
+    Returns:
+        The integer limit on the number of steps per epoch or `None`, if no
+        limit has been set.
     """
     return _MAX_STEPS_PER_EPOCH
 

--- a/keras/src/backend/jax/distribution_lib.py
+++ b/keras/src/backend/jax/distribution_lib.py
@@ -90,7 +90,8 @@ def distribute_data_input(per_process_batch, layout, batch_dim_name):
     the data need to be further partitioned to map to each of the devices.
 
     Args:
-        inputs: `jax.Array` that is already sharded to a local process size.
+        per_process_batch: `jax.Array` that is already sharded to a local
+            process size.
         layout: `TensorLayout` for the distribution information, or a
             `jax.sharding.Sharding` instance.
 

--- a/keras/src/backend/tensorflow/sparse.py
+++ b/keras/src/backend/tensorflow/sparse.py
@@ -59,8 +59,8 @@ def sparse_union_indices_and_values(x1, x2_indices, x2_values=None):
     for these indices.
 
     Args:
-        x: a `tf.SparseTensor`.
-        indices: another set of indices in the `tf.SparseTensor` format.
+        x1: a `tf.SparseTensor`.
+        x2_indices: another set of indices in the `tf.SparseTensor` format.
     Returns: A tuple containing:
         - the indices for the union
         - `x1` values for the union indices (some zeros were added)
@@ -91,7 +91,7 @@ def indexed_slices_union_indices_and_values(x1, x2_indices, x2_values=None):
     Args:
         x1: the first `tf.IndexedSlices`.
         x2_indices: the indices for the second `tf.IndexedSlices`.
-        x2_value: (optional) the values for the second `tf.IndexedSlices`.
+        x2_values: (optional) the values for the second `tf.IndexedSlices`.
     Returns: A tuple containing:
         - the indices for the union
         - `x1` values for the union indices (some zeros were added)

--- a/keras/src/layers/attention/multi_head_attention.py
+++ b/keras/src/layers/attention/multi_head_attention.py
@@ -274,7 +274,7 @@ class MultiHeadAttention(Layer):
         Args:
             query_shape: Shape of the `query` tensor.
             value_shape: Shape of the `value` tensor.
-            key: Optional shape of the `key` tensor.
+            key_shape: Optional shape of the `key` tensor.
         """
         key_shape = value_shape if key_shape is None else key_shape
 

--- a/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/iou.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/bounding_boxes/iou.py
@@ -186,9 +186,9 @@ def compute_ciou(boxes1, boxes2, bounding_box_format, image_shape=None):
     represent the bounding boxes.
 
     Args:
-        box1 (tensor): tensor representing the first bounding box with
+        boxes1 (tensor): tensor representing the first bounding box with
             shape (..., 4).
-        box2 (tensor): tensor representing the second bounding box with
+        boxes2 (tensor): tensor representing the second bounding box with
             shape (..., 4).
         bounding_box_format: a case-insensitive string (for example, "xyxy").
             Each bounding box is defined by these 4 values. For detailed

--- a/keras/src/optimizers/sgd.py
+++ b/keras/src/optimizers/sgd.py
@@ -83,7 +83,7 @@ class SGD(optimizer.Optimizer):
         is not 0.
 
         Args:
-          var_list: list of model variables to build SGD variables on.
+          variables: list of model variables to build SGD variables on.
         """
         if self.built:
             return

--- a/keras/src/trainers/data_adapters/array_data_adapter.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter.py
@@ -448,7 +448,7 @@ def can_convert_arrays(arrays):
     """Check if array like-inputs can be handled by `ArrayDataAdapter`
 
     Args:
-        inputs: Structure of `Tensor`s, NumPy arrays, or tensor-like.
+        arrays: Structure of `Tensor`s, NumPy arrays, or tensor-like.
 
     Returns:
         `True` if `arrays` can be handled by `ArrayDataAdapter`, `False`

--- a/keras/src/utils/summary_utils.py
+++ b/keras/src/utils/summary_utils.py
@@ -397,8 +397,8 @@ def get_layer_index_bound_by_layer_name(layers, layer_range=None):
     display.
 
     Args:
-        model: `Model` instance.
-        layer_names: a list or tuple of 2 strings, the starting layer name and
+        layers: list of `Layer` instances.
+        layer_range: a list or tuple of 2 strings, the starting layer name and
             ending layer name (both inclusive) for the result. All layers will
             be included when `None` is provided.
 


### PR DESCRIPTION
## Description

Several docstrings document parameter names that don't exist in the corresponding signature, so the rendered API docs advertise arguments that raise `TypeError` when passed.

I found these by parsing every `Args:` section in the codebase and comparing the documented names against the actual signatures, then reviewing each hit by hand.

| Location | Documented | Actual signature |
|---|---|---|
| `keras.config.set_max_steps_per_epoch` | `max_epochs` | `(max_steps_per_epoch)` |
| `keras.config.max_steps_per_epoch` | `max_epochs` | `()` — takes no arguments |
| `compute_ciou` | `box1`, `box2` | `(boxes1, boxes2, ...)` |
| `MultiHeadAttention.build` | `key` | `(query_shape, value_shape, key_shape)` |
| `SGD.build` | `var_list` | `(variables)` |
| `can_convert_arrays` | `inputs` | `(arrays)` |
| `get_layer_index_bound_by_layer_name` | `model`, `layer_names` | `(layers, layer_range)` |
| `sparse_union_indices_and_values` | `x`, `indices` | `(x1, x2_indices, ...)` |
| `indexed_slices_union_indices_and_values` | `x2_value` | `(..., x2_values)` |
| `distribute_data_input` | `inputs` | `(per_process_batch, ...)` |

Verified at runtime that the documented names are rejected — note Python's own suggestion in the second case:

```
TypeError: set_max_steps_per_epoch() got an unexpected keyword argument 'max_epochs'
TypeError: compute_ciou() got an unexpected keyword argument 'box1'. Did you mean 'boxes1'?
TypeError: can_convert_arrays() got an unexpected keyword argument 'inputs'
```

Two notes on the less obvious ones:

- **`max_steps_per_epoch()`** had an `Args:` section despite taking no arguments (the only such case in the codebase). I replaced it with the `Returns:` section its sibling `max_epochs()` already has, and corrected the surrounding text, which described epochs rather than steps per epoch.
- **`SGD.build`** was the only stale one among the optimizers — `rmsprop`, `lion` and `lamb` genuinely take `var_list`, so their docstrings are correct and untouched. Only SGD's parameter was renamed to `variables` without the docstring following.

Docstrings only. No behavior change (18 insertions, 17 deletions).

## Test log

```
$ ruff check <changed files>
All checks passed!

$ ruff format --check <changed files>
8 files already formatted

$ KERAS_BACKEND=torch pytest keras/src/optimizers/sgd_test.py \
    keras/src/layers/attention/multi_head_attention_test.py \
    keras/src/utils/summary_utils_test.py
3 failed, 60 passed in 9.56s
```

The 3 failures are `Cannot convert a MPS Tensor to float64` in `sgd_test.py` — an Apple Silicon limitation unrelated to this change. They reproduce identically on a pristine `master` checkout:

```
$ git stash && pytest keras/src/optimizers/sgd_test.py
FAILED SGDTest::test_clip_norm / test_clip_value / test_correctness_with_golden
3 failed, 4 passed
```

`array_data_adapter_test.py` and the bounding-box tests require JAX/TensorFlow, which aren't installed locally; those changes are docstring-only and carry no runtime effect.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**AI disclosure (per the [AI-Assisted Contribution Policy](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md#ai-assisted-contribution-policy)):** I used an AI coding assistant to help scan for these mismatches and draft the edits. I reviewed every changed line, verified the signature mismatches at runtime, and ran the checks above. I take responsibility for the contents of this PR.