### PR TITLE
Let the backend provide fused rms and layer normalization

### DIFF
--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -1719,3 +1719,47 @@ def space_to_depth(x, block_size, data_format="channels_last"):
         # Reshape: (N, C, bH, bW, new_H, new_W) -> (N, C*bH*bW, new_H, new_W)
         x = x.reshape(n, c * block_size**2, new_h, new_w)
     return x
+
+
+def _trailing_normalized_shape(x, axis):
+    """The shape torch normalizes over, or None if the axes are not trailing.
+
+    `tnn.rms_norm` and `tnn.layer_norm` normalize over the last axes of the
+    input, so axes that are not a trailing run have no fused form and belong
+    on the composed path.
+    """
+    ndim = len(x.shape)
+    if ndim == 0:
+        # A scalar has no axis to normalize over. The composed path expands it
+        # first, so hand it back rather than canonicalizing an axis that is
+        # out of bounds.
+        return None
+    if isinstance(axis, int):
+        axis = [axis]
+    axis = sorted(canonicalize_axis(a, ndim) for a in axis)
+    if axis != list(range(ndim - len(axis), ndim)):
+        return None
+    return tuple(x.shape[d] for d in axis)
+
+
+def rms_normalization(x, scale=None, axis=-1, epsilon=None):
+    normalized_shape = _trailing_normalized_shape(x, axis)
+    if normalized_shape is None:
+        return None
+    if scale is not None and tuple(scale.shape) != normalized_shape:
+        return None
+    if epsilon is None:
+        epsilon = backend.epsilon()
+    return tnn.rms_norm(x, normalized_shape, scale, epsilon)
+
+
+def layer_normalization(x, gamma=None, beta=None, axis=-1, epsilon=None):
+    normalized_shape = _trailing_normalized_shape(x, axis)
+    if normalized_shape is None:
+        return None
+    for weight in (gamma, beta):
+        if weight is not None and tuple(weight.shape) != normalized_shape:
+            return None
+    if epsilon is None:
+        epsilon = backend.epsilon()
+    return tnn.layer_norm(x, normalized_shape, gamma, beta, epsilon)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -20,7 +20,6 @@ from keras.src.backend.common.backend_utils import (
 from keras.src.ops import operation_utils
 from keras.src.ops.operation import Operation
 from keras.src.ops.operation_utils import reduce_shape
-from keras.src.utils.python_utils import is_continuous_axis
 
 
 class Relu(Operation):
@@ -3046,15 +3045,13 @@ def _rms_normalization(x, scale=None, axis=-1, epsilon=None):
 
     if isinstance(axis, (tuple, list)):
         axis = sorted(axis)
-    if backend.backend() == "torch" and is_continuous_axis(axis):
-        import torch.nn.functional as F
-
-        if isinstance(axis, (tuple, list)):
-            normalized_shape = tuple(x.shape[dim] for dim in axis)
-        else:
-            normalized_shape = (x.shape[axis],)
-        outputs = F.rms_norm(x, normalized_shape, scale, epsilon)
-    else:
+    outputs = None
+    fused_rms_normalization = getattr(backend.nn, "rms_normalization", None)
+    if fused_rms_normalization is not None:
+        outputs = fused_rms_normalization(
+            x, scale=scale, axis=axis, epsilon=epsilon
+        )
+    if outputs is None:
         if len(x.shape) == 0:
             x = backend.numpy.expand_dims(x, axis=0)
         rrms = backend.math.rsqrt(
@@ -3182,19 +3179,22 @@ def _layer_normalization(
             return backend.numpy.reshape(v, broadcast_shape)
         return v
 
+    outputs = None
     if rms_scaling:
         variance = backend.numpy.var(x, axis=axis, keepdims=True)
         inv = backend.math.rsqrt(variance + epsilon)
-        outputs = outputs = x * inv
+        outputs = x * inv
         if gamma is not None:
             outputs = outputs * backend.cast(_broadcast(gamma), x.dtype)
-    elif backend.config.backend() == "torch" and is_continuous_axis(axis):
-        # when using torch backend,use kernel to improve performance
-        import torch.nn.functional as F
-
-        normalized_shape = tuple(input_shape[dim] for dim in axis)
-        outputs = F.layer_norm(x, normalized_shape, gamma, beta, epsilon)
     else:
+        fused_layer_normalization = getattr(
+            backend.nn, "layer_normalization", None
+        )
+        if fused_layer_normalization is not None:
+            outputs = fused_layer_normalization(
+                x, gamma=gamma, beta=beta, axis=axis, epsilon=epsilon
+            )
+    if outputs is None:
         # Calculate the mean & variance along self.axis (layer activations).
         mean, variance = moments(x, axes=axis, keepdims=True)
         gamma, beta = _broadcast(gamma), _broadcast(beta)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2873,6 +2873,36 @@ class NNOpsCorrectnessTest(testing.TestCase):
         )
         self.assertAllClose(knn.LayerNorm()(x), expected_output, atol=1e-3)
 
+    @parameterized.named_parameters(
+        ("leading", [0, 1]),
+        ("interior", [1, 2]),
+        ("trailing", [1, 2, 3]),
+    )
+    def test_normalization_over_continuous_axes(self, axis):
+        # A backend that normalizes with a fused kernel only handles trailing
+        # axes, so any other continuous run has to reach the composed path.
+        x = np.arange(120, dtype="float32").reshape((2, 3, 4, 5)) / 120.0
+        axes = tuple(axis)
+        epsilon = 1e-5
+
+        expected = x / np.sqrt(
+            np.mean(np.square(x), axis=axes, keepdims=True) + epsilon
+        )
+        self.assertAllClose(
+            knn.rms_normalization(x, axis=axis, epsilon=epsilon),
+            expected,
+            atol=1e-5,
+        )
+
+        mean = np.mean(x, axis=axes, keepdims=True)
+        variance = np.var(x, axis=axes, keepdims=True)
+        expected = (x - mean) / np.sqrt(variance + epsilon)
+        self.assertAllClose(
+            knn.layer_normalization(x, axis=axis, epsilon=epsilon),
+            expected,
+            atol=1e-5,
+        )
+
 
 class NNOpsDtypeTest(testing.TestCase):
     """Test the floating dtype to verify that the behavior matches JAX."""

--- a/keras/src/utils/python_utils.py
+++ b/keras/src/utils/python_utils.py
@@ -5,18 +5,6 @@ import os
 import types as python_types
 
 
-def is_continuous_axis(axis):
-    # Used to determine whether the dimensions in an axis are continuous
-    if isinstance(axis, int) or len(axis) <= 1:
-        return True
-
-    step = axis[1] - axis[0]
-    if step not in (1, -1):
-        return False
-
-    return all(axis[i + 1] - axis[i] == step for i in range(len(axis) - 1))
-
-
 def default(method):
     """Decorates a method to detect overrides in subclasses."""
     method._is_default = True

--- a/keras/src/utils/python_utils_test.py
+++ b/keras/src/utils/python_utils_test.py
@@ -99,17 +99,3 @@ class PythonUtilsTest(testing.TestCase):
         bad_encoded_code = "This isn't valid base64!"
         with self.assertRaises(AttributeError):
             python_utils.func_load(bad_encoded_code)
-
-    def test_is_continuous_axis(self):
-        # Single axis
-        self.assertTrue(python_utils.is_continuous_axis(1))
-        self.assertTrue(python_utils.is_continuous_axis([1]))
-        # Forward-ordered continuous
-        self.assertTrue(python_utils.is_continuous_axis([1, 2, 3]))
-        self.assertTrue(python_utils.is_continuous_axis([-2, -1]))
-        # Reverse-ordered continuous
-        self.assertTrue(python_utils.is_continuous_axis([3, 2, 1]))
-        self.assertTrue(python_utils.is_continuous_axis([-1, -2]))
-        # Non-continuous
-        self.assertFalse(python_utils.is_continuous_axis([1, 3]))
-        self.assertFalse(python_utils.is_continuous_axis([-1, -3]))


### PR DESCRIPTION
## Description

`_rms_normalization` and `_layer_normalization` reached for the torch fused kernels behind a literal `backend.backend() == "torch"` check guarded by `is_continuous_axis`. That guard is wrong. It checks that the axes are consecutive but not that they are trailing, and trailing is what `F.rms_norm` and `F.layer_norm` require. On master, `rms_normalization(x, axis=[0, 1])` and `layer_normalization(x, axis=[1, 2])` raise `RuntimeError: Given normalized_shape=[2, 3], expected input with shape [*, 2, 3]` on torch, where jax, tensorflow and numpy all return the right answer.

Rather than tighten the guard in `ops/nn.py`, this moves the decision to the backend. `ops/nn.py` looks for `rms_normalization` and `layer_normalization` on `backend.nn` and calls them if they are there. A backend returns `None` for anything its kernel cannot express, and the composed path runs as before. The torch implementation moves into `keras/src/backend/torch/nn.py`, where it declines a non trailing axis run, a weight that is not shaped like the axes it scales, and a 0-d input.

That last one is worth calling out because it changes torch behaviour. `rms_normalization` on a scalar raised `IndexError: tuple index out of range` on torch, while jax, tensorflow and numpy all return `[1.]` through the composed path, which expands the input first. Declining 0-d hands it back to that path, so torch now agrees with the others. `layer_normalization` on a scalar still raises on all four backends, which is a separate issue and untouched here.

`is_continuous_axis` had no other callers, so it and its test are removed.

The wider reason for the hook is that torch is not the only backend with fused normalization kernels. mlx has `mx.fast.rms_norm` and `mx.fast.layer_norm`, and measured on Apple Silicon they run 3.1x to 7.9x faster than the composed path in the forward pass and 2.7x to 4.5x faster with gradients. There is no way to reach them while the dispatch is a hardcoded backend name.

`test_normalization_over_continuous_axes` covers leading, interior and trailing axis runs for both ops. The first two fail on master. Full `keras/src/ops/nn_test.py`, `keras/src/layers/normalization/` and `keras/src/utils/python_utils_test.py` pass on jax, tensorflow, torch and numpy.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
