### PR TITLE
Fix GPTQ/AWQ calibration: dead hooks, zero-point range, group cache, and sequential Hessians

### DIFF
--- a/keras/src/quantizers/awq_core.py
+++ b/keras/src/quantizers/awq_core.py
@@ -15,6 +15,7 @@ from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
 from keras.src.quantizers.awq import AWQ
 from keras.src.quantizers.awq_config import AWQConfig
 from keras.src.quantizers.gptq_core import find_layers_in_block
+from keras.src.quantizers.gptq_core import get_calibration_call_attribute
 from keras.src.quantizers.gptq_core import get_dataloader
 from keras.src.quantizers.utils import should_quantize_layer
 
@@ -23,8 +24,10 @@ from keras.src.quantizers.utils import should_quantize_layer
 def stream_activations(layers_map, awq_objects):
     """Context manager to capture activations for AWQ calibration.
 
-    Temporarily patches layer.call methods to capture activation statistics
-    for computing per-channel scaling factors.
+    Temporarily patches each layer's dispatched forward method
+    (`layer.quantized_call` if the layer is already in a quantized mode,
+    `layer.call` otherwise) to capture activation statistics for computing
+    per-channel scaling factors.
 
     Args:
         layers_map: Dict[str, Layer]. Mapping from layer names to layers.
@@ -47,12 +50,13 @@ def stream_activations(layers_map, awq_objects):
 
     try:
         for name, layer in layers_map.items():
-            original_calls[name] = layer.call
-            layer.call = create_hook(name, layer.call)
+            attr = get_calibration_call_attribute(layer)
+            original_calls[name] = (attr, getattr(layer, attr))
+            setattr(layer, attr, create_hook(name, original_calls[name][1]))
         yield
     finally:
-        for name, layer in layers_map.items():
-            layer.call = original_calls[name]
+        for name, (attr, original_call) in original_calls.items():
+            setattr(layers_map[name], attr, original_call)
 
 
 def apply_awq_layerwise(dataloader, config, structure, filters=None):

--- a/keras/src/quantizers/awq_test.py
+++ b/keras/src/quantizers/awq_test.py
@@ -954,3 +954,78 @@ class AWQAccuracyTest(testing.TestCase):
         y_after = reloaded.predict(x_eval)
 
         self.assertAllClose(y_before, y_after)
+
+    def test_awq_calibration_hooks_fire_during_model_quantize(self):
+        """Calibration hooks must run during `model.quantize("awq")`.
+
+        Regression test: `model.quantize` switches layers to their quantized
+        dtype policy before calibration, after which `Operation.__call__`
+        dispatches to `quantized_call` instead of `call`. The calibration
+        hooks used to patch `call` only, so they never fired: activation
+        magnitudes stayed zero and the AWQ scale search was
+        activation-blind. Asserts the hook actually runs and records
+        non-zero activation magnitudes.
+        """
+        keras.utils.set_random_seed(123)
+        seq_len = 16
+        vocab = 48
+        embed_dim = 8
+
+        block = models.Sequential(
+            [
+                layers.Dense(16, activation="relu"),
+                layers.Dense(embed_dim),
+            ]
+        )
+
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab, embed_dim)
+        x = embedding(inputs)
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        outputs = layers.Dense(4)(x)
+        model = models.Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=7)
+        dataset = [
+            rng.integers(0, vocab, size=(1, seq_len), dtype=np.int32)
+            for _ in range(4)
+        ]
+        tokenizer = _char_tokenizer(vocab_size=vocab, seq_len=seq_len)
+
+        config = AWQConfig(
+            dataset=dataset,
+            tokenizer=tokenizer,
+            group_size=8,
+            num_samples=4,
+            sequence_length=seq_len,
+            num_grid_points=5,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        hook_calls = [0]
+        max_magnitude = [0.0]
+        original_update = AWQ.update_activation_magnitudes
+
+        def spy_update(awq_self, inp):
+            hook_calls[0] += 1
+            result = original_update(awq_self, inp)
+            magnitudes = ops.convert_to_numpy(awq_self.activation_magnitudes)
+            max_magnitude[0] = max(
+                max_magnitude[0], float(np.abs(magnitudes).max())
+            )
+            return result
+
+        AWQ.update_activation_magnitudes = spy_update
+        try:
+            model.quantize("awq", config=config)
+        finally:
+            AWQ.update_activation_magnitudes = original_update
+
+        self.assertGreater(hook_calls[0], 0)
+        # All-zero magnitudes would be replaced with ones, making the
+        # scale search activation-blind.
+        self.assertGreater(max_magnitude[0], 0.0)

--- a/keras/src/quantizers/gptq.py
+++ b/keras/src/quantizers/gptq.py
@@ -125,6 +125,17 @@ def gptq_quantize_matrix(
     # Compute effective group size
     effective_group = in_features if group_size == -1 else group_size
 
+    # Per-group cached params, reused until the column index crosses into
+    # the next group. The cache must live across processing blocks: a group
+    # can span several blocks (`group_size == -1` covers the whole matrix,
+    # and `group_size > blocksize` covers more than one block). Resetting it
+    # per block would recompute and re-append the same group's params once
+    # per block, corrupting the [out_features, n_groups] scale/zero layout.
+    cached_scale = None
+    cached_zero = None
+    cached_maxq = None
+    cached_group_start = -1
+
     # Process features in blocks
     for block_start in range(0, in_features, blocksize):
         block_end = min(block_start + blocksize, in_features)
@@ -139,12 +150,6 @@ def gptq_quantize_matrix(
         block_inv_hessian = inv_hessian[
             block_start:block_end, block_start:block_end
         ]
-
-        # Per-group cached params for reuse within the group
-        cached_scale = None
-        cached_zero = None
-        cached_maxq = None
-        cached_group_start = -1
 
         for block_idx in range(block_size):
             # Current global column index, represents the original column

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from contextlib import contextmanager
 
 import numpy as np
@@ -36,7 +37,7 @@ def get_calibration_call_attribute(layer):
 
 
 @contextmanager
-def stream_hessians(layers_map, gptq_objects):
+def stream_hessians(layers_map, gptq_objects, execution_trace=None):
     """
     Temporarily monkey-patch each target layer's forward method so
     that input activations are streamed into the GPTQ instance
