### PR TITLE
fix(preprocessing): apply correct h/w offsets to bounding boxes in RandomCrop

### DIFF
--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -234,20 +234,20 @@ class RandomCrop(BaseImagePreprocessingLayer):
             if len(self.backend.shape(boxes)) == 3:
                 boxes = self.backend.numpy.stack(
                     [
-                        self.backend.numpy.maximum(boxes[:, :, 0] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 1] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 2] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 3] - w_start, 0),
+                        self.backend.numpy.maximum(boxes[:, :, 0] - w_start, 0),
+                        self.backend.numpy.maximum(boxes[:, :, 1] - h_start, 0),
+                        self.backend.numpy.maximum(boxes[:, :, 2] - w_start, 0),
+                        self.backend.numpy.maximum(boxes[:, :, 3] - h_start, 0),
                     ],
                     axis=-1,
                 )
             else:
                 boxes = self.backend.numpy.stack(
                     [
-                        self.backend.numpy.maximum(boxes[:, 0] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 1] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 2] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 3] - w_start, 0),
+                        self.backend.numpy.maximum(boxes[:, 0] - w_start, 0),
+                        self.backend.numpy.maximum(boxes[:, 1] - h_start, 0),
+                        self.backend.numpy.maximum(boxes[:, 2] - w_start, 0),
+                        self.backend.numpy.maximum(boxes[:, 3] - h_start, 0),
                     ],
                     axis=-1,
                 )

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -234,15 +234,11 @@ class RandomCrop(BaseImagePreprocessingLayer):
             # Shift by the crop offsets and clip to the crop size so boxes
             # stay within the cropped image. `boxes[..., i]` handles both
             # batched (B, N, 4) and unbatched (N, 4) boxes.
-            x1 = self.backend.numpy.clip(
-                boxes[..., 0] - w_start, 0, self.width
-            )
+            x1 = self.backend.numpy.clip(boxes[..., 0] - w_start, 0, self.width)
             y1 = self.backend.numpy.clip(
                 boxes[..., 1] - h_start, 0, self.height
             )
-            x2 = self.backend.numpy.clip(
-                boxes[..., 2] - w_start, 0, self.width
-            )
+            x2 = self.backend.numpy.clip(boxes[..., 2] - w_start, 0, self.width)
             y2 = self.backend.numpy.clip(
                 boxes[..., 3] - h_start, 0, self.height
             )

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop.py
@@ -231,26 +231,22 @@ class RandomCrop(BaseImagePreprocessingLayer):
             )
             h_start = self.backend.cast(h_start, boxes.dtype)
             w_start = self.backend.cast(w_start, boxes.dtype)
-            if len(self.backend.shape(boxes)) == 3:
-                boxes = self.backend.numpy.stack(
-                    [
-                        self.backend.numpy.maximum(boxes[:, :, 0] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 1] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 2] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, :, 3] - h_start, 0),
-                    ],
-                    axis=-1,
-                )
-            else:
-                boxes = self.backend.numpy.stack(
-                    [
-                        self.backend.numpy.maximum(boxes[:, 0] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 1] - h_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 2] - w_start, 0),
-                        self.backend.numpy.maximum(boxes[:, 3] - h_start, 0),
-                    ],
-                    axis=-1,
-                )
+            # Shift by the crop offsets and clip to the crop size so boxes
+            # stay within the cropped image. `boxes[..., i]` handles both
+            # batched (B, N, 4) and unbatched (N, 4) boxes.
+            x1 = self.backend.numpy.clip(
+                boxes[..., 0] - w_start, 0, self.width
+            )
+            y1 = self.backend.numpy.clip(
+                boxes[..., 1] - h_start, 0, self.height
+            )
+            x2 = self.backend.numpy.clip(
+                boxes[..., 2] - w_start, 0, self.width
+            )
+            y2 = self.backend.numpy.clip(
+                boxes[..., 3] - h_start, 0, self.height
+            )
+            boxes = self.backend.numpy.stack([x1, y1, x2, y2], axis=-1)
 
             # Convert to user defined bounding box format
             boxes = convert_format(

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
@@ -195,6 +195,37 @@ class RandomCropTest(testing.TestCase):
         self.assertAllClose(output["boxes"], expected_boxes)
         self.assertAllClose(output["labels"], np.array([[0]]))
 
+    def test_bounding_boxes_clipped_to_crop_size(self):
+        layer = layers.RandomCrop(
+            2, 4, data_format="channels_last", bounding_box_format="xyxy"
+        )
+
+        # Unbatched boxes: shape (num_boxes, 4)
+        bounding_boxes = {
+            "boxes": np.array([[0.0, 0.0, 8.0, 8.0]]),
+            "labels": np.array([0]),
+        }
+        output = layer.transform_bounding_boxes(
+            bounding_boxes, (3, 1), training=True
+        )
+        # Box extends beyond the crop: it must be clipped to its size.
+        # x2 = clip(8 - w_start, 0, 4) = 4 ; y2 = clip(8 - h_start, 0, 2) = 2
+        expected_boxes = np.array([[0.0, 0.0, 4.0, 2.0]])
+        self.assertAllClose(output["boxes"], expected_boxes)
+        self.assertAllClose(output["labels"], np.array([0]))
+
+        # Batched boxes: shape (batch, num_boxes, 4)
+        bounding_boxes = {
+            "boxes": np.array([[[0.0, 0.0, 8.0, 8.0]]]),
+            "labels": np.array([[0]]),
+        }
+        output = layer.transform_bounding_boxes(
+            bounding_boxes, (3, 1), training=True
+        )
+        expected_boxes = np.array([[[0.0, 0.0, 4.0, 2.0]]])
+        self.assertAllClose(output["boxes"], expected_boxes)
+        self.assertAllClose(output["labels"], np.array([[0]]))
+
     def test_segmentation_mask_preserves_dtype_and_classes(self):
         # Masks hold discrete class indices; the resize fallback must use
         # nearest-neighbor interpolation so no new classes appear, and the

--- a/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
+++ b/keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py
@@ -164,6 +164,37 @@ class RandomCropTest(testing.TestCase):
             transformed_data["bounding_boxes"]["labels"],
         )
 
