### PR TITLE
Fix calibration memory, AWQ staging, and sampling reproducibility

### DIFF
--- a/keras/src/quantizers/awq_core.py
+++ b/keras/src/quantizers/awq_core.py
@@ -14,6 +14,8 @@ from keras.src.dtype_policies.dtype_policy import AWQDTypePolicy
 from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
 from keras.src.quantizers.awq import AWQ
 from keras.src.quantizers.awq_config import AWQConfig
+from keras.src.quantizers.gptq_core import _execution_stages
+from keras.src.quantizers.gptq_core import calibration_no_grad_scope
 from keras.src.quantizers.gptq_core import find_layers_in_block
 from keras.src.quantizers.gptq_core import get_calibration_call_attribute
 from keras.src.quantizers.gptq_core import get_dataloader
@@ -21,7 +23,7 @@ from keras.src.quantizers.utils import should_quantize_layer
 
 
 @contextmanager
-def stream_activations(layers_map, awq_objects):
+def stream_activations(layers_map, awq_objects, execution_trace=None):
     """Context manager to capture activations for AWQ calibration.
 
     Temporarily patches each layer's dispatched forward method
@@ -32,15 +34,29 @@ def stream_activations(layers_map, awq_objects):
     Args:
         layers_map: Dict[str, Layer]. Mapping from layer names to layers.
         awq_objects: Dict[str, AWQ]. Mapping from names to AWQ instances.
+        execution_trace: Optional dict. When provided, each layer's FIRST
+            hook invocation records `{name: (call_index, input_tensor)}`
+            into it - the block-level execution order and the identity of
+            the input each layer consumes. Used to derive within-block
+            quantization stages (see `apply_awq_layerwise`). The recorded
+            tensors are only kept alive for identity comparison; callers
+            should drop the trace after use.
 
     Yields:
         None: The patched state is active only within the `with` block.
     """
     original_calls = {}
+    call_counter = [0]
 
     def create_hook(name, original_call_func):
         def hook(*args, **kwargs):
             inp = args[0] if args else kwargs["inputs"]
+            if execution_trace is not None and name not in execution_trace:
+                # Record block-level execution order and the input tensor's
+                # identity on the first call (a live reference is kept so
+                # the id cannot be recycled while tracing).
+                execution_trace[name] = (call_counter[0], inp)
+                call_counter[0] += 1
             num_features = awq_objects[name].rows
             input_2d = ops.reshape(inp, (-1, num_features))
             awq_objects[name].update_activation_magnitudes(input_2d)
@@ -122,19 +138,46 @@ def apply_awq_layerwise(dataloader, config, structure, filters=None):
                 for name, layer in sub_layers_map.items()
             }
 
-            # Capture activation statistics
-            with stream_activations(sub_layers_map, awq_objects):
-                for sample_idx in range(num_samples):
-                    current_input = inputs[sample_idx]
-                    if len(current_input.shape) == 2:
-                        current_input = ops.expand_dims(current_input, axis=0)
-                    _ = block(current_input)
+            def run_calibration_sweep(layers, objects, trace=None):
+                with stream_activations(layers, objects, execution_trace=trace):
+                    for sample_idx in range(num_samples):
+                        current_input = inputs[sample_idx]
+                        if len(current_input.shape) == 2:
+                            current_input = ops.expand_dims(
+                                current_input, axis=0
+                            )
+                        _ = block(current_input)
 
-            # Quantize each layer
-            for name, awq_object in awq_objects.items():
-                logging.info(f"Quantizing {name}...")
-                awq_object.quantize_layer()
-                awq_object.free()
+            # Capture activation statistics
+            execution_trace = {}
+            run_calibration_sweep(
+                sub_layers_map, awq_objects, trace=execution_trace
+            )
+
+            # Quantize the block's layers in execution-order stages ("true
+            # sequential", matching the GPTQ path): after each stage is
+            # quantized, downstream stages' activation statistics are
+            # re-estimated so their scale searches see the quantized
+            # upstream activations they will actually get at inference.
+            stages = _execution_stages(sub_layers_map, execution_trace)
+            del execution_trace
+
+            for stage_idx, stage_names in enumerate(stages):
+                if stage_idx > 0:
+                    stage_map = {
+                        name: sub_layers_map[name] for name in stage_names
+                    }
+                    stage_objects = {}
+                    for name in stage_names:
+                        awq_objects[name].free()
+                        awq_objects[name] = AWQ(sub_layers_map[name], config)
+                        stage_objects[name] = awq_objects[name]
+                    run_calibration_sweep(stage_map, stage_objects)
+
+                for name in stage_names:
+                    logging.info(f"Quantizing {name}...")
+                    awq_objects[name].quantize_layer()
+                    awq_objects[name].free()
 
             del awq_objects
 
