### PR TITLE
Add CODEOWNERS for .github directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Reviewers for GitHub Actions workflows and repository configuration.
+/.github/ @jeffcarp @divyashreepathihalli


### PR DESCRIPTION
## Description
Adds `.github/CODEOWNERS` to automatically request reviews from @jeffcarp and @divyashreepathihalli for any pull requests modifying files in the `/.github/` directory (workflows, configurations, and templates).

## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.