### PR TITLE
Use shared workflow for PR contributor terms check

### DIFF
--- a/.github/workflows/pr-contributor-terms.yml
+++ b/.github/workflows/pr-contributor-terms.yml
@@ -15,42 +15,4 @@ permissions:
 jobs:
   verify:
     if: github.repository == 'keras-team/keras'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Verify contributor agreement'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-          script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            const body = pr.body || '';
-
-            const requiredTerms = [
-              'I am a human, and not a bot.',
-              'I will be responsible for responding to review comments in a timely manner.',
-              'I will work with the maintainers to push this PR forward until submission.'
-            ];
-
-            const unchecked = [];
-            for (const term of requiredTerms) {
-              // Check that the checkbox is checked: [x] or [X]
-              const checkedPattern = new RegExp(`-\\s*\\[\\s*[xX]\\s*\\]\\s*${term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
-              if (!checkedPattern.test(body)) {
-                unchecked.push(term);
-              }
-            }
-
-            if (unchecked.length > 0) {
-              core.setFailed(
-                `The following contributor agreement terms have not been accepted:\n` +
-                unchecked.map(t => `  - ${t}`).join('\n') +
-                `\n\nPlease check all boxes in the Contributor Agreement section of the PR description.`
-              );
-            } else {
-              core.info('All contributor agreement terms accepted.');
-            }
+    uses: keras-team/shared-workflows/.github/workflows/pr-contributor-terms.yml@1ff60fd615b03a85abdffac6d7cbe390988bb305 # v1


### PR DESCRIPTION
## Description
Replaces the inline PR contributor agreement check workflow with the reusable workflow from `keras-team/shared-workflows` (added in https://github.com/keras-team/shared-workflows/pull/1).

This reusable workflow:
- Exempts maintainers, organization members, and collaborators (`OWNER`, `MEMBER`, `COLLABORATOR`) from needing contributor agreement checkboxes checked.
- Automatically exempts bot accounts.
- Centralizes contributor terms verification across Keras repositories.

### Verified Behavior
- Workflow run (exempt team member with unchecked boxes passes): https://github.com/keras-team/keras/actions/runs/33012207081
  - `PR author association 'MEMBER' is exempt from contributor terms check.`

-----

(Leaving the checkboxes below unchecked to validate)

## Contributor Agreement
- [ ] I am a human, and not a bot.
- [ ] I will be responsible for responding to review comments in a timely manner.
- [ ] I will work with the maintainers to push this PR forward until submission.