@@ -186,12 +229,13 @@ def awq_quantize(config, quantization_layer_structure, filters=None):
         num_samples=config.num_samples,
     )
 
-    apply_awq_layerwise(
-        dataloader[: config.num_samples],
-        config,
-        quantization_layer_structure,
-        filters=filters,
-    )
+    with calibration_no_grad_scope():
+        apply_awq_layerwise(
+            dataloader[: config.num_samples],
+            config,
+            quantization_layer_structure,
+            filters=filters,
+        )
 
 
 def get_group_size_for_layer(layer, config):

--- a/keras/src/quantizers/awq_core.py
+++ b/keras/src/quantizers/awq_core.py
@@ -142,7 +142,7 @@ def apply_awq_layerwise(dataloader, config, structure, filters=None):
                 with stream_activations(layers, objects, execution_trace=trace):
                     for sample_idx in range(num_samples):
                         current_input = inputs[sample_idx]
-                        if len(current_input.shape) == 2:
+                        if ops.ndim(current_input) == 2:
                             current_input = ops.expand_dims(
                                 current_input, axis=0
                             )

--- a/keras/src/quantizers/awq_test.py
+++ b/keras/src/quantizers/awq_test.py
@@ -7,6 +7,7 @@ import pytest
 from absl.testing import parameterized
 
 import keras
+from keras.src import backend
 from keras.src import layers
 from keras.src import models
 from keras.src import ops
@@ -1029,3 +1030,95 @@ class AWQAccuracyTest(testing.TestCase):
         # All-zero magnitudes would be replaced with ones, making the
         # scale search activation-blind.
         self.assertGreater(max_magnitude[0], 0.0)