@@ -64,6 +65,13 @@ def stream_hessians(layers_map, gptq_objects):
          the Keras layers that should be patched during calibration. Keys must
          match `gptq_objects`.
         gptq_objects: Dict[str, GPTQ]. Mapping from names to GPTQ instances.
+        execution_trace: Optional dict. When provided, each layer's FIRST
+         hook invocation records `{name: (call_index, input_tensor)}` into
+         it — the block-level execution order and the identity of the input
+         each layer consumes. Used to derive within-block quantization
+         stages (see `apply_gptq_layerwise`). The recorded tensors are only
+         kept alive for identity comparison; callers should drop the trace
+         after use.
 
     Yields:
         None: The patched state is active only within the `with` block. After
@@ -80,10 +88,17 @@ def stream_hessians(layers_map, gptq_objects):
     ```
     """
     original_calls = {}
+    call_counter = [0]
 
     def create_hook(name, original_call_func):
         def hook(*args, **kwargs):
             inp = args[0] if args else kwargs["inputs"]
+            if execution_trace is not None and name not in execution_trace:
+                # Record block-level execution order and the input tensor's
+                # identity on the first call (a live reference is kept so the
+                # id cannot be recycled while tracing).
+                execution_trace[name] = (call_counter[0], inp)
+                call_counter[0] += 1
             # Explicitly reshape the input tensor to be 2D, with the
             # second dimension matching the number of input features
             # expected by the layer's kernel.
@@ -260,6 +275,58 @@ def find_layers_in_block(block):
     return found_layers
 
 
+def _execution_stages(layer_names, execution_trace):
+    """Groups a block's layers into sequential quantization stages.
+
+    Reference GPTQ implementations quantize a block's sub-layers in
+    topological order ("true sequential"): once an upstream sub-layer is
+    quantized, downstream Hessians are re-estimated on the quantized
+    activations. Without this, e.g. an MLP's Hessian is captured while the
+    attention sub-layers are still full-precision, and the error
+    corrections it derives are tuned to activations that no longer exist
+    once attention is quantized too — which measurably degrades quality
+    below plain round-to-nearest.
+
+    Stages are derived from the calibration trace: layers are ordered by
+    first invocation, and layers that consumed the *same* input tensor
+    (e.g. the query/key/value projections, or an MLP's gate/up pair) share
+    a stage since quantizing one cannot affect the others' inputs. Layers
+    that never fired during tracing are placed in the first stage,
+    preserving their (empty) Hessian behavior.
+
+    Args:
+        layer_names: Iterable of layer names in the block.
+        execution_trace: Dict of `{name: (call_index, input_tensor)}`
+            recorded by `stream_hessians`.
+
+    Returns:
+        List of lists of layer names, one list per stage, in execution
+        order.
+    """
+    traced = [name for name in layer_names if name in execution_trace]
+    untraced = [name for name in layer_names if name not in execution_trace]
+    traced.sort(key=lambda name: execution_trace[name][0])
+
+    stages = []
+    current_stage, current_input_id = [], None
+    for name in traced:
+        input_id = id(execution_trace[name][1])
+        if current_stage and input_id != current_input_id:
+            stages.append(current_stage)
+            current_stage = []
+        current_stage.append(name)
+        current_input_id = input_id
+    if current_stage:
+        stages.append(current_stage)
+
+    if untraced:
+        if stages:
+            stages[0] = untraced + stages[0]
+        else:
+            stages = [untraced]
+    return stages
+
+
 def apply_gptq_layerwise(dataloader, config, structure, filters=None):
     """Applies GPTQ quantization layer-by-layer to a Keras model.
 
@@ -322,6 +389,10 @@ def apply_gptq_layerwise(dataloader, config, structure, filters=None):
 
     progbar = keras_utils.Progbar(target=len(transformer_blocks))
 
+    # Layers whose Hessian saw too few calibration tokens relative to their
+    # input width, collected across all blocks for a single summary warning.
+    undersampled_layers = []
+
     for block_idx, block in enumerate(transformer_blocks):
         logging.info(f"Quantizing Block {block_idx}")
         sub_layers_map = find_layers_in_block(block)
@@ -347,17 +418,50 @@ def apply_gptq_layerwise(dataloader, config, structure, filters=None):
                 for name, layer in sub_layers_map.items()
             }
 
-            with stream_hessians(sub_layers_map, gptq_objects):
+            execution_trace = {}
+            with stream_hessians(
+                sub_layers_map, gptq_objects, execution_trace=execution_trace
+            ):
                 for start in range(0, num_samples, batch_size):
                     batch = _stack_calibration_batch(
                         inputs[start : start + batch_size]
                     )
                     _ = block(batch)
 
-            for name, gptq_object in gptq_objects.items():
-                logging.info(f"Quantizing {name}...")
-                gptq_object.quantize_and_correct_layer()
-                gptq_object.free()
+            # Quantize the block's layers in execution-order stages ("true
+            # sequential", as in reference GPTQ): after each stage is
+            # quantized, downstream stages' Hessians are re-estimated so
+            # their error corrections are computed against the quantized
+            # upstream activations they will actually see at inference.
+            stages = _execution_stages(sub_layers_map, execution_trace)
+            del execution_trace
+
+            for stage_idx, stage_names in enumerate(stages):
+                if stage_idx > 0:
+                    stage_map = {
+                        name: sub_layers_map[name] for name in stage_names
+                    }
+                    stage_objects = {}
+                    for name in stage_names:
+                        gptq_objects[name].free()
+                        gptq_objects[name] = GPTQ(sub_layers_map[name], config)
+                        stage_objects[name] = gptq_objects[name]
+                    with stream_hessians(stage_map, stage_objects):
+                        for start in range(0, num_samples, batch_size):
+                            batch = _stack_calibration_batch(
+                                inputs[start : start + batch_size]
+                            )
+                            _ = block(batch)
+
+                for name in stage_names:
+                    gptq_object = gptq_objects[name]
+                    tokens = int(gptq_object.num_samples)
+                    rows = int(gptq_object.rows)
+                    if tokens < 4 * rows:
+                        undersampled_layers.append((name, tokens, rows))
+                    logging.info(f"Quantizing {name}...")
+                    gptq_object.quantize_and_correct_layer()
+                    gptq_object.free()
 
             del gptq_objects
 
@@ -375,6 +479,25 @@ def apply_gptq_layerwise(dataloader, config, structure, filters=None):
                     next_block_inputs.append(output[sample_idx])
             inputs = next_block_inputs
         progbar.update(current=block_idx + 1)
+
+    if undersampled_layers:
+        worst = min(t / r for _, t, r in undersampled_layers)
+        examples = ", ".join(
+            f"{name} ({tokens} tokens for {rows} input features)"
+            for name, tokens, rows in undersampled_layers[:3]
+        )
+        warnings.warn(
+            f"GPTQ calibration is undersampled for "
+            f"{len(undersampled_layers)} layer(s): fewer than 4 calibration "
+            "tokens per input feature (worst ratio: "
+            f"{worst:.1f}). With this little data the Hessian is close to "
+            "singular and GPTQ's error correction can overfit the "
+            "calibration set and produce worse results than plain "
+            "round-to-nearest. Increase `num_samples` and/or "
+            "`sequence_length` in `GPTQConfig` (8 or more tokens per input "
+            f"feature is recommended). Examples: {examples}.",
+            stacklevel=2,
+        )
 
     logging.info("Quantization process complete.")
 

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -15,23 +15,45 @@ from keras.src.quantizers.gptq_config import GPTQConfig
 from keras.src.quantizers.utils import should_quantize_layer
 
 
+def get_calibration_call_attribute(layer):
+    """Returns the name of the forward method dispatched for `layer`.
+
+    `Operation.__call__` dispatches to `layer.quantized_call` (instead of
+    `layer.call`) as soon as the layer has a quantization mode. During
+    `model.quantize(...)`, layers are switched to their quantized dtype
+    policy before calibration runs, so calibration hooks must patch the
+    method that is actually invoked.
+
+    Args:
+        layer: The Keras layer to inspect.
+
+    Returns:
+        str. Either `"quantized_call"` or `"call"`.
+    """
+    if getattr(layer, "quantization_mode", None) is not None:
+        return "quantized_call"
+    return "call"
+
+
 @contextmanager
 def stream_hessians(layers_map, gptq_objects):
     """
-    Temporarily monkey-patch each target layer's `call` method so
+    Temporarily monkey-patch each target layer's forward method so
     that input activations are streamed into the GPTQ instance
     running Hessian estimate at capture time.
 
     On `__enter__`: For every (name, layer) in `layers_map`, replaces
-     `layer.call` with a wrapper that:
+     the layer's dispatched forward method (`layer.quantized_call` if the
+     layer is already in a quantized mode, `layer.call` otherwise) with a
+     wrapper that:
      1) extracts the layer input from `*args`/`**kwargs`,
      2) reshapes it to 2D `[-1, rows]` where
       `rows = gptq_objects[name].rows`,
      3) calls `gptq_objects[name].update_hessian_with_batch(x2d)`
-     4) delegates to the original `layer.call` and returns its
+     4) delegates to the original forward method and returns its
       output.
 
-    On `__exit__`: All original `layer.call` methods are restored even if an
+    On `__exit__`: All original forward methods are restored even if an
      exception occurs.
 
     * Space complexity: O(d**2) per layer (for the Hessian).
@@ -54,7 +76,7 @@ def stream_hessians(layers_map, gptq_objects):
     ...         if len(sample.shape) == 2:
     ...             sample = ops.expand_dims(sample, 0)
     ...         _ = block(sample)   # hooks update Hessians on-the-fly
-    >>> # <- original layer.call methods restored here
+    >>> # <- original forward methods restored here
     ```
     """
     original_calls = {}
@@ -76,12 +98,13 @@ def stream_hessians(layers_map, gptq_objects):
 
     try:
         for name, layer in layers_map.items():
-            original_calls[name] = layer.call
-            layer.call = create_hook(name, layer.call)
+            attr = get_calibration_call_attribute(layer)
+            original_calls[name] = (attr, getattr(layer, attr))
+            setattr(layer, attr, create_hook(name, original_calls[name][1]))
         yield
     finally:
-        for name, layer in layers_map.items():
-            layer.call = original_calls[name]
+        for name, (attr, original_call) in original_calls.items():
+            setattr(layers_map[name], attr, original_call)
 
 
 def get_dataloader(

--- a/keras/src/quantizers/gptq_core_test.py
+++ b/keras/src/quantizers/gptq_core_test.py
@@ -369,3 +369,48 @@ class TestGPTQCore(testing.TestCase):
         with self.assertRaisesRegex(ValueError, error_message):
             # We pass None as structure to trigger the error
             gptq_quantize(config, quantization_layer_structure=None)
+
+
+class TestExecutionStages(testing.TestCase):
+    def test_stages_group_by_shared_input_and_order(self):
+        from keras.src.quantizers.gptq_core import _execution_stages
+
+        x_attn, x_out, x_mlp, x_down = (
+            object(),
+            object(),
+            object(),
+            object(),
+        )
+        trace = {
+            "query": (0, x_attn),
+            "key": (1, x_attn),
+            "value": (2, x_attn),
+            "attention_output": (3, x_out),
+            "gate": (4, x_mlp),
+            "up": (5, x_mlp),
+            "down": (6, x_down),
+        }
+        stages = _execution_stages(list(trace), trace)
+        self.assertEqual(
+            stages,
+            [
+                ["query", "key", "value"],
+                ["attention_output"],
+                ["gate", "up"],
+                ["down"],
+            ],
+        )
+
+    def test_untraced_layers_join_first_stage(self):
+        from keras.src.quantizers.gptq_core import _execution_stages
+
+        x = object()
+        trace = {"a": (0, x)}
+        stages = _execution_stages(["ghost", "a"], trace)
+        self.assertEqual(stages, [["ghost", "a"]])
+
+    def test_no_trace_single_stage(self):
+        from keras.src.quantizers.gptq_core import _execution_stages
+
+        stages = _execution_stages(["a", "b"], {})
+        self.assertEqual(stages, [["a", "b"]])

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -18,6 +18,7 @@ from keras.src.quantizers.gptq import gptq_quantize_matrix
 from keras.src.quantizers.gptq_config import GPTQConfig
 from keras.src.quantizers.gptq_core import find_layers_in_block
 from keras.src.quantizers.quantization_config import QuantizationConfig
+from keras.src.quantizers.quantizers import GPTQQuantizer
 from keras.src.quantizers.quantizers import dequantize_with_sz_map
 from keras.src.quantizers.quantizers import dequantize_with_zero_point
 from keras.src.quantizers.quantizers import quantize_with_zero_point
@@ -579,6 +580,135 @@ class GPTQTest(testing.TestCase):
         # entries; an all-zeros Hessian would be replaced by the identity
         # (dead-feature path), silently disabling error correction.
         self.assertGreater(max_off_diagonal[0], 0.0)
+
+    @parameterized.named_parameters(
+        ("per_channel", -1, 1),
+        ("group_gt_blocksize", 256, 2),
+        ("group_eq_blocksize", 128, 4),
+        ("group_lt_blocksize", 64, 8),
+    )
+    def test_gptq_quantize_matrix_group_param_shapes(
+        self, group_size, expected_groups
+    ):
+        """Scale/zero must have one column per quantization group.
+
+        Regression test: the per-group parameter cache was reset at every
+        processing block, so a group spanning several blocks (`group_size`
+        of -1, or larger than `blocksize`) had its params recomputed and
+        re-appended once per block, producing `[out, n_blocks]`-shaped
+        scales that could not be assigned to the layer's
+        `[out, n_groups]` variables.
+        """
+        rng = np.random.default_rng(0)
+        in_features, out_features = 512, 16
+        w = ops.convert_to_tensor(
+            rng.standard_normal((out_features, in_features)).astype("float32")
+        )
+        x = rng.standard_normal((2048, in_features)).astype("float32")
+        hessian = ops.convert_to_tensor(
+            (2.0 / 2048) * (x.T @ x)
+            + 0.01 * np.eye(in_features, dtype="float32")
+        )
+        config = GPTQConfig(
+            tokenizer=None, dataset=None, weight_bits=4, group_size=group_size
+        )
+        _, scale, zero, g_idx = gptq_quantize_matrix(
+            w,
+            hessian=hessian,
+            blocksize=128,
+            group_size=group_size,
+            compute_scale_zero=GPTQQuantizer(config).find_params,
+        )
+        self.assertEqual(tuple(scale.shape), (out_features, expected_groups))
+        self.assertEqual(tuple(zero.shape), (out_features, expected_groups))
+        self.assertEqual(
+            int(ops.convert_to_numpy(ops.max(g_idx))), expected_groups - 1
+        )
+
+    def test_gptq_model_quantize_per_channel_group_size(self):
+        """`model.quantize("gptq")` with `group_size=-1` must not crash.
+
+        Regression test: with per-channel quantization the layer builds
+        `[out, 1]` scale variables, but the solver used to emit one scale
+        chunk per 128-column processing block, crashing the assignment for
+        any layer with more than 128 input features.
+        """
+        vocab_size, seq_len, embed_dim = 64, 8, 256
+
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab_size, embed_dim)
+        x = embedding(inputs)
+        block = models.Sequential([layers.Dense(4)])
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        model = models.Model(inputs, layers.Dense(2)(x))
+
+        rng = np.random.default_rng(seed=5)
+        dataset = [
+            rng.integers(0, vocab_size, size=(1, seq_len)).astype("int32")
+            for _ in range(2)
+        ]
+        config = GPTQConfig(
+            dataset=dataset,
+            tokenizer=lambda text: text,
+            weight_bits=4,
+            num_samples=2,
+            sequence_length=seq_len,
+            group_size=-1,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+        model.quantize("gptq", config=config)
+
+        dense = block.layers[0]
+        self.assertTrue(dense.is_gptq_calibrated)
+        self.assertEqual(tuple(dense.kernel_scale.shape), (4, 1))
+        self.assertEqual(tuple(dense.kernel_zero.shape), (4, 1))
+
+    def test_gptq_warns_on_undersampled_calibration(self):
+        """Fewer than 4 calibration tokens per input feature must warn.
+
+        With a near-singular Hessian, GPTQ's error correction overfits the
+        calibration set and can produce worse results than plain
+        round-to-nearest; the user should be told to increase
+        `num_samples`/`sequence_length`.
+        """
+        vocab_size, seq_len, embed_dim = 64, 8, 256
+
+        def build():
+            inputs = layers.Input(shape=(seq_len,), dtype="int32")
+            embedding = layers.Embedding(vocab_size, embed_dim)
+            x = embedding(inputs)
+            block = models.Sequential([layers.Dense(4)])
+            x = block(x)
+            x = layers.GlobalAveragePooling1D()(x)
+            model = models.Model(inputs, layers.Dense(2)(x))
+            return model, embedding, block
+
+        rng = np.random.default_rng(seed=5)
+        dataset = [
+            rng.integers(0, vocab_size, size=(1, seq_len)).astype("int32")
+            for _ in range(2)
+        ]
+
+        model, embedding, block = build()
+        config = GPTQConfig(
+            dataset=dataset,
+            tokenizer=lambda text: text,
+            weight_bits=4,
+            num_samples=2,
+            sequence_length=seq_len,
+            group_size=-1,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+        # 2 samples x 8 tokens = 16 tokens for a 256-feature layer.
+        with self.assertWarnsRegex(UserWarning, "undersampled"):
+            model.quantize("gptq", config=config)
 
 
 def _compute_scale_zero(x, **_):

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -505,6 +505,81 @@ class GPTQTest(testing.TestCase):
             self.assertIn(dense.path, found)
             self.assertIs(found[dense.path], dense)
 
+    def test_gptq_calibration_hooks_fire_during_model_quantize(self):
+        """Calibration hooks must run during `model.quantize("gptq")`.
+
+        Regression test: `model.quantize` switches layers to their quantized
+        dtype policy before calibration, after which `Operation.__call__`
+        dispatches to `quantized_call` instead of `call`. The calibration
+        hooks used to patch `call` only, so they never fired: the Hessian
+        stayed all-zeros and GPTQ silently degenerated to plain nearest
+        rounding. Asserts the hook actually runs and accumulates a
+        non-trivial (non-diagonal) Hessian.
+        """
+        keras.utils.set_random_seed(123)
+        embed_dim = 8
+
+        block = models.Sequential(
+            [
+                layers.Dense(16, activation="relu"),
+                layers.Dense(embed_dim),
+            ]
+        )
+
+        inputs = layers.Input(shape=(SEQ_LEN,), dtype="int32")
+        embedding = layers.Embedding(VOCAB_SIZE, embed_dim)
+        x = embedding(inputs)
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        outputs = layers.Dense(NUM_CLASSES)(x)
+        model = models.Model(inputs, outputs)
+
+        rng = np.random.default_rng(seed=7)
+        dataset = [
+            rng.integers(0, VOCAB_SIZE, size=(1, SEQ_LEN), dtype=np.int32)
+            for _ in range(4)
+        ]
+        tokenizer = _char_tokenizer(vocab_size=VOCAB_SIZE, seq_len=SEQ_LEN)
+
+        config = GPTQConfig(
+            dataset=dataset,
+            tokenizer=tokenizer,
+            weight_bits=4,
+            group_size=8,
+            num_samples=4,
+            sequence_length=SEQ_LEN,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        hook_calls = [0]
+        max_off_diagonal = [0.0]
+        original_update = GPTQ.update_hessian_with_batch
+
+        def spy_update(gptq_self, inp):
+            hook_calls[0] += 1
+            result = original_update(gptq_self, inp)
+            hessian = ops.convert_to_numpy(gptq_self.hessian)
+            off_diagonal = hessian - np.diag(np.diag(hessian))
+            max_off_diagonal[0] = max(
+                max_off_diagonal[0], float(np.abs(off_diagonal).max())
+            )
+            return result
+
+        GPTQ.update_hessian_with_batch = spy_update
+        try:
+            model.quantize("gptq", config=config)
+        finally:
+            GPTQ.update_hessian_with_batch = original_update
+
+        self.assertGreater(hook_calls[0], 0)
+        # A Hessian built from real activations has non-zero off-diagonal
+        # entries; an all-zeros Hessian would be replaced by the identity
+        # (dead-feature path), silently disabling error correction.
+        self.assertGreater(max_off_diagonal[0], 0.0)
+
 
 def _compute_scale_zero(x, **_):
     # Per-column asymmetric int4 example

--- a/keras/src/quantizers/quantizers.py
+++ b/keras/src/quantizers/quantizers.py
@@ -1487,6 +1487,16 @@ def compute_quantization_parameters(
         min_values = ops.min(x_reshaped, axis=1)
         max_values = ops.max(x_reshaped, axis=1)
 
+    # Unsigned asymmetric quantization: clamp the range to include zero,
+    # matching reference GPTQ/AWQ (`xmin = min(xmin, 0)`,
+    # `xmax = max(xmax, 0)`). This guarantees the zero point lands in
+    # [0, maxq] (so it is representable in `bits`-bit packed formats) and
+    # that the quantized grid can represent 0 exactly, even for groups
+    # whose values are all-negative or all-positive.
+    if not signed and not symmetric:
+        min_values = ops.minimum(min_values, 0.0)
+        max_values = ops.maximum(max_values, 0.0)
+
     # Symmetric quantization: make range symmetric around zero
     if symmetric:
         max_abs = ops.maximum(ops.abs(min_values), max_values)
@@ -1527,6 +1537,7 @@ def compute_quantization_parameters(
             zero = ops.full_like(scale, ops.divide(ops.add(maxq, 1), 2))
         else:
             zero = ops.round(ops.divide(ops.negative(min_values), scale))
+        zero = ops.clip(zero, 0, maxq)
 
     # Reshape output to [out_features, n_groups] or [out_features, 1]
     if n_groups > 1:

--- a/keras/src/quantizers/quantizers_test.py
+++ b/keras/src/quantizers/quantizers_test.py
@@ -1171,6 +1171,60 @@ class ComputeScaleZeroTest(testing.TestCase):
         self.assertTrue(ops.all(ops.greater(scale, 0.0)))
 
     @parameterized.named_parameters(
+        ("bits2", 2),
+        ("bits4", 4),
+        ("bits8", 8),
+    )
+    def test_unsigned_asymmetric_zero_point_stays_in_range(self, bits):
+        """Zero point must stay in [0, maxq] for one-sided weight groups.
+
+        Regression test: the unsigned asymmetric branch used to compute
+        `zero = round(-min / scale)` without clamping the range to include
+        zero, so all-negative groups produced zero points far above `maxq`
+        (unrepresentable in `bits`-bit packed export formats), and the
+        quantized grid could not represent 0. Reference GPTQ/AWQ clamp with
+        `xmin = min(xmin, 0)`, `xmax = max(xmax, 0)`.
+        """
+        maxq = 2**bits - 1
+        rng = np.random.default_rng(5)
+
+        # All-negative groups: without the range clamp, zero overflows.
+        x_negative = ops.array((-1.0 - rng.random((8, 16))).astype("float32"))
+        scale, zero, _ = compute_quantization_parameters(
+            x_negative,
+            bits=bits,
+            symmetric=False,
+            per_channel=True,
+            group_size=8,
+        )
+        zero_np = ops.convert_to_numpy(zero)
+        self.assertTrue(np.all(zero_np >= 0))
+        self.assertTrue(np.all(zero_np <= maxq))
+        # With max clamped to 0, the top of the grid is exactly 0:
+        # zero == maxq and (maxq - zero) * scale == 0.
+        self.assertTrue(np.all(zero_np == maxq))
+
+        # All-positive groups: zero must be 0 (bottom of the grid is 0).
+        x_positive = ops.array((1.0 + rng.random((8, 16))).astype("float32"))
+        _, zero, _ = compute_quantization_parameters(
+            x_positive,
+            bits=bits,
+            symmetric=False,
+            per_channel=True,
+            group_size=8,
+        )
+        zero_np = ops.convert_to_numpy(zero)
+        self.assertTrue(np.all(zero_np == 0))
+
+        # The clamped range must still cover the original values.
+        scale_np = ops.convert_to_numpy(scale)
+        min_np = ops.convert_to_numpy(
+            ops.min(ops.reshape(x_negative, (8, 2, 8)), axis=2)
+        )
+        # Lowest representable value (q=0): (0 - zero) * scale <= min.
+        self.assertTrue(np.all(-maxq * scale_np <= min_np + 1e-6))
+
+    @parameterized.named_parameters(
         ("sym_true", True),
         ("sym_false", False),
     )


### PR DESCRIPTION
## Description

### Problem

It was recently discovered that `model.quantize("gptq")` and `model.quantize("awq")` do not run calibration. This bug has existed for several months.

The quantize flow first switches each layer to its quantized dtype policy. After the switch, `Operation.__call__` dispatches to `quantized_call`. The calibration hooks patch `layer.call`. That method never runs again. The GPTQ Hessian stays zero, so GPTQ silently becomes round-to-nearest (RTN), and `activation_order` becomes a no-op. The AWQ activation statistics stay zero, so the AWQ scale search is activation-blind.

The regression started in #21641. AWQ inherited it in #21992. Nothing fails loudly: calibration forwards use the fp kernel until calibration completes, so outputs always look plausible.

Verification of the fix found three more defects:

- The unsigned asymmetric zero point has no clamp. All-negative weight groups get zero points up to 255. These values do not fit any 4-bit packed export format.
- `gptq_quantize_matrix` resets its group-parameter cache in each 128-column processing block. With `group_size=-1`, this crashes `model.quantize` on layers wider than 128 inputs.
- Calibration captures all Hessians of a block in one pass, while every sub-layer is still full precision. The MLP corrections then target activations that change when attention is quantized. This within-block staleness made calibrated GPTQ worse than RTN.

## Fix

- The calibration hooks now patch the method that `Operation.__call__` dispatches: `quantized_call` for a quantized layer, `call` otherwise.
- `compute_quantization_parameters` clamps the unsigned asymmetric range to include zero (`min <= 0 <= max`), as reference GPTQ/AutoGPTQ do. Zero points now always fit `[0, 2^bits - 1]`.
- The group-parameter cache now lives across processing blocks. `group_size=-1` and `group_size > blocksize` produce correct `[out, n_groups]` scales.
- `apply_gptq_layerwise` quantizes each block in execution-order stages and re-estimates downstream Hessians after each stage. This is the `true_sequential` behavior that AutoGPTQ uses by default.
- A single aggregated warning fires when a layer gets fewer than 4 calibration tokens per input feature.

## Results

All runs: RunPod GPUs, torch backend (since it was available in an existing template) - however the results will replicate across backends, wikitext-2, W4 g128. Repro: [benchmark harness](https://gist.github.com/JyotinderSingh/402982ac773d8518d194d32ec4acb548) + [A/B patches](https://gist.github.com/JyotinderSingh/3188c9c4d67eb53774634e83cd98cd3a).

**Proof the hooks were dead** (GPT-2, fp32 PPL 109.98 — matches the 110.03 published in #21628/#21641):
- Pre-fix GPTQ output is bit-exact RTN: 0 of 56.6M weight nibbles differ.
- Two disjoint calibration sets give byte-identical quantized weights.
- Pre-fix PPL (111.07) reproduces the number published in #21641 (111.11). The published GPTQ numbers are RTN numbers.

### AWQ quality
(quantization loss = ΔPPL vs each model's own fp32):

| Model | Activation-blind (before) | Calibrated (after) |
|---|---:|---:|
| Gemma-3 1B | +26.00% | **+8.67%** |
| Llama-3.2 1B | +16.80% | **+11.42%** |

### GPTQ quality
(Llama-3.2 1B, fp32 PPL 26.73)

| Configuration | PPL | Loss |
|---|---:|---:|
| RTN (= pre-fix GPTQ) | 32.62 | +22.1% |
| Calibrated, stale Hessians | 39.09 | +46.3% |
| + true-sequential (this PR) | 32.7–34.1 | +22.5–27.7% |
| **+ `activation_order=True`** | **29.37** | **+9.9%** |

With this PR plus `activation_order=True`, calibrated GPTQ beats RTN with less than half the loss.

## Tests

- Hook-firing regression tests through `model.quantize` (red on master, green here).
- Zero-point range tests for one-sided weight groups (2/4/8-bit).
- Scale-shape tests for group sizes {-1, 256, 128, 64}, plus end-to-end `group_size=-1`.
- Execution-stage grouping unit tests and an undersampling-warning test.

## Learnings

- A fallback that keeps outputs correct can hide a dead code path. Tests must assert on calibration side effects (hook counts, Hessian content), not on outputs alone.
- Quantization quality claims need an explicit RTN baseline. W4 g128 RTN is strong, so "close to fp" does not show that calibration works.
- Benchmarks must go through the public `model.quantize` path. Unit-level harnesses bypassed this bug for a year.
- Within-block sequencing matters on modern LLMs, and `activation_order` is critical for Llama-style down projections. Both only work when the Hessian is real.
- Calibration needs enough data. Below ~4 tokens per input feature, GPTQ corrections overfit a near-singular Hessian and lose to RTN.

## Evidence

- [Verification notebook](https://gist.github.com/JyotinderSingh/73c7c54678996ed61f3f7cbb2b56540a) — summary, minimal repro (CPU, ~30 s), all result tables
- [Benchmark harness](https://gist.github.com/JyotinderSingh/402982ac773d8518d194d32ec4acb548) — `bench.py` + pod drivers
- [A/B variant patches](https://gist.github.com/JyotinderSingh/3188c9c4d67eb53774634e83cd98cd3a) — pre-fix / hooks-fix / full-fix states
- [Investigation probes + raw results](https://gist.github.com/JyotinderSingh/8fb4696d31ec5f07b9cb61041af0afb8) — AutoGPTQ reference comparison (bit-exact), per-layer audit on real Llama Hessians, held-out-Hessian study, raw JSONL records

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