+    def test_bounding_boxes_offsets_applied_to_correct_axes(self):
+        layer = layers.RandomCrop(
+            2, 4, data_format="channels_last", bounding_box_format="xyxy"
+        )
+
+        # Unbatched boxes: shape (num_boxes, 4)
+        bounding_boxes = {
+            "boxes": np.array([[3.0, 4.0, 5.0, 5.0]]),
+            "labels": np.array([0]),
+        }
+        output = layer.transform_bounding_boxes(
+            bounding_boxes, (3, 1), training=True
+        )
+        # Crop starts at row 3 (h_start), column 1 (w_start).
+        # x coordinates must shift by w_start, y coordinates by h_start.
+        expected_boxes = np.array([[2.0, 1.0, 4.0, 2.0]])
+        self.assertAllClose(output["boxes"], expected_boxes)
+        self.assertAllClose(output["labels"], np.array([0]))
+
+        # Batched boxes: shape (batch, num_boxes, 4)
+        bounding_boxes = {
+            "boxes": np.array([[[3.0, 4.0, 5.0, 5.0]]]),
+            "labels": np.array([[0]]),
+        }
+        output = layer.transform_bounding_boxes(
+            bounding_boxes, (3, 1), training=True
+        )
+        expected_boxes = np.array([[[2.0, 1.0, 4.0, 2.0]]])
+        self.assertAllClose(output["boxes"], expected_boxes)
+        self.assertAllClose(output["labels"], np.array([[0]]))
+
     def test_segmentation_mask_preserves_dtype_and_classes(self):
         # Masks hold discrete class indices; the resize fallback must use
         # nearest-neighbor interpolation so no new classes appear, and the


### PR DESCRIPTION
## Description

Fixes #23518

`RandomCrop.transform_bounding_boxes` subtracts the vertical crop offset
(`h_start`) from the x coordinates and the horizontal offset (`w_start`) from
the y coordinates. In `xyxy` format x coordinates must be shifted by `w_start`
and y coordinates by `h_start` — the offsets were applied to the wrong axes,
silently corrupting detection labels whenever `h_start != w_start` (i.e.
virtually every training step, since both offsets are drawn independently at
random).

`CenterCrop` performs the equivalent shift correctly (x↔w, y↔h).

## Changes

- `random_crop.py`: shift bounding boxes by the correct offsets and clip them
  to the crop size (`self.width` / `self.height`) so they stay within the
  cropped image, matching `CenterCrop` / `RandomZoom` behavior. Batched
  (rank-3) and unbatched (rank-2) boxes share a single code path via
  `boxes[..., i]` indexing.
- `random_crop_test.py`: add `test_bounding_boxes_offsets_applied_to_correct_axes`
  and `test_bounding_boxes_clipped_to_crop_size`, with explicit expected values
  for both branches. The existing bounding-box test only asserted shapes, which
  is why this shipped unnoticed.

## Before / after

Box `[3, 4, 5, 5]` (xyxy), crop offset `(h_start=3, w_start=1)`:

- Before this PR: `[0, 3, 2, 4]` (swapped axes)
- After this PR: `[2, 1, 4, 2]`

Box `[0, 0, 8, 8]` (xyxy), same crop offset:

- Before this PR: `[0, 0, 5, 7]` (swapped axes, extends beyond the 4x2 crop)
- After this PR: `[0, 0, 4, 2]` (correct axes, clipped to the crop size)

## Out of scope (follow-up)

- With relative formats (`rel_xyxy`, ...), the initial conversion to `xyxy`
  uses the crop dimensions instead of the input image dimensions.

## Tests

`keras/src/layers/preprocessing/image_preprocessing/random_crop_test.py`
passes with the tensorflow backend (Google Colab, CPU): 10 passed, including
the two new tests.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.