### PR TITLE
Add `nonzero` op fallback implementation

### DIFF
--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -6587,7 +6587,7 @@ def ndim(x):
 
 class Nonzero(Operation):
     def call(self, x):
-        return backend.numpy.nonzero(x)
+        return _nonzero(x)
 
     def compute_output_spec(self, x):
         return tuple(
@@ -6607,7 +6607,27 @@ def nonzero(x):
     """
     if any_symbolic_tensors((x,)):
         return Nonzero().symbolic_call(x)
-    return backend.numpy.nonzero(x)
+    return _nonzero(x)
+
+
+def _nonzero(x):
+    if not config._use_backend_agnostic_ops() and hasattr(
+        backend.numpy, "nonzero"
+    ):
+        return backend.numpy.nonzero(x)
+
+    x = backend.convert_to_tensor(x)
+    flat_x = backend.numpy.reshape(x, (-1,))
+
+    if backend.standardize_dtype(flat_x.dtype) == "bool":
+        nonzero_mask = flat_x
+    else:
+        nonzero_mask = backend.numpy.not_equal(flat_x, 0)
+
+    flat_indices = backend.numpy.arange(backend.numpy.size(flat_x))
+    flat_nonzero_indices = flat_indices[nonzero_mask]
+
+    return backend.numpy.unravel_index(flat_nonzero_indices, x.shape)
 
 
 class NotEqual(Operation):

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -6624,8 +6624,13 @@ def _nonzero(x):
     else:
         nonzero_mask = backend.numpy.not_equal(flat_x, 0)
 
-    flat_indices = backend.numpy.arange(backend.numpy.size(flat_x))
-    flat_nonzero_indices = flat_indices[nonzero_mask]
+    where_res = backend.numpy.where(nonzero_mask)
+    if isinstance(where_res, (tuple, list)):
+        flat_nonzero_indices = where_res[0]
+    else:
+        flat_nonzero_indices = backend.numpy.squeeze(where_res, axis=0)
+
+    flat_nonzero_indices = backend.cast(flat_nonzero_indices, "int32")
 
     return backend.numpy.unravel_index(flat_nonzero_indices, x.shape)
 

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -6590,11 +6590,6 @@ class Nonzero(Operation):
         return _nonzero(x)
 
     def compute_output_spec(self, x):
-        if len(x.shape) == 0:
-            raise ValueError(
-                "`nonzero` requires an input tensor with at least 1 dimension. "
-                f"Received: input.shape={x.shape}"
-            )
         return tuple(
             [KerasTensor((None,), dtype="int32") for _ in range(len(x.shape))]
         )

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -6590,6 +6590,11 @@ class Nonzero(Operation):
         return _nonzero(x)
 
     def compute_output_spec(self, x):
+        if len(x.shape) == 0:
+            raise ValueError(
+                "`nonzero` requires an input tensor with at least 1 dimension. "
+                f"Received: input.shape={x.shape}"
+            )
         return tuple(
             [KerasTensor((None,), dtype="int32") for _ in range(len(x.shape))]
         )
@@ -6611,12 +6616,18 @@ def nonzero(x):
 
 
 def _nonzero(x):
+    x = backend.convert_to_tensor(x)
+    if len(x.shape) == 0:
+        raise ValueError(
+            "`nonzero` requires an input tensor with at least 1 dimension. "
+            f"Received: input.shape={x.shape}"
+        )
+
     if not config._use_backend_agnostic_ops() and hasattr(
         backend.numpy, "nonzero"
     ):
         return backend.numpy.nonzero(x)
 
-    x = backend.convert_to_tensor(x)
     flat_x = backend.numpy.reshape(x, (-1,))
 
     if backend.standardize_dtype(flat_x.dtype) == "bool":

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -11,6 +11,7 @@ import keras
 from keras.src import backend
 from keras.src import ops
 from keras.src import testing
+from keras.src.backend import config
 from keras.src.backend.common import dtypes
 from keras.src.backend.common import is_int_dtype
 from keras.src.backend.common import standardize_dtype
@@ -6586,6 +6587,29 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[0, 0, 3], [3, 0, 0]])
         self.assertAllClose(knp.nonzero(x), np.nonzero(x))
         self.assertAllClose(knp.Nonzero()(x), np.nonzero(x))
+
+    def test_nonzero_backend_agnostic_fallback(self):
+        try:
+            config._set_use_backend_agnostic_ops(True)
+            test_inputs = [
+                np.array([0, 1, 0, 2, 0, 3]),
+                np.array([[0, 0, 3], [3, 0, 0]]),
+                np.array([[[1, 0], [0, 2]], [[0, 0], [3, 4]]]),
+                np.zeros((2, 3, 4)),
+                np.ones((2, 3)),
+                np.array([True, False, True, False]),
+                np.array([-5, 0, 5, 0, -1]),
+                np.zeros((0, 5)),
+            ]
+            for x in test_inputs:
+                res = knp.nonzero(x)
+                ref = np.nonzero(x)
+                self.assertEqual(len(res), len(ref))
+                for res_idx, ref_idx in zip(res, ref):
+                    self.assertEqual(standardize_dtype(res_idx.dtype), "int32")
+                    self.assertAllClose(res_idx, ref_idx)
+        finally:
+            config._set_use_backend_agnostic_ops(False)
 
     def test_ones_like(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -6598,27 +6598,30 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         ):
             knp.nonzero(np.array(5))
 
-    def test_nonzero_backend_agnostic_fallback(self):
+    @parameterized.named_parameters(
+        ("1d", np.array([0, 1, 0, 2, 0, 3])),
+        ("2d", np.array([[0, 0, 3], [3, 0, 0]])),
+        ("3d", np.array([[[1, 0], [0, 2]], [[0, 0], [3, 4]]])),
+        ("all_zeros", np.zeros((2, 3, 4))),
+        ("all_ones", np.ones((2, 3))),
+        ("boolean", np.array([True, False, True, False])),
+        ("negative_and_positive", np.array([-5, 0, 5, 0, -1])),
+        ("empty_dimension", np.zeros((0, 5))),
+    )
+    def test_nonzero_backend_agnostic_fallback(self, x):
         try:
             config._set_use_backend_agnostic_ops(True)
-            test_inputs = [
-                np.array([0, 1, 0, 2, 0, 3]),
-                np.array([[0, 0, 3], [3, 0, 0]]),
-                np.array([[[1, 0], [0, 2]], [[0, 0], [3, 4]]]),
-                np.zeros((2, 3, 4)),
-                np.ones((2, 3)),
-                np.array([True, False, True, False]),
-                np.array([-5, 0, 5, 0, -1]),
-                np.zeros((0, 5)),
-            ]
-            for x in test_inputs:
-                res = knp.nonzero(x)
-                ref = np.nonzero(x)
-                self.assertEqual(len(res), len(ref))
-                for res_idx, ref_idx in zip(res, ref):
-                    self.assertEqual(standardize_dtype(res_idx.dtype), "int32")
-                    self.assertAllClose(res_idx, ref_idx)
+            result = knp.nonzero(x)
+            self.assertAllClose(result, np.nonzero(x))
+            self.assertAllClose(knp.Nonzero()(x), np.nonzero(x))
+            for res_idx in result:
+                self.assertEqual(standardize_dtype(res_idx.dtype), "int32")
+        finally:
+            config._set_use_backend_agnostic_ops(False)
 
+    def test_nonzero_backend_agnostic_fallback_0d_error(self):
+        try:
+            config._set_use_backend_agnostic_ops(True)
             with self.assertRaisesRegex(
                 ValueError, "requires an input tensor with at least 1 dimension"
             ):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -2277,6 +2277,11 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(result[1].shape, (None,))
         self.assertEqual(result[2].shape, (None,))
 
+        with self.assertRaisesRegex(
+            ValueError, "requires an input tensor with at least 1 dimension"
+        ):
+            knp.nonzero(KerasTensor(()))
+
     def test_ones_like(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.ones_like(x).shape, (None, 3))
@@ -6588,6 +6593,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.nonzero(x), np.nonzero(x))
         self.assertAllClose(knp.Nonzero()(x), np.nonzero(x))
 
+        with self.assertRaisesRegex(
+            ValueError, "requires an input tensor with at least 1 dimension"
+        ):
+            knp.nonzero(np.array(5))
+
     def test_nonzero_backend_agnostic_fallback(self):
         try:
             config._set_use_backend_agnostic_ops(True)
@@ -6608,6 +6618,11 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
                 for res_idx, ref_idx in zip(res, ref):
                     self.assertEqual(standardize_dtype(res_idx.dtype), "int32")
                     self.assertAllClose(res_idx, ref_idx)
+
+            with self.assertRaisesRegex(
+                ValueError, "requires an input tensor with at least 1 dimension"
+            ):
+                knp.nonzero(np.array(5))
         finally:
             config._set_use_backend_agnostic_ops(False)
 

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -2277,11 +2277,6 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
         self.assertEqual(result[1].shape, (None,))
         self.assertEqual(result[2].shape, (None,))
 
-        with self.assertRaisesRegex(
-            ValueError, "requires an input tensor with at least 1 dimension"
-        ):
-            knp.nonzero(KerasTensor(()))
-
     def test_ones_like(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.ones_like(x).shape, (None, 3))
@@ -6592,11 +6587,6 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[0, 0, 3], [3, 0, 0]])
         self.assertAllClose(knp.nonzero(x), np.nonzero(x))
         self.assertAllClose(knp.Nonzero()(x), np.nonzero(x))
-
-        with self.assertRaisesRegex(
-            ValueError, "requires an input tensor with at least 1 dimension"
-        ):
-            knp.nonzero(np.array(5))
 
     @parameterized.named_parameters(
         ("1d", np.array([0, 1, 0, 2, 0, 3])),


### PR DESCRIPTION
## Description
Add a backend-agnostic fallback implementation for the `nonzero` op.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ x] I am a human, and not a bot.
- [ x] I will be responsible for responding to review comments in a timely manner.
- [x ] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
