### PR TITLE
Reject unsupported quantization modes in ReversibleEmbedding before mutation

### DIFF
--- a/keras/src/layers/core/reversible_embedding.py
+++ b/keras/src/layers/core/reversible_embedding.py
@@ -383,6 +383,11 @@ class ReversibleEmbedding(layers.Embedding):
     def quantize(self, mode=None, type_check=True, config=None):
         if type_check and type(self) is not ReversibleEmbedding:
             raise self._not_implemented_error(self.quantize)
+        # Reject unsupported modes before mutating any state so that
+        # `Model.quantize` records the layer as skipped instead of leaving it
+        # half-quantized.
+        if mode not in ("int8", "int4"):
+            raise self._quantization_mode_error(mode)
 
         self.quantization_config = config
 

--- a/keras/src/layers/core/reversible_embedding_test.py
+++ b/keras/src/layers/core/reversible_embedding_test.py
@@ -11,9 +11,11 @@ from keras.src import models
 from keras.src import ops
 from keras.src import saving
 from keras.src import testing
+from keras.src.quantizers.gptq_config import GPTQConfig
 from keras.src.quantizers.quantization_config import Int4QuantizationConfig
 from keras.src.quantizers.quantization_config import Int8QuantizationConfig
 from keras.src.quantizers.quantizers import AbsMaxQuantizer
+from keras.src.quantizers.report import QuantizationReport
 from keras.src.testing import test_case
 from keras.src.testing import test_utils
 from keras.src.testing.test_utils import named_product
@@ -205,6 +207,87 @@ class ReversibleEmbeddingTest(test_case.TestCase):
         new_model.quantize(mode)
         new_model.load_weights(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
+
+    @parameterized.named_parameters(
+        named_product(mode=("float8", "gptq"), tie_weights=(True, False))
+    )
+    def test_quantize_unsupported_mode_no_mutation(self, mode, tie_weights):
+        # `ReversibleEmbedding` only supports int8/int4. Other modes must be
+        # rejected before any state is mutated, so that `Model.quantize`
+        # records the layer as skipped instead of leaving it half-quantized.
+        layer = layers.ReversibleEmbedding(10, 16, tie_weights=tie_weights)
+        layer.build()
+        x = np.random.randint(0, 9, size=(4, 3))
+        x_reverse = np.random.uniform(size=(4, 16)).astype("float32")
+        y_before = layer(x)
+        y_reverse_before = layer(x_reverse, reverse=True)
+        original_dtype_policy = layer.dtype_policy
+
+        if mode == "gptq":
+            config = GPTQConfig(dataset=None, tokenizer=None)
+        else:
+            config = None
+        with self.assertRaisesRegex(
+            NotImplementedError, "Invalid quantization mode."
+        ):
+            layer.quantize(mode, config=config)
+
+        # No state was stashed or replaced by the failed quantization.
+        self.assertIsNone(layer.quantization_config)
+        self.assertFalse(getattr(layer, "_is_quantized", False))
+        self.assertEqual(layer.dtype_policy, original_dtype_policy)
+        self.assertDType(layer.embeddings, layer.variable_dtype)
+        if not tie_weights:
+            self.assertDType(layer.reverse_embeddings, layer.variable_dtype)
+
+        # The layer still works in both directions with unchanged outputs.
+        self.assertAllClose(layer(x), y_before)
+        self.assertAllClose(layer(x_reverse, reverse=True), y_reverse_before)
+
+        # The failed attempt must not block a supported quantization.
+        layer.quantize("int8")
+        self.assertTrue(layer._is_quantized)
+
+    @parameterized.named_parameters(named_product(tie_weights=(True, False)))
+    def test_model_quantize_unsupported_mode_skips_with_reason(
+        self, tie_weights
+    ):
+        # When quantizing a whole model with a mode the embedding does not
+        # support, the embedding must be skipped (and reported as such) while
+        # the rest of the model is quantized and remains usable.
+        embedding = layers.ReversibleEmbedding(10, 16, tie_weights=tie_weights)
+        dense = layers.Dense(8)
+        model = models.Sequential([embedding, dense])
+        x = np.random.randint(0, 9, size=(4, 3))
+        model.build((None, 3))
+
+        # `ternary` is supported by `Dense` but not by the embedding.
+        report = model.quantize("ternary", verbose=False)
+
+        # The embedding was skipped with the "no support" reason and the
+        # report lists it; the dense layer was quantized.
+        unsupported = report.skipped_by_reason(
+            QuantizationReport.SKIP_NO_SUPPORT
+        )
+        self.assertIn(embedding.path or embedding.name, unsupported)
+        quantized_paths = [path for path, _, _ in report.quantized]
+        self.assertIn(dense.path or dense.name, quantized_paths)
+
+        # The embedding was left completely untouched.
+        self.assertIsNone(embedding.quantization_config)
+        self.assertFalse(getattr(embedding, "_is_quantized", False))
+        self.assertDType(embedding.embeddings, embedding.variable_dtype)
+        if not tie_weights:
+            self.assertDType(
+                embedding.reverse_embeddings, embedding.variable_dtype
+            )
+
+        # The model still runs, and so does the reverse path.
+        y = model.predict(x, verbose=0)
+        self.assertEqual(y.shape, (4, 3, 8))
+        x_reverse = np.random.uniform(size=(4, 16)).astype("float32")
+        y_reverse = embedding(x_reverse, reverse=True)
+        self.assertEqual(ops.shape(y_reverse), (4, 10))
 
     @staticmethod
     def _build_reversible_for_mode(mode, tie_weights):


### PR DESCRIPTION
## Description

`ReversibleEmbedding.quantize` assigned `self.quantization_config` before validating the mode, so an unsupported mode (float8/gptq/awq/ternary) raised `NotImplementedError` only after stashing a stale config on the layer — which `Model.quantize` then recorded as skipped while `get_config()` still serialized the leftover config.

We validate the mode first, mirroring `Embedding.quantize`, so a skipped layer is left completely untouched.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