+
+    def _tiny_awq_model_and_config(self, num_samples=4):
+        """Embedding -> [Dense(16, relu), Dense(8)] block, tiny AWQ config."""
+        keras.utils.set_random_seed(123)
+        seq_len, vocab, embed_dim = 16, 48, 8
+
+        block = models.Sequential(
+            [
+                layers.Dense(16, activation="relu"),
+                layers.Dense(embed_dim),
+            ]
+        )
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab, embed_dim)
+        x = embedding(inputs)
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        model = models.Model(inputs, layers.Dense(4)(x))
+
+        rng = np.random.default_rng(seed=7)
+        dataset = [
+            rng.integers(0, vocab, size=(1, seq_len), dtype=np.int32)
+            for _ in range(num_samples)
+        ]
+        config = AWQConfig(
+            dataset=dataset,
+            tokenizer=_char_tokenizer(vocab_size=vocab, seq_len=seq_len),
+            group_size=8,
+            num_samples=num_samples,
+            sequence_length=seq_len,
+            num_grid_points=5,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+        return model, config
+
+    def test_awq_recalibrates_downstream_stages(self):
+        """AWQ must re-capture downstream statistics between stages.
+
+        The two chained Dense layers form two execution stages. The first
+        sweep captures both layers (2 hook calls per sample); after the
+        first Dense is quantized, the second Dense's statistics must be
+        re-captured against the quantized upstream activations (1 more
+        call per sample). A single-sweep implementation records only
+        2 * num_samples calls.
+        """
+        num_samples = 4
+        model, config = self._tiny_awq_model_and_config(num_samples)
+
+        hook_calls = [0]
+        original_update = AWQ.update_activation_magnitudes
+
+        def spy_update(awq_self, inp):
+            hook_calls[0] += 1
+            return original_update(awq_self, inp)
+
+        AWQ.update_activation_magnitudes = spy_update
+        try:
+            model.quantize("awq", config=config)
+        finally:
+            AWQ.update_activation_magnitudes = original_update
+
+        self.assertEqual(hook_calls[0], 3 * num_samples)
+
+    def test_awq_calibration_runs_without_grad_tracking(self):
+        """Calibration forwards must not build autograd graphs on torch.
+
+        The per-sample activations are retained across the whole
+        calibration loop, so retained graphs previously accumulated every
+        intermediate activation and exhausted GPU memory.
+        """
+        if backend.backend() != "torch":
+            self.skipTest("gradient tracking is specific to torch")
+        model, config = self._tiny_awq_model_and_config()
+
+        graph_free = [True]
+        original_update = AWQ.update_activation_magnitudes
+
+        def spy_update(awq_self, inp):
+            if getattr(inp, "grad_fn", None) is not None:
+                graph_free[0] = False
+            return original_update(awq_self, inp)
+
+        AWQ.update_activation_magnitudes = spy_update
+        try:
+            model.quantize("awq", config=config)
+        finally:
+            AWQ.update_activation_magnitudes = original_update
+
+        self.assertTrue(graph_free[0])

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -232,9 +232,13 @@ def get_dataloader(
         # stride chosen to cover the space roughly uniformly
         if stride is None:
             stride = max(1, (max_start + 1) // num_samples)
-        # offset derived deterministically from seed
+        # Offset derived deterministically from the seed. Python's
+        # built-in `hash()` must not be used here: string/tuple hashes are
+        # randomized per process (PYTHONHASHSEED), which silently made
+        # calibration windows - and therefore every quantization result -
+        # unreproducible across runs despite the fixed seed.
         offset = (
-            (abs(hash(("gptq-calib", seed))) % (max_start + 1))
+            int(np.random.default_rng(seed).integers(0, max_start + 1))
             if max_start > 0
             else 0
         )

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -1,10 +1,12 @@
 import math
 import warnings
 from contextlib import contextmanager
+from contextlib import nullcontext
 
 import numpy as np
 from absl import logging
 
+from keras.src import backend
 from keras.src import ops
 from keras.src import utils as keras_utils
 from keras.src.dtype_policies.dtype_policy import GPTQDTypePolicy
@@ -34,6 +36,26 @@ def get_calibration_call_attribute(layer):
     if getattr(layer, "quantization_mode", None) is not None:
         return "quantized_call"
     return "call"
+
+
+def calibration_no_grad_scope():
+    """Returns a context manager that disables gradient tracking.
+
+    Calibration is inference-only: it runs forward passes to accumulate
+    statistics and then assigns quantized values to variables. On the torch
+    backend those forwards would otherwise build autograd graphs, and
+    because per-sample activations are retained across the whole
+    calibration loop (and AWQ stashes activation samples for its clipping
+    search), the graphs and every intermediate activation stay alive until
+    the block completes - enough to exhaust GPU memory on models that fit
+    comfortably otherwise. JAX and TensorFlow build no such graphs in eager
+    mode, so this is a no-op there.
+    """
+    if backend.backend() == "torch":
+        import torch
+
+        return torch.no_grad()
+    return nullcontext()
 
 
 @contextmanager
@@ -540,12 +562,13 @@ def gptq_quantize(config, quantization_layer_structure, filters=None):
     # is now a NumPy array, which can be sliced and reused.
     calibration_dataloader = dataloader[: config.num_samples]
 
-    apply_gptq_layerwise(
-        calibration_dataloader,
-        config,
-        quantization_layer_structure,
-        filters=filters,
-    )
+    with calibration_no_grad_scope():
+        apply_gptq_layerwise(
+            calibration_dataloader,
+            config,
+            quantization_layer_structure,
+            filters=filters,
+        )
 
 
 def get_group_size_for_layer(layer, config):

--- a/keras/src/quantizers/gptq_core_test.py
+++ b/keras/src/quantizers/gptq_core_test.py
@@ -414,3 +414,31 @@ class TestExecutionStages(testing.TestCase):
 
         stages = _execution_stages(["a", "b"], {})
         self.assertEqual(stages, [["a", "b"]])
+
+
+class TestDataloaderReproducibility(testing.TestCase):
+    def test_strided_offset_is_process_stable(self):
+        """The strided sampling offset must not depend on PYTHONHASHSEED.
+
+        The offset was previously derived via `hash(("gptq-calib", seed))`;
+        Python randomizes string hashing per process, so calibration
+        windows - and therefore every quantization result - silently
+        differed between runs despite the fixed seed. These golden values
+        pin the numpy-based derivation (seed=42, 1000 tokens, seq len 8,
+        4 samples); the old hash-based offset only reproduces them under
+        one specific PYTHONHASHSEED by coincidence.
+        """
+
+        class PassthroughTokenizer:
+            def tokenize(self, x):
+                return np.asarray(x, dtype=np.int32)
+
+        out = get_dataloader(
+            PassthroughTokenizer(),
+            8,
+            [np.arange(1000, dtype=np.int32)],
+            num_samples=4,
+        )
+        self.assertEqual(out.shape, (4, 1, 8))
+        self.assertAllClose(out[:, 0, 0], np.array([88, 336, 584, 832]))
+        self.assertAllClose(out[0, 0], np.arange(88, 96))

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -581,6 +581,61 @@ class GPTQTest(testing.TestCase):
         # (dead-feature path), silently disabling error correction.
         self.assertGreater(max_off_diagonal[0], 0.0)
 
+    def test_gptq_calibration_runs_without_grad_tracking(self):
+        """Calibration forwards must not build autograd graphs on torch.
+
+        Per-sample activations are retained across the whole calibration
+        loop, so retained graphs previously accumulated every intermediate
+        activation of every forward pass and exhausted GPU memory on
+        models that fit comfortably otherwise.
+        """
+        if backend.backend() != "torch":
+            self.skipTest("gradient tracking is specific to torch")
+        keras.utils.set_random_seed(123)
+        vocab_size, seq_len, embed_dim = 64, 8, 8
+
+        inputs = layers.Input(shape=(seq_len,), dtype="int32")
+        embedding = layers.Embedding(vocab_size, embed_dim)
+        x = embedding(inputs)
+        block = models.Sequential([layers.Dense(embed_dim)])
+        x = block(x)
+        x = layers.GlobalAveragePooling1D()(x)
+        model = models.Model(inputs, layers.Dense(2)(x))
+
+        rng = np.random.default_rng(seed=5)
+        dataset = [
+            rng.integers(0, vocab_size, size=(1, seq_len)).astype("int32")
+            for _ in range(2)
+        ]
+        config = GPTQConfig(
+            dataset=dataset,
+            tokenizer=lambda text: text,
+            weight_bits=4,
+            num_samples=2,
+            sequence_length=seq_len,
+            group_size=8,
+            quantization_layer_structure={
+                "pre_block_layers": [embedding],
+                "sequential_blocks": [block],
+            },
+        )
+
+        graph_free = [True]
+        original_update = GPTQ.update_hessian_with_batch
+
+        def spy_update(gptq_self, inp):
+            if getattr(inp, "grad_fn", None) is not None:
+                graph_free[0] = False
+            return original_update(gptq_self, inp)
+
+        GPTQ.update_hessian_with_batch = spy_update
+        try:
+            model.quantize("gptq", config=config)
+        finally:
+            GPTQ.update_hessian_with_batch = original_update
+
+        self.assertTrue(graph_free[0])
+
     @parameterized.named_parameters(
         ("per_channel", -1, 1),
         ("group_gt_blocksize", 256, 2),


### PR DESCRIPTION
## Description

Three follow-ups to #23512.

### 1. Calibration used too much memory on torch

Calibration only does forward passes. But on the torch backend, these forward passes made autograd graphs. The calibration loop keeps the activations of all samples. Thus the graphs stayed in memory until the block was complete. The GPTQ solve also recorded thousands of operations for each layer.

The result: on master, `model.quantize("gptq")` and `model.quantize("awq")` cannot quantize a 1B-parameter model on a 32 GB GPU. The failure occurs with any number of calibration samples.

`calibration_no_grad_scope()` now stops gradient tracking during calibration. On torch, it applies `torch.no_grad()`. On JAX and TensorFlow, no graphs occur, thus it does nothing.

### 2. AWQ did not recalibrate downstream layers

#23512 gave GPTQ staged calibration, but AWQ kept one sweep. AWQ recorded the statistics of all layers in a block while all layers were still full precision. The statistics of the MLP layers thus did not agree with the activations that these layers get after quantization of the attention layers.

AWQ now uses the same stages as GPTQ. `stream_activations` records the execution order. The shared `_execution_stages` helper divides the block into stages. After each stage, AWQ records the statistics of the downstream layers again.

### 3. Calibration sampling was not reproducible

`get_dataloader` calculated its sampling offset with `hash(("gptq-calib", seed))`. Python makes string hashes different in each process. The calibration windows thus changed in each run, although the seed stayed the same.

The offset now comes from `np.random.default_rng(seed)`, which is stable.

### Measurements

* GPU: RTX PRO 4500 (32 GB). Model: Llama-3.2 1B. Data: wikitext-2.
* Configuration: W4 g128, 128 samples of 128 tokens. The float32 baseline is 26.726 PPL.

| Test | Master | This branch |
|---|---|---|
| `model.quantize("gptq")` | out of memory, more than 31.3 GB | 6.8 GB peak |
| `model.quantize("awq")` | out of memory, more than 31.3 GB | 5.9 GB peak |
| Two equal GPTQ runs | 35.02 and 39.70 PPL | equal bytes |
| Two equal AWQ runs | not applicable (out of memory) | equal bytes |
| AWQ perplexity | 29.67 (one sweep) | 29.50 to 29.78 (staged) |

The AWQ stages do not change the quality on this model. The per-channel statistics of AWQ are less sensitive to the stale data than the error corrections of GPTQ. The stages make the two algorithms agree and remove an incorrect measurement. The calibration time increases by 18%. The memory fix does not change the numbers. On CPU with the same calibration data, master and this branch write the same bytes to all quantized variables. This is true with gradients on and off.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
