### PR TITLE
Fix the Histogram operation reading histogram from the math namespace

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -9684,7 +9684,7 @@ class Histogram(Operation):
         x = backend.convert_to_tensor(x)
         if len(x.shape) > 1:
             raise ValueError("Input tensor must be 1-dimensional")
-        return backend.math.histogram(x, bins=self.bins, range=self.range)
+        return backend.numpy.histogram(x, bins=self.bins, range=self.range)
 
     def compute_output_spec(self, x):
         return (

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -12866,6 +12866,12 @@ class HistogramTest(testing.TestCase):
         self.assertEqual(edges.shape, expected_edges.shape)
         self.assertAllClose(edges, expected_edges)
 
+        # The operation form is what a functional model calls at inference.
+        counts, edges = knp.Histogram()(input_tensor)
+
+        self.assertAllClose(counts, expected_counts)
+        self.assertAllClose(edges, expected_edges)
+
     def test_histogram_custom_bins(self):
         hist_op = knp.histogram
         input_tensor = np.random.rand(8)


### PR DESCRIPTION
## Description

`Histogram.call` reads `backend.math.histogram`, which does not exist. Every backend defines `histogram` in `backend/<name>/numpy.py`, and the `keras.ops.histogram` function reaches it correctly as `backend.numpy.histogram` a few lines below. Only the operation class points at the wrong namespace, so it raises `AttributeError` on jax, tensorflow, torch and numpy alike.

It surfaces whenever the op lands in a functional graph as its own node rather than inside a layer:

```python
inputs = keras.Input(shape=(8,))
counts, edges = keras.ops.histogram(keras.ops.reshape(inputs, (-1,)), bins=5)
keras.Model(inputs, (counts, edges)).predict(np.random.randn(1, 8))
```

Building the model is fine, since symbolic tracing goes through `compute_output_spec`. `predict` then reaches `Histogram.call` and raises.

The existing tests miss it because they all call `keras.ops.histogram` on eager input, which never constructs the operation. `test_histogram_predict` does build a model, but it wraps the call in a layer, so at inference the layer body runs eagerly and takes the function path as well. The default args test now covers the operation form too, and it fails on master without this change.

Tested with `keras/src/ops/numpy_test.py` on the jax, tensorflow, torch and numpy backends.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
