### PR TITLE
Adds quantization mode registry

### DIFF
--- a/keras/api/_tf_keras/keras/dtype_policies/__init__.py
+++ b/keras/api/_tf_keras/keras/dtype_policies/__init__.py
@@ -26,9 +26,6 @@ from keras.src.dtype_policies.dtype_policy import (
 from keras.src.dtype_policies.dtype_policy import (
     QuantizedFloat8DTypePolicy as QuantizedFloat8DTypePolicy,
 )
-from keras.src.dtype_policies.dtype_policy import (
-    TernaryDTypePolicy as TernaryDTypePolicy,
-)
 from keras.src.dtype_policies.dtype_policy_map import (
     DTypePolicyMap as DTypePolicyMap,
 )

--- a/keras/api/dtype_policies/__init__.py
+++ b/keras/api/dtype_policies/__init__.py
@@ -26,9 +26,6 @@ from keras.src.dtype_policies.dtype_policy import (
 from keras.src.dtype_policies.dtype_policy import (
     QuantizedFloat8DTypePolicy as QuantizedFloat8DTypePolicy,
 )
-from keras.src.dtype_policies.dtype_policy import (
-    TernaryDTypePolicy as TernaryDTypePolicy,
-)
 from keras.src.dtype_policies.dtype_policy_map import (
     DTypePolicyMap as DTypePolicyMap,
 )

--- a/keras/src/dtype_policies/__init__.py
+++ b/keras/src/dtype_policies/__init__.py
@@ -9,7 +9,10 @@ from keras.src.dtype_policies.dtype_policy import GPTQDTypePolicy
 from keras.src.dtype_policies.dtype_policy import Int4DTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedFloat8DTypePolicy
-from keras.src.dtype_policies.dtype_policy import TernaryDTypePolicy
+from keras.src.dtype_policies.dtype_policy import (
+    _get_quantized_dtype_policy_by_str,
+)
+from keras.src.dtype_policies.dtype_policy import _is_quantized_policy_string
 from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
 
 ALL_OBJECTS = {
@@ -21,7 +24,6 @@ ALL_OBJECTS = {
     DTypePolicyMap,
     GPTQDTypePolicy,
     Int4DTypePolicy,
-    TernaryDTypePolicy,
 }
 ALL_OBJECTS_DICT = {cls.__name__: cls for cls in ALL_OBJECTS}
 
@@ -91,10 +93,6 @@ def get(identifier):
     Returns:
         A Keras `DTypePolicy` instance.
     """
-    from keras.src.dtype_policies.dtype_policy import (
-        _get_quantized_dtype_policy_by_str,
-    )
-
     if identifier is None:
         return dtype_policy.dtype_policy()
     if isinstance(identifier, DTypePolicy):
@@ -102,7 +100,7 @@ def get(identifier):
     if isinstance(identifier, dict):
         return deserialize(identifier)
     if isinstance(identifier, str):
-        if identifier.startswith(QUANTIZATION_MODES):
+        if _is_quantized_policy_string(identifier):
             return _get_quantized_dtype_policy_by_str(identifier)
         else:
             return DTypePolicy(identifier)

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -6,6 +6,133 @@ from keras.src.backend.common import global_state
 QUANTIZATION_MODES = ("int8", "float8", "int4", "ternary", "gptq", "awq")
 
 
+def _mode_registry():
+    """Returns the quantization mode registry, imported on first use.
+
+    The import must be deferred: `keras.src.quantizers` registers the
+    built-in modes on import, and those mode modules import the policy
+    classes defined below, so a module-level import here would be a cycle.
+    """
+    from keras.src.quantizers import mode_registry
+
+    return mode_registry
+
+
+def _parse_int4_mode(mode_str):
+    """Parses the `"int4/<block_size>"` grammar into policy parameters."""
+    parts = mode_str.split("/")
+    expected_format = "'int4/<block_size>'"
+
+    # Validate format
+    if len(parts) != 2 or parts[0] != "int4":
+        raise ValueError(
+            "Invalid mode for Int4DTypePolicy. Expected format "
+            f"{expected_format}, but got '{mode_str}'."
+        )
+
+    # Validate and cast block_size. Older checkpoints encoded per-channel
+    # int4 as the literal "None" in the policy string (e.g.
+    # "int4/None_from_float32"); normalize it to -1 so those checkpoints
+    # still deserialize. Both "None" and -1 mean per-channel quantization.
+    if parts[1] == "None":
+        block_size = -1
+    else:
+        try:
+            block_size = int(parts[1])
+        except ValueError:
+            raise ValueError(
+                "Invalid mode for Int4DTypePolicy. <block_size> must be "
+                "an integer. Expected format "
+                f"{expected_format}, but got '{mode_str}'."
+            )
+
+    # Validate supported values
+    if block_size < -1 or block_size == 0:
+        raise ValueError(
+            "Invalid block_size in mode. Supported values are "
+            "-1 (per-channel) or a positive integer (sub-channel), "
+            f"but got {block_size} from '{mode_str}'."
+        )
+    return {"block_size": block_size}
+
+
+def _parse_bits_and_group_mode(
+    mode_str, name, policy_name, validate_weight_bits, group_size_semantics
+):
+    """Parses the `"<name>/<weight_bits>/<group_size>"` grammar.
+
+    Shared by the two calibration policies, which differ only in the
+    bit-widths they accept and in how `group_size=-1` reads.
+    """
+    parts = mode_str.split("/")
+    expected_format = f"'{name}/<weight_bits>/<group_size>'"
+
+    # Validate format
+    if len(parts) != 3 or parts[0] != name:
+        raise ValueError(
+            f"Invalid mode for {policy_name}. Expected format "
+            f"{expected_format}, but got '{mode_str}'."
+        )
+
+    # Validate and cast weight_bits and group_size
+    try:
+        weight_bits = int(parts[1])
+        group_size = int(parts[2])
+    except ValueError:
+        raise ValueError(
+            f"Invalid mode for {policy_name}. <weight_bits> and "
+            "<group_size> must be integers. Expected format "
+            f"{expected_format}, but got '{mode_str}'."
+        )
+
+    validate_weight_bits(weight_bits, mode_str)
+
+    if group_size < -1 or group_size == 0:
+        raise ValueError(
+            "Invalid group_size in mode. Supported values are "
+            f"-1 ({group_size_semantics}) or a positive integer, "
+            f"but got {group_size} from '{mode_str}'."
+        )
+    return {"weight_bits": weight_bits, "group_size": group_size}
+
+
+def _validate_gptq_weight_bits(weight_bits, mode_str):
+    if weight_bits not in [2, 3, 4, 8]:
+        raise ValueError(
+            "Invalid weight_bits in mode. Supported values are "
+            f"2, 3, 4, and 8, but got {weight_bits} from '{mode_str}'."
+        )
+
+
+def _validate_awq_weight_bits(weight_bits, mode_str):
+    # AWQ presently only supports 4-bit quantization.
+    if weight_bits != 4:
+        raise ValueError(
+            "Invalid weight_bits in mode. AWQ only supports 4-bit "
+            f"quantization, but got {weight_bits} from '{mode_str}'."
+        )
+
+
+def _parse_gptq_mode(mode_str):
+    return _parse_bits_and_group_mode(
+        mode_str,
+        "gptq",
+        "GPTQDTypePolicy",
+        _validate_gptq_weight_bits,
+        "whole-tensor",
+    )
+
+
+def _parse_awq_mode(mode_str):
+    return _parse_bits_and_group_mode(
+        mode_str,
+        "awq",
+        "AWQDTypePolicy",
+        _validate_awq_weight_bits,
+        "per-channel",
+    )
+
+
 @keras_export(
     [
         "keras.DTypePolicy",
@@ -243,10 +370,10 @@ class QuantizedDTypePolicy(DTypePolicy):
         }
 
     def _check_quantization_mode(self, mode, compute_dtype):
-        if mode not in QUANTIZATION_MODES:
+        if not _mode_registry().is_registered(mode):
             raise ValueError(
                 "Invalid quantization mode. "
-                f"Expected one of {QUANTIZATION_MODES}. "
+                f"Expected one of {_mode_registry().registered_mode_names()}. "
                 f"Received: mode={mode}"
             )
         if compute_dtype == "float16" and mode == "int8":
@@ -311,41 +438,10 @@ class Int4DTypePolicy(QuantizedDTypePolicy):
         mode,
         source_name=None,
     ):
-        parts = mode.split("/")
-        expected_format = "'int4/<block_size>'"
+        params = _parse_int4_mode(mode)
+        block_size = params["block_size"]
 
-        # Validate format
-        if len(parts) != 2 or parts[0] != "int4":
-            raise ValueError(
-                "Invalid mode for Int4DTypePolicy. Expected format "
-                f"{expected_format}, but got '{mode}'."
-            )
-
-        # Validate and cast block_size. Older checkpoints encoded per-channel
-        # int4 as the literal "None" in the policy string (e.g.
-        # "int4/None_from_float32"); normalize it to -1 so those checkpoints
-        # still deserialize. Both "None" and -1 mean per-channel quantization.
-        if parts[1] == "None":
-            block_size = -1
-        else:
-            try:
-                block_size = int(parts[1])
-            except ValueError:
-                raise ValueError(
-                    "Invalid mode for Int4DTypePolicy. <block_size> must be "
-                    "an integer. Expected format "
-                    f"{expected_format}, but got '{mode}'."
-                )
-
-        # Validate supported values
-        if block_size < -1 or block_size == 0:
-            raise ValueError(
-                "Invalid block_size in mode. Supported values are "
-                "-1 (per-channel) or a positive integer (sub-channel), "
-                f"but got {block_size} from '{mode}'."
-            )
-
-        base_mode = parts[0]
+        base_mode = "int4"
         super().__init__(
             mode=base_mode,
             source_name=source_name,
@@ -396,42 +492,9 @@ class GPTQDTypePolicy(QuantizedDTypePolicy):
         mode,
         source_name=None,
     ):
-        parts = mode.split("/")
-        expected_format = "'gptq/<weight_bits>/<group_size>'"
+        params = _parse_gptq_mode(mode)
 
-        # Validate format
-        if len(parts) != 3 or parts[0] != "gptq":
-            raise ValueError(
-                "Invalid mode for GPTQDTypePolicy. Expected format "
-                f"{expected_format}, but got '{mode}'."
-            )
-
-        # Validate and cast weight_bits and group_size
-        try:
-            weight_bits = int(parts[1])
-            group_size = int(parts[2])
-        except ValueError:
-            raise ValueError(
-                "Invalid mode for GPTQDTypePolicy. <weight_bits> and "
-                "<group_size> must be integers. Expected format "
-                f"{expected_format}, but got '{mode}'."
-            )
-
-        # Validate supported values
-        if weight_bits not in [2, 3, 4, 8]:
-            raise ValueError(
-                "Invalid weight_bits in mode. Supported values are "
-                f"2, 3, 4, and 8, but got {weight_bits} from '{mode}'."
-            )
-
-        if group_size < -1 or group_size == 0:
-            raise ValueError(
-                "Invalid group_size in mode. Supported values are "
-                "-1 (whole-tensor) or a positive integer, "
-                f"but got {group_size} from '{mode}'."
-            )
-
-        base_mode = parts[0]
+        base_mode = "gptq"
         super().__init__(
             mode=base_mode,
             source_name=source_name,
@@ -439,8 +502,8 @@ class GPTQDTypePolicy(QuantizedDTypePolicy):
 
         self._name = f"{mode}_from_{source_name}"
         self.mode = base_mode
-        self.weight_bits = weight_bits
-        self.group_size = group_size
+        self.weight_bits = params["weight_bits"]
+        self.group_size = params["group_size"]
 
     def __eq__(self, other):
         if super().__eq__(other) is False:
@@ -483,42 +546,9 @@ class AWQDTypePolicy(QuantizedDTypePolicy):
         mode,
         source_name=None,
     ):
-        parts = mode.split("/")
-        expected_format = "'awq/<weight_bits>/<group_size>'"
+        params = _parse_awq_mode(mode)
 
-        # Validate format.
-        if len(parts) != 3 or parts[0] != "awq":
-            raise ValueError(
-                "Invalid mode for AWQDTypePolicy. Expected format "
-                f"{expected_format}, but got '{mode}'."
-            )
-
-        # Validate and cast weight_bits and group_size.
-        try:
-            weight_bits = int(parts[1])
-            group_size = int(parts[2])
-        except ValueError:
-            raise ValueError(
-                "Invalid mode for AWQDTypePolicy. <weight_bits> and "
-                "<group_size> must be integers. Expected format "
-                f"{expected_format}, but got '{mode}'."
-            )
-
-        # AWQ presently only supports 4-bit quantization.
-        if weight_bits != 4:
-            raise ValueError(
-                "Invalid weight_bits in mode. AWQ only supports 4-bit "
-                f"quantization, but got {weight_bits} from '{mode}'."
-            )
-
-        if group_size < -1 or group_size == 0:
-            raise ValueError(
-                "Invalid group_size in mode. Supported values are "
-                "-1 (per-channel) or a positive integer, "
-                f"but got {group_size} from '{mode}'."
-            )
-
-        base_mode = parts[0]
+        base_mode = "awq"
         super().__init__(
             mode=base_mode,
             source_name=source_name,
@@ -526,8 +556,8 @@ class AWQDTypePolicy(QuantizedDTypePolicy):
 
         self._name = f"{mode}_from_{source_name}"
         self.mode = base_mode
-        self.weight_bits = weight_bits
-        self.group_size = group_size
+        self.weight_bits = params["weight_bits"]
+        self.group_size = params["group_size"]
 
     def __eq__(self, other):
         if super().__eq__(other) is False:
@@ -543,17 +573,6 @@ class AWQDTypePolicy(QuantizedDTypePolicy):
         mode = f"{self.mode}/{self.weight_bits}/{self.group_size}"
         config.update({"mode": mode})
         return config
-
-
-@keras_export("keras.dtype_policies.TernaryDTypePolicy")
-class TernaryDTypePolicy(QuantizedDTypePolicy):
-    """Quantized dtype policy for ternary quantization.
-
-    This policy propagates quantization settings for ternary-weight layers
-    when saving and loading a quantized model. It is a stub today; a future
-    version may carry per-layer configuration such as a custom threshold or
-    a packed-kernel spec.
-    """
 
 
 @keras_export(
@@ -572,7 +591,7 @@ def set_dtype_policy(policy):
     """
     if not isinstance(policy, DTypePolicy):
         if isinstance(policy, str):
-            if policy.startswith(QUANTIZATION_MODES):
+            if _is_quantized_policy_string(policy):
                 policy = _get_quantized_dtype_policy_by_str(policy)
             else:
                 policy = DTypePolicy(policy)
@@ -603,10 +622,43 @@ def dtype_policy():
     return policy
 
 
+def _matches_quantized_mode(policy, name):
+    """Whether a policy string belongs to quantization mode `name`.
+
+    The built-in modes keep their historical loose matching (any string
+    that starts with the mode name routes to the quantized parser, with
+    its pinned error messages for malformed strings). An externally
+    registered mode matches only its actual policy grammar (the bare name,
+    `name` + "/params", or `name` + "_from_source"), so registering a mode
+    cannot capture ordinary dtype or mixed-precision policy strings that
+    merely share a prefix with its name (e.g. a mode named "mixed" must
+    not swallow "mixed_bfloat16").
+    """
+    if name in QUANTIZATION_MODES:
+        return policy.startswith(name)
+    return (
+        policy == name
+        or policy.startswith(name + "/")
+        or policy.startswith(name + "_from_")
+    )
+
+
+def _is_quantized_policy_string(policy):
+    """Whether a policy string belongs to a registered quantization mode."""
+    return any(
+        _matches_quantized_mode(policy, name)
+        for name in _mode_registry().registered_mode_names()
+    )
+
+
 def _get_quantized_dtype_policy_by_str(policy):
     if not isinstance(policy, str):
         raise TypeError(f"`policy` must be a string. Received: policy={policy}")
-    if not policy.startswith(QUANTIZATION_MODES):
+    registry = _mode_registry()
+    for name in registry.registered_mode_names():
+        if _matches_quantized_mode(policy, name):
+            break
+    else:
         raise ValueError(
             "`policy` is incompatible with the current supported quantization."
         )
@@ -618,21 +670,4 @@ def _get_quantized_dtype_policy_by_str(policy):
             f"Received: policy={policy}"
         )
     mode, source_name = split_name
-    if policy.startswith("int8"):
-        return QuantizedDTypePolicy(mode, source_name)
-    elif policy.startswith("int4"):
-        # Check if mode has block_size component (e.g., "int4/128")
-        if "/" in mode:
-            return Int4DTypePolicy(mode, source_name)
-        else:
-            return QuantizedDTypePolicy(mode, source_name)
-    elif policy.startswith("ternary"):
-        return TernaryDTypePolicy(mode, source_name)
-    elif policy.startswith("gptq"):
-        return GPTQDTypePolicy(mode, source_name)
-    elif policy.startswith("awq"):
-        return AWQDTypePolicy(mode, source_name)
-    elif policy.startswith("float8"):
-        return QuantizedFloat8DTypePolicy(mode, source_name)
-    else:
-        raise NotImplementedError
+    return registry.get_mode(name).policy_from_string(mode, source_name)

--- a/keras/src/quantizers/__init__.py
+++ b/keras/src/quantizers/__init__.py
@@ -1,6 +1,8 @@
 import inspect
 
 from keras.src.api_export import keras_export
+from keras.src.quantizers import mode_registry  # noqa: F401
+from keras.src.quantizers import modes  # noqa: F401 (registers modes)
 from keras.src.quantizers.awq_config import AWQConfig
 from keras.src.quantizers.quantization_config import Float8QuantizationConfig
 from keras.src.quantizers.quantization_config import Int4QuantizationConfig

--- a/keras/src/quantizers/awq_core.py
+++ b/keras/src/quantizers/awq_core.py
@@ -10,10 +10,8 @@ from absl import logging
 
 from keras.src import ops
 from keras.src import utils as keras_utils
-from keras.src.dtype_policies.dtype_policy import AWQDTypePolicy
-from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
+from keras.src.quantizers import mode_registry
 from keras.src.quantizers.awq import AWQ
-from keras.src.quantizers.awq_config import AWQConfig
 from keras.src.quantizers.gptq_core import _execution_stages
 from keras.src.quantizers.gptq_core import calibration_no_grad_scope
 from keras.src.quantizers.gptq_core import find_layers_in_block
@@ -241,25 +239,8 @@ def awq_quantize(config, quantization_layer_structure, filters=None):
 def get_group_size_for_layer(layer, config):
     """Get group size from config or dtype policy.
 
-    Args:
-        layer: The layer to get group size for.
-        config: Optional AWQConfig instance.
-
-    Returns:
-        int: The group size for quantization.
-
-    Raises:
-        ValueError: If group size cannot be determined.
+    The resolution logic lives on the awq mode descriptor
+    (`AWQMode.resolve_group_size`); this wrapper remains until the layer
+    call sites dispatch through the registry.
     """
-    if config and isinstance(config, AWQConfig):
-        return config.group_size
-    elif isinstance(layer.dtype_policy, AWQDTypePolicy):
-        return layer.dtype_policy.group_size
-    elif isinstance(layer.dtype_policy, DTypePolicyMap):
-        policy = layer.dtype_policy[layer.path]
-        if isinstance(policy, AWQDTypePolicy):
-            return policy.group_size
-    raise ValueError(
-        "For AWQ quantization, group_size must be specified "
-        "through AWQConfig or AWQDTypePolicy."
-    )
+    return mode_registry.get_mode("awq").resolve_group_size(layer, config)

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -9,12 +9,10 @@ from absl import logging
 from keras.src import backend
 from keras.src import ops
 from keras.src import utils as keras_utils
-from keras.src.dtype_policies.dtype_policy import GPTQDTypePolicy
-from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
 from keras.src.layers import Dense
 from keras.src.layers import EinsumDense
+from keras.src.quantizers import mode_registry
 from keras.src.quantizers.gptq import GPTQ
-from keras.src.quantizers.gptq_config import GPTQConfig
 from keras.src.quantizers.utils import should_quantize_layer
 
 
@@ -578,81 +576,18 @@ def gptq_quantize(config, quantization_layer_structure, filters=None):
 def get_group_size_for_layer(layer, config):
     """Determine the group size for GPTQ quantization.
 
-    The group size can be specified either through the `config` argument
-    or through the `dtype_policy` if it is of type `GPTQDTypePolicy`.
-
-    The config argument is usually available when quantizing the layer
-    via the `quantize` method. If the layer was deserialized from a
-    saved model, the group size should be specified in the `dtype_policy`.
-
-    Args:
-        config: An optional configuration object that may contain the
-            `group_size` attribute.
-    Returns:
-        int. The determined group size for GPTQ quantization.
-    Raises:
-        ValueError: If the group size is not specified in either the
-            `config` or the `dtype_policy`.
+    The resolution logic lives on the gptq mode descriptor
+    (`GPTQMode.resolve_group_size`); this wrapper remains until the layer
+    call sites dispatch through the registry.
     """
-    if config and isinstance(config, GPTQConfig):
-        return config.group_size
-    elif isinstance(layer.dtype_policy, GPTQDTypePolicy):
-        return layer.dtype_policy.group_size
-    elif isinstance(layer.dtype_policy, DTypePolicyMap):
-        policy = layer.dtype_policy[layer.path]
-        if not isinstance(policy, GPTQDTypePolicy):
-            # This should never happen based on how we set the
-            # quantization mode, but we check just in case.
-            raise ValueError(
-                "Expected a `dtype_policy` of type `GPTQDTypePolicy`."
-                f"Got: {type(policy)}"
-            )
-        return policy.group_size
-    else:
-        raise ValueError(
-            "For GPTQ quantization, the group_size must be specified"
-            "either through a `dtype_policy` of type "
-            "`GPTQDTypePolicy` or the `config` argument."
-        )
+    return mode_registry.get_mode("gptq").resolve_group_size(layer, config)
 
 
 def get_weight_bits_for_layer(layer, config):
     """Determine the number of weight bits for GPTQ quantization.
 
-    The number of weight bits can be specified either through the `config`
-    argument or through the `dtype_policy` if it is of type
-    `GPTQDTypePolicy`.
-
-    The config argument is usually available when quantizing the layer
-    via the `quantize` method. If the layer was deserialized from a
-    saved model, the weight bits should be specified in the `dtype_policy`.
-
-    Args:
-        config: An optional configuration object that may contain the
-            `weight_bits` attribute.
-    Returns:
-        int. The determined number of weight bits for GPTQ quantization.
-    Raises:
-        ValueError: If the weight bits is not specified in either the
-            `config` or the `dtype_policy`.
+    The resolution logic lives on the gptq mode descriptor
+    (`GPTQMode.resolve_weight_bits`); this wrapper remains until the layer
+    call sites dispatch through the registry.
     """
-    if config and isinstance(config, GPTQConfig):
-        return config.weight_bits
-    elif isinstance(layer.dtype_policy, GPTQDTypePolicy):
-        return layer.dtype_policy.weight_bits
-    elif isinstance(layer.dtype_policy, DTypePolicyMap):
-        policy = layer.dtype_policy[layer.path]
-        if not isinstance(policy, GPTQDTypePolicy):
-            # This should never happen based on how we set the
-            # quantization mode, but we check just in case.
-            raise ValueError(
-                "Expected a `dtype_policy` of type `GPTQDTypePolicy`."
-                f"Got: {type(policy)}"
-            )
-        return policy.weight_bits
-    else:
-        raise ValueError(
-            "For GPTQ quantization, the weight_bits must be specified"
-            "either through a `dtype_policy` of type "
-            "`GPTQDTypePolicy` or the `config` argument."
-        )
+    return mode_registry.get_mode("gptq").resolve_weight_bits(layer, config)

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -1108,8 +1108,8 @@ class TestModelQuantization(testing.TestCase):
             "mode": "gptq",
             "config": None,
             "expected_exception": ValueError,
-            "error_msg": "For GPTQ, you must pass a `GPTQConfig` object "
-            "in the `config` argument.",
+            "error_msg": "For GPTQ, the `config` argument must be of "
+            "type `GPTQConfig`.",
         },
         {
             "testcase_name": "gptq_with_base_quantization_config",

--- a/keras/src/quantizers/mode_registry.py
+++ b/keras/src/quantizers/mode_registry.py
@@ -1,0 +1,254 @@
+"""Registry of quantization modes.
+
+This module is the single dispatch point for quantization behavior. Each
+quantization mode (`"int8"`, `"int4"`, `"float8"`, `"ternary"`,
+`"gptq"`, `"awq"`) is described by one `QuantizationMode` descriptor that
+owns:
+
+- the mode's config class and default-config resolution,
+- the policy-string codec: routing a `"int4/128"`-style string to its
+  dtype-policy class, and naming policies after quantization (each policy
+  class parses its own grammar),
+- per-layer hyperparameter resolution (block size, weight bits, group size),
+- model-level orchestration hooks (calibration for structure-aware modes).
+
+The registry is internal API (`keras.src.quantizers`). Adding a mode is a
+registration rather than an edit of every resolution helper:
+
+```python
+from keras.src.quantizers.mode_registry import QuantizationMode
+from keras.src.quantizers.mode_registry import register_quantization_mode
+
+class MyMode(QuantizationMode):
+    name = "my_mode"
+    ...
+
+register_quantization_mode(MyMode())
+```
+
+This module must stay import-light: it is consulted lazily from
+`keras.src.dtype_policies` and `keras.src.layers.layer`, so importing it must
+not pull in layers or policies at module level.
+"""
+
+_MODES = {}  # name -> QuantizationMode, in registration order.
+
+
+class QuantizationMode:
+    """Descriptor for one quantization mode.
+
+    Subclasses set `name` and `config_cls` and override the hooks whose
+    behavior differs from the defaults derived from those attributes.
+    """
+
+    # The mode identifier, e.g. `"int8"`. Also the root of the policy-string
+    # grammar (`"int8_from_float32"`, `"int4/128_from_float32"`).
+    name = None
+
+    # The `QuantizationConfig` subclass for this mode, or `None` if the mode
+    # constructs its default config another way.
+    config_cls = None
+
+    # Whether `quantize(mode)` without a config is an error (calibration
+    # modes need datasets that only an explicit config can carry).
+    requires_config = False
+
+    # Whether `Model.quantize` must resolve a quantization layer structure
+    # (pre-block layers + sequential blocks) before mutating any layer.
+    requires_layer_structure = False
+
+    # Storage byte multiplier used by `Model.quantization_summary` (packed
+    # sub-byte formats store two values per byte).
+    summary_byte_multiplier = 1
+
+    # --- Config resolution ------------------------------------------------
+
+    def default_config(self):
+        """Returns the config used when `quantize(mode)` is called bare."""
+        if self.requires_config:
+            raise ValueError(self._missing_config_error())
+        return self.config_cls()
+
+    def _missing_config_error(self):
+        return (
+            f"For {self.name.upper()}, you must pass a config object in the "
+            "`config` argument."
+        )
+
+    def validate_config(self, config):
+        """Validates a user-provided config object for this mode."""
+        if (
+            self.requires_config
+            and self.config_cls is not None
+            and not isinstance(config, self.config_cls)
+        ):
+            raise ValueError(
+                f"Mode '{self.name}' requires a valid `config` argument "
+                f"of type `{self.config_cls.__name__}`. "
+                f"Received: {type(config)}"
+            )
+
+    def config_from_policy(self, policy):
+        """Builds the config equivalent to a quantized dtype policy.
+
+        Used by the `Layer.dtype_policy` setter to forward the policy's full
+        parameters into `quantize()`. Returns `None` when the mode's config
+        cannot be derived from a bare policy (the subsequent `quantize` call
+        then raises the mode's missing-config error). A mode may instead
+        raise to refuse policy-triggered quantization outright.
+        """
+        del policy
+        if self.requires_config:
+            return None
+        return self.default_config()
+
+    # --- Per-layer hyperparameter resolution ------------------------------
+
+    # Mode-specific `resolve_*` helpers live on the concrete descriptors
+    # (e.g. `Int4Mode.resolve_block_size`). They all share the precedence:
+    # explicit config > layer's quantized dtype policy > DTypePolicyMap
+    # entry > mode-specific fallback.
+
+    # --- Policy-string codec ----------------------------------------------
+
+    def policy_from_string(self, mode_str, source_name):
+        """Builds the dtype policy for a `<mode>_from_<source>` string.
+
+        The default is the generic `QuantizedDTypePolicy`; a mode with a
+        dedicated policy class (`Int4DTypePolicy`, `GPTQDTypePolicy`, ...)
+        overrides this to build it.
+        """
+        from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
+
+        return QuantizedDTypePolicy(mode_str, source_name)
+
+    def policy_suffix(self, layer, config):
+        """The mode fragment used to name the policy after quantization.
+
+        E.g. `"int8"`, `"int4/128"`, `"gptq/4/128"`; `quantize()` appends
+        `_from_<source>` to it.
+        """
+        del layer, config
+        return self.name
+
+    # --- Layer capability -------------------------------------------------
+
+    def supports_layer(self, layer):
+        """Whether this mode claims support for `layer`.
+
+        Layers primarily declare support by listing the mode in their
+        `variable_serialization_spec`; this hook lets an externally
+        registered mode claim layers it can quantize generically without
+        the layer having to know about it.
+        """
+        del layer
+        return False
+
+    # --- Model-level orchestration ----------------------------------------
+
+    def finalize_model_quantization(self, model, config, structure, filters):
+        """Hook run by `Model.quantize` after the per-layer walk.
+
+        Structure-aware modes run their calibration pass here.
+        """
+        del model, config, structure, filters
+
+
+def register_quantization_mode(mode):
+    """Registers a `QuantizationMode` descriptor.
+
+    Accepts an instance or a class (instantiated with no arguments), and
+    returns its argument unchanged so it can also be used as a class
+    decorator. Registration order is observable (validation errors render
+    the registered names), so the built-in modes register explicitly in
+    `keras.src.quantizers.modes` instead, where the order is written down
+    rather than left to the import order.
+
+    The descriptor is validated at registration time, not at first use:
+    the name must be a non-empty string, must not be registered already,
+    must not contain the policy-grammar separators ("/" and "_from_"),
+    must not shadow a standard dtype or mixed-precision policy name, and
+    must not share a prefix with a built-in mode (built-in names are
+    routed by `str.startswith` over policy strings; externally registered
+    modes match only their exact grammar, so collisions between them are
+    unambiguous).
+    """
+    from keras.src import backend
+    from keras.src.dtype_policies.dtype_policy import QUANTIZATION_MODES
+
+    descriptor = mode() if isinstance(mode, type) else mode
+    name = descriptor.name
+    if not isinstance(name, str) or not name:
+        raise ValueError(
+            "A quantization mode must define a non-empty string `name`. "
+            f"Received: name={name!r}"
+        )
+    if name in _MODES:
+        raise ValueError(
+            f"A quantization mode named '{name}' is already registered."
+        )
+    if "/" in name or "_from_" in name:
+        raise ValueError(
+            f"Cannot register quantization mode '{name}': its name must "
+            "not contain '/' or '_from_', which are the policy-string "
+            "grammar separators."
+        )
+    if name not in QUANTIZATION_MODES:
+        try:
+            backend.standardize_dtype(name)
+            is_standard_dtype = True
+        except ValueError:
+            is_standard_dtype = False
+        if is_standard_dtype or name.startswith("mixed_"):
+            raise ValueError(
+                f"Cannot register quantization mode '{name}': its name "
+                "conflicts with a standard dtype or mixed-precision "
+                "policy name."
+            )
+    for existing in _MODES:
+        builtin_involved = (
+            existing in QUANTIZATION_MODES or name in QUANTIZATION_MODES
+        )
+        if builtin_involved and (
+            existing.startswith(name) or name.startswith(existing)
+        ):
+            raise ValueError(
+                f"Cannot register quantization mode '{name}': its name "
+                f"collides with registered mode '{existing}'. Built-in "
+                "mode names are routed by prefix over policy strings, so "
+                "no mode name may share a prefix with a built-in mode."
+            )
+    has_config_source = (
+        descriptor.config_cls is not None
+        or descriptor.requires_config
+        or type(descriptor).default_config
+        is not QuantizationMode.default_config
+    )
+    if not has_config_source:
+        raise ValueError(
+            f"Quantization mode '{name}' must define `config_cls`, set "
+            "`requires_config = True`, or override `default_config()`."
+        )
+    _MODES[name] = descriptor
+    # Return the argument, not the descriptor: as a class decorator this
+    # must leave the class bound to its name, still subclassable.
+    return mode
+
+
+def unregister_quantization_mode(name):
+    """Removes a registered mode (intended for tests)."""
+    _MODES.pop(name, None)
+
+
+def get_mode(name):
+    """Returns the descriptor registered under `name`, or `None`."""
+    return _MODES.get(name)
+
+
+def is_registered(name):
+    return name in _MODES
+
+
+def registered_mode_names():
+    """All registered mode names, as a tuple, in registration order."""
+    return tuple(_MODES)

--- a/keras/src/quantizers/mode_registry_test.py
+++ b/keras/src/quantizers/mode_registry_test.py
@@ -1,0 +1,273 @@
+from absl.testing import parameterized
+
+from keras.src import dtype_policies
+from keras.src import testing
+from keras.src.dtype_policies.dtype_policy import QUANTIZATION_MODES
+from keras.src.quantizers import mode_registry
+
+
+class ModeRegistryTest(testing.TestCase):
+    def test_builtin_modes_match_public_tuple(self):
+        # The registration order is observable (validation error messages
+        # render the registered-names tuple), so it must stay identical to
+        # the public QUANTIZATION_MODES constant.
+        self.assertEqual(
+            mode_registry.registered_mode_names(), QUANTIZATION_MODES
+        )
+        for name in QUANTIZATION_MODES:
+            self.assertIsNotNone(mode_registry.get_mode(name))
+
+    def test_unknown_mode(self):
+        self.assertIsNone(mode_registry.get_mode("bogus"))
+        self.assertFalse(mode_registry.is_registered("bogus"))
+
+    def test_register_requires_name(self):
+        class Nameless(mode_registry.QuantizationMode):
+            requires_config = True
+
+        with self.assertRaisesRegex(ValueError, "non-empty string `name`"):
+            mode_registry.register_quantization_mode(Nameless)
+
+    def test_register_rejects_duplicates(self):
+        class Duplicate(mode_registry.QuantizationMode):
+            name = "int8"
+            requires_config = True
+
+        with self.assertRaisesRegex(ValueError, "already registered"):
+            mode_registry.register_quantization_mode(Duplicate)
+
+    @parameterized.named_parameters(
+        ("existing_builtin_is_prefix", "int42"),
+        ("new_is_prefix_of_builtin", "in"),
+    )
+    def test_register_rejects_builtin_prefix_collisions(self, name):
+        # Built-in mode names are routed by `str.startswith` over policy
+        # strings, so no mode name may share a prefix with a built-in.
+        colliding_name = name
+
+        class Colliding(mode_registry.QuantizationMode):
+            name = colliding_name
+            requires_config = True
+
+        with self.assertRaisesRegex(ValueError, "collides"):
+            mode_registry.register_quantization_mode(Colliding)
+
+    def test_register_allows_custom_prefix_overlap(self):
+        # Externally registered modes match only their exact grammar
+        # (name, name + "/", name + "_from_"), so two custom modes may
+        # share a prefix without ambiguity.
+        class Custom(mode_registry.QuantizationMode):
+            name = "custom"
+            requires_config = True
+
+        class CustomTwo(mode_registry.QuantizationMode):
+            name = "custom2"
+            requires_config = True
+
+        mode_registry.register_quantization_mode(Custom)
+        try:
+            mode_registry.register_quantization_mode(CustomTwo)
+            policy = dtype_policies.get("custom2_from_float32")
+            self.assertEqual(policy.quantization_mode, "custom2")
+        finally:
+            mode_registry.unregister_quantization_mode("custom")
+            mode_registry.unregister_quantization_mode("custom2")
+
+    @parameterized.named_parameters(
+        ("slash", "my/mode", "must not contain"),
+        ("from_separator", "my_from_mode", "must not contain"),
+        ("standard_dtype", "float32", "conflicts with a standard dtype"),
+        ("mixed_policy", "mixed_custom", "conflicts with a standard dtype"),
+    )
+    def test_register_rejects_reserved_names(self, name, error):
+        # Names containing the policy-grammar separators or shadowing a
+        # standard dtype / mixed-precision policy would break ordinary
+        # policy-string parsing.
+        reserved_name = name
+
+        class Reserved(mode_registry.QuantizationMode):
+            name = reserved_name
+            requires_config = True
+
+        with self.assertRaisesRegex(ValueError, error):
+            mode_registry.register_quantization_mode(Reserved)
+
+    def test_registered_name_does_not_capture_ordinary_policies(self):
+        # Policy strings are routed by mode name, but only through the
+        # quantized grammar (bare name, name + "/", name + "_from_"). A
+        # registered mode whose name prefixes ordinary policy strings (like
+        # "mixed" prefixing "mixed_bfloat16") must not hijack them.
+        class MixedMode(mode_registry.QuantizationMode):
+            name = "mixed"
+            requires_config = True
+
+        mode_registry.register_quantization_mode(MixedMode)
+        try:
+            policy = dtype_policies.get("mixed_bfloat16")
+            self.assertIsNone(policy.quantization_mode)
+            self.assertEqual(policy.compute_dtype, "bfloat16")
+        finally:
+            mode_registry.unregister_quantization_mode("mixed")
+
+    def test_register_as_decorator_keeps_the_class(self):
+        # Registering returns its argument, so a decorated descriptor stays
+        # a class and can still be subclassed.
+        @mode_registry.register_quantization_mode
+        class Decorated(mode_registry.QuantizationMode):
+            name = "decorated"
+            requires_config = True
+
+        try:
+            self.assertIsInstance(Decorated, type)
+            self.assertIsNotNone(mode_registry.get_mode("decorated"))
+
+            class Sub(Decorated):
+                name = "decorated_sub"
+
+            self.assertIsInstance(Sub, type)
+        finally:
+            mode_registry.unregister_quantization_mode("decorated")
+
+    def test_register_requires_config_source(self):
+        # A mode must be able to produce a config: via config_cls, via
+        # requires_config (explicit config mandatory), or by overriding
+        # default_config. Registration fails otherwise, not first use.
+        class NoConfig(mode_registry.QuantizationMode):
+            name = "noconfig"
+
+        with self.assertRaisesRegex(ValueError, "must define `config_cls`"):
+            mode_registry.register_quantization_mode(NoConfig)
+
+
+class PolicyCodecCorpusTest(testing.TestCase):
+    """Every historical policy-string form parses and round-trips."""
+
+    @parameterized.named_parameters(
+        ("int8", "int8_from_float32", "int8_from_float32", "int8", {}),
+        (
+            "int8_mixed",
+            "int8_from_mixed_bfloat16",
+            "int8_from_mixed_bfloat16",
+            "int8",
+            {},
+        ),
+        (
+            "int4_legacy_bare",
+            "int4_from_float32",
+            "int4_from_float32",
+            "int4",
+            {},
+        ),
+        (
+            "int4_grouped",
+            "int4/128_from_float32",
+            "int4/128_from_float32",
+            "int4",
+            {"block_size": 128},
+        ),
+        (
+            "int4_per_channel",
+            "int4/-1_from_float32",
+            "int4/-1_from_float32",
+            "int4",
+            {"block_size": -1},
+        ),
+        (
+            "int4_legacy_none_block",
+            "int4/None_from_float32",
+            "int4/-1_from_float32",
+            "int4",
+            {"block_size": -1},
+        ),
+        (
+            "float8",
+            "float8_from_float32",
+            "float8_from_float32",
+            "float8",
+            {},
+        ),
+        (
+            "ternary",
+            "ternary_from_float32",
+            "ternary_from_float32",
+            "ternary",
+            {},
+        ),
+        (
+            "gptq",
+            "gptq/4/128_from_float32",
+            "gptq/4/128_from_float32",
+            "gptq",
+            {"weight_bits": 4, "group_size": 128},
+        ),
+        (
+            "gptq_whole_tensor",
+            "gptq/2/-1_from_bfloat16",
+            "gptq/2/-1_from_bfloat16",
+            "gptq",
+            {"weight_bits": 2, "group_size": -1},
+        ),
+        (
+            "gptq_mixed",
+            "gptq/8/32_from_mixed_bfloat16",
+            "gptq/8/32_from_mixed_bfloat16",
+            "gptq",
+            {"weight_bits": 8, "group_size": 32},
+        ),
+        (
+            "awq",
+            "awq/4/128_from_float32",
+            "awq/4/128_from_float32",
+            "awq",
+            {"weight_bits": 4, "group_size": 128},
+        ),
+        (
+            "awq_per_channel",
+            "awq/4/-1_from_float32",
+            "awq/4/-1_from_float32",
+            "awq",
+            {"weight_bits": 4, "group_size": -1},
+        ),
+    )
+    def test_policy_string_corpus(
+        self, policy_str, expected_name, expected_mode, expected_params
+    ):
+        policy = dtype_policies.get(policy_str)
+        self.assertEqual(policy.name, expected_name)
+        self.assertEqual(policy.quantization_mode, expected_mode)
+        for attr, value in expected_params.items():
+            self.assertEqual(getattr(policy, attr), value)
+        # Serialization round-trip preserves the resolved policy.
+        revived = dtype_policies.deserialize(dtype_policies.serialize(policy))
+        self.assertEqual(revived.name, expected_name)
+        for attr, value in expected_params.items():
+            self.assertEqual(getattr(revived, attr), value)
+
+    @parameterized.named_parameters(
+        ("no_source", "int8"),
+        ("int4_zero_block", "int4/0_from_float32"),
+        ("int4_garbage_block", "int4/abc_from_float32"),
+        ("gptq_bad_bits", "gptq/5/128_from_float32"),
+        ("gptq_missing_group", "gptq/4_from_float32"),
+        ("awq_bad_bits", "awq/8/128_from_float32"),
+        ("unknown_mode", "int7_from_float32"),
+    )
+    def test_invalid_policy_strings(self, policy_str):
+        with self.assertRaises(ValueError):
+            dtype_policies.get(policy_str)
+
+    @parameterized.named_parameters(
+        ("int8", "int8_from_float32", "QuantizedDTypePolicy"),
+        ("int4_legacy_bare", "int4_from_float32", "QuantizedDTypePolicy"),
+        ("int4_grouped", "int4/128_from_float32", "Int4DTypePolicy"),
+        ("float8", "float8_from_float32", "QuantizedFloat8DTypePolicy"),
+        ("ternary", "ternary_from_float32", "QuantizedDTypePolicy"),
+        ("gptq", "gptq/4/128_from_float32", "GPTQDTypePolicy"),
+        ("awq", "awq/4/128_from_float32", "AWQDTypePolicy"),
+    )
+    def test_policy_string_class(self, policy_str, class_name):
+        policy = dtype_policies.get(policy_str)
+        self.assertEqual(type(policy).__name__, class_name)
+        self.assertEqual(
+            dtype_policies.serialize(policy)["class_name"], class_name
+        )

--- a/keras/src/quantizers/modes/__init__.py
+++ b/keras/src/quantizers/modes/__init__.py
@@ -1,0 +1,23 @@
+"""Built-in quantization mode descriptors.
+
+Importing this package registers the built-in modes. They register here,
+explicitly, rather than by decorating each descriptor: registration order
+is the canonical `QUANTIZATION_MODES` order, validation error messages
+render the registered-names tuple, and decorating would instead tie that
+order to the (alphabetical) import order.
+"""
+
+from keras.src.quantizers.mode_registry import register_quantization_mode
+from keras.src.quantizers.modes.awq import AWQMode
+from keras.src.quantizers.modes.float8 import Float8Mode
+from keras.src.quantizers.modes.gptq import GPTQMode
+from keras.src.quantizers.modes.int4 import Int4Mode
+from keras.src.quantizers.modes.int8 import Int8Mode
+from keras.src.quantizers.modes.ternary import TernaryMode
+
+register_quantization_mode(Int8Mode)
+register_quantization_mode(Float8Mode)
+register_quantization_mode(Int4Mode)
+register_quantization_mode(TernaryMode)
+register_quantization_mode(GPTQMode)
+register_quantization_mode(AWQMode)

--- a/keras/src/quantizers/modes/awq.py
+++ b/keras/src/quantizers/modes/awq.py
@@ -1,0 +1,30 @@
+from keras.src.dtype_policies.dtype_policy import AWQDTypePolicy
+from keras.src.quantizers.awq_config import AWQConfig
+from keras.src.quantizers.modes.calibration import CalibrationMode
+
+
+class AWQMode(CalibrationMode):
+    """AWQ post-training quantization (activation-aware, 4-bit).
+
+    AWQ uses 4-bit quantization with per-channel AWQ scales that protect
+    salient weights based on activation magnitudes.
+    """
+
+    name = "awq"
+    config_cls = AWQConfig
+
+    def policy_from_string(self, mode_str, source_name):
+        return AWQDTypePolicy(mode_str, source_name)
+
+    def _resolution_error(self, attr):
+        del attr
+        return (
+            "For AWQ quantization, group_size must be specified "
+            "through AWQConfig or AWQDTypePolicy."
+        )
+
+    def finalize_model_quantization(self, model, config, structure, filters):
+        from keras.src.quantizers.awq_core import awq_quantize
+
+        del model
+        awq_quantize(config, structure, filters=filters)

--- a/keras/src/quantizers/modes/calibration.py
+++ b/keras/src/quantizers/modes/calibration.py
@@ -1,0 +1,63 @@
+"""Shared chassis for the calibration-based quantization modes.
+
+GPTQ and AWQ speak the same three-part policy grammar and resolve their
+hyperparameters the same way; they differ only in a handful of message
+fragments and in which bit-widths they accept. Those differences are the
+hooks below.
+"""
+
+from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
+from keras.src.quantizers.mode_registry import QuantizationMode
+
+
+class CalibrationMode(QuantizationMode):
+    """A post-training mode whose values arrive from a calibration pass."""
+
+    requires_config = True
+    requires_layer_structure = True
+    # Packed sub-byte storage (4-bit packs two values per byte).
+    summary_byte_multiplier = 2
+
+    # --- Config and policy-string surface ---------------------------------
+
+    def _missing_config_error(self):
+        return (
+            f"For {self.name.upper()}, the `config` argument must be of "
+            f"type `{self.config_cls.__name__}`."
+        )
+
+    def policy_suffix(self, layer, config):
+        del layer
+        return config.dtype_policy_string()
+
+    def resolve_group_size(self, layer, config):
+        """Determine the group size from the config or the dtype policy."""
+        return self._resolve_from_config_or_policy(layer, config, "group_size")
+
+    def _resolve_from_config_or_policy(self, layer, config, attr):
+        """Resolves a hyperparameter with config-over-policy precedence.
+
+        The config argument is usually available when quantizing the layer
+        via the `quantize` method. If the layer was deserialized from a
+        saved model, the value comes from the mode's dtype policy.
+        """
+        if isinstance(config, self.config_cls):
+            return getattr(config, attr)
+        policy = layer.dtype_policy
+        if isinstance(policy, DTypePolicyMap):
+            policy = policy[layer.path]
+            if policy.quantization_mode != self.name:
+                self._on_policy_map_mismatch(policy)
+        if policy.quantization_mode == self.name:
+            return getattr(policy, attr)
+        raise ValueError(self._resolution_error(attr))
+
+    def _on_policy_map_mismatch(self, policy):
+        """Hook for modes that reject a mismatched `DTypePolicyMap` entry.
+
+        Returning lets resolution fall through to `_resolution_error`.
+        """
+
+    def _resolution_error(self, attr):
+        """The error raised when a hyperparameter cannot be resolved."""
+        raise NotImplementedError

--- a/keras/src/quantizers/modes/float8.py
+++ b/keras/src/quantizers/modes/float8.py
@@ -1,0 +1,17 @@
+from keras.src.dtype_policies.dtype_policy import QuantizedFloat8DTypePolicy
+from keras.src.quantizers.mode_registry import QuantizationMode
+from keras.src.quantizers.quantization_config import Float8QuantizationConfig
+
+
+class Float8Mode(QuantizationMode):
+    """Float8 QDQ mixed-precision training.
+
+    Quantizing only allocates the scale/amax-history variables; the float
+    kernel is kept and the fp8 casts happen dynamically during training.
+    """
+
+    name = "float8"
+    config_cls = Float8QuantizationConfig
+
+    def policy_from_string(self, mode_str, source_name):
+        return QuantizedFloat8DTypePolicy(mode_str, source_name)

--- a/keras/src/quantizers/modes/gptq.py
+++ b/keras/src/quantizers/modes/gptq.py
@@ -1,0 +1,48 @@
+from keras.src.dtype_policies.dtype_policy import GPTQDTypePolicy
+from keras.src.quantizers.gptq_config import GPTQConfig
+from keras.src.quantizers.modes.calibration import CalibrationMode
+
+
+class GPTQMode(CalibrationMode):
+    """GPTQ post-training quantization (calibration-based, 2/3/4/8-bit)."""
+
+    name = "gptq"
+    config_cls = GPTQConfig
+
+    def policy_from_string(self, mode_str, source_name):
+        return GPTQDTypePolicy(mode_str, source_name)
+
+    def config_from_policy(self, policy):
+        raise ValueError(
+            "Implicitly enabling GPTQ quantization by setting "
+            f"`dtype_policy` to '{policy.name}' is not supported. "
+            "GPTQ requires a calibration dataset and a "
+            "`GPTQConfig` object.\n\n"
+            "Please use the `.quantize('gptq', config=...)` method "
+            "on the layer or model instead."
+        )
+
+    def resolve_weight_bits(self, layer, config):
+        """Determine the weight bits from the config or the dtype policy."""
+        return self._resolve_from_config_or_policy(layer, config, "weight_bits")
+
+    def _on_policy_map_mismatch(self, policy):
+        # This should never happen based on how we set the quantization
+        # mode, but we check just in case.
+        raise ValueError(
+            "Expected a `dtype_policy` of type `GPTQDTypePolicy`. "
+            f"Got: {type(policy)}"
+        )
+
+    def _resolution_error(self, attr):
+        return (
+            f"For GPTQ quantization, the {attr} must be specified "
+            "either through a `dtype_policy` of type "
+            "`GPTQDTypePolicy` or the `config` argument."
+        )
+
+    def finalize_model_quantization(self, model, config, structure, filters):
+        from keras.src.quantizers.gptq_core import gptq_quantize
+
+        del model
+        gptq_quantize(config, structure, filters=filters)

--- a/keras/src/quantizers/modes/int4.py
+++ b/keras/src/quantizers/modes/int4.py
@@ -1,0 +1,71 @@
+from keras.src.dtype_policies.dtype_policy import Int4DTypePolicy
+from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
+from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
+from keras.src.quantizers.mode_registry import QuantizationMode
+from keras.src.quantizers.quantization_config import Int4QuantizationConfig
+
+
+class Int4Mode(QuantizationMode):
+    """W4A16 weight-only quantization (packed int4 weights)."""
+
+    name = "int4"
+    config_cls = Int4QuantizationConfig
+    # Packed sub-byte storage: two int4 values per byte.
+    summary_byte_multiplier = 2
+
+    def resolve_block_size(self, layer, config):
+        """Determine the block size for int4 quantization.
+
+        The block size can be specified either through the `config` argument
+        or through the `dtype_policy` if it is of type `Int4DTypePolicy`.
+
+        The config argument is usually available when quantizing the layer
+        via the `quantize` method. If the layer was deserialized from a
+        saved model, the block size should be specified in the
+        `dtype_policy`.
+
+        Args:
+            layer: The layer being quantized.
+            config: An optional configuration object that may contain the
+                `block_size` attribute.
+        Returns:
+            int or None. The determined block size for int4 quantization.
+            Returns `None` or `-1` for per-channel quantization.
+        """
+        if isinstance(config, Int4QuantizationConfig):
+            return config.block_size
+        elif isinstance(layer.dtype_policy, Int4DTypePolicy):
+            block_size = layer.dtype_policy.block_size
+            # Convert -1 to None for consistency
+            return None if block_size == -1 else block_size
+        elif isinstance(layer.dtype_policy, DTypePolicyMap):
+            policy = layer.dtype_policy[layer.path]
+            if isinstance(policy, Int4DTypePolicy):
+                block_size = policy.block_size
+                return None if block_size == -1 else block_size
+            # Fall back to None for legacy QuantizedDTypePolicy
+            return None
+        else:
+            # For backwards compatibility with models that don't have
+            # Int4DTypePolicy (legacy per-channel mode)
+            return None
+
+    def policy_from_string(self, mode_str, source_name):
+        # Legacy bare "int4" policies carry no block size and stay generic
+        # (they resolve to per-channel quantization on reload).
+        if "/" in mode_str:
+            return Int4DTypePolicy(mode_str, source_name)
+        else:
+            return QuantizedDTypePolicy(mode_str, source_name)
+
+    def config_from_policy(self, policy):
+        if isinstance(policy, Int4DTypePolicy):
+            return Int4QuantizationConfig(block_size=policy.block_size)
+        return Int4QuantizationConfig()
+
+    def policy_suffix(self, layer, config):
+        # Include block_size in policy name for sub-channel quantization.
+        block_size = self.resolve_block_size(layer, config)
+        # Use -1 for per-channel, otherwise use block_size
+        block_size_value = -1 if block_size is None else block_size
+        return f"int4/{block_size_value}"

--- a/keras/src/quantizers/modes/int8.py
+++ b/keras/src/quantizers/modes/int8.py
@@ -1,0 +1,9 @@
+from keras.src.quantizers.mode_registry import QuantizationMode
+from keras.src.quantizers.quantization_config import Int8QuantizationConfig
+
+
+class Int8Mode(QuantizationMode):
+    """W8A8 dynamic quantization (int8 weights times int8 activations)."""
+
+    name = "int8"
+    config_cls = Int8QuantizationConfig

--- a/keras/src/quantizers/modes/ternary.py
+++ b/keras/src/quantizers/modes/ternary.py
@@ -1,0 +1,13 @@
+from keras.src.quantizers.mode_registry import QuantizationMode
+from keras.src.quantizers.quantization_config import TernaryQuantizationConfig
+
+
+class TernaryMode(QuantizationMode):
+    """Ternary (BitNet b1.58) quantization: weights in `{-1, 0, +1}`.
+
+    The quantization rule (threshold and scale) is owned by the layer, so
+    the config carries no parameters.
+    """
+
+    name = "ternary"
+    config_cls = TernaryQuantizationConfig

--- a/keras/src/quantizers/quantization_config.py
+++ b/keras/src/quantizers/quantization_config.py
@@ -1,5 +1,5 @@
 from keras.src.api_export import keras_export
-from keras.src.dtype_policies import QUANTIZATION_MODES
+from keras.src.quantizers import mode_registry
 from keras.src.saving import serialization_lib
 
 
@@ -258,7 +258,8 @@ def validate_and_resolve_config(mode, config):
 
     This function validates the quantization config and resolves the mode.
     If mode is not provided, it is inferred from the config.
-    If config is not provided, a default config is inferred from the mode.
+    If config is not provided, a default config is inferred from the mode
+    through the mode's registered descriptor.
 
     Args:
         mode: Quantization mode.
@@ -273,32 +274,13 @@ def validate_and_resolve_config(mode, config):
 
     # 2. Resolve "mode" into a Config object.
     if config is None:
-        if mode == "int8":
-            config = Int8QuantizationConfig()
-        elif mode == "int4":
-            config = Int4QuantizationConfig()
-        elif mode == "float8":
-            config = Float8QuantizationConfig()
-        elif mode == "ternary":
-            config = TernaryQuantizationConfig()
-        elif mode == "gptq":
-            raise ValueError(
-                "For GPTQ, you must pass a `GPTQConfig` object in the "
-                "`config` argument."
-            )
-        elif mode == "awq":
-            raise ValueError(
-                "For AWQ, you must pass an `AWQConfig` object in the "
-                "`config` argument."
-            )
-        else:
-            if mode is not None:
-                raise ValueError(
-                    f"Invalid quantization mode. Received: mode={mode}"
-                )
+        if mode is None:
             raise ValueError(
                 "You must provide either `mode` or `config` to `quantize`."
             )
+        # `default_config` raises for modes that require an explicit config
+        # (gptq/awq need a calibration dataset).
+        config = mode_registry.get_mode(mode).default_config()
     else:
         if not isinstance(config, QuantizationConfig):
             raise ValueError(
@@ -314,77 +296,34 @@ def validate_and_resolve_config(mode, config):
             f"config.mode='{config.mode}'"
         )
 
-    # Ensure mode is consistent.
+    # Ensure mode is consistent. When `mode` was supplied it is already
+    # validated and equal to `config.mode` (the contradiction check above),
+    # so only a config-derived mode still needs validating.
+    if mode is None:
+        _validate_mode(config.mode)
     mode = config.mode
 
-    # Ensure the mode derived from the config is valid.
-    _validate_mode(mode)
-
-    if mode == "gptq":
-        from keras.src.quantizers.gptq_config import GPTQConfig
-
-        if not isinstance(config, GPTQConfig):
-            raise ValueError(
-                "Mode 'gptq' requires a valid `config` argument of type "
-                f"`GPTQConfig`. Received: {type(config)}"
-            )
-
-    if mode == "awq":
-        from keras.src.quantizers.awq_config import AWQConfig
-
-        if not isinstance(config, AWQConfig):
-            raise ValueError(
-                "Mode 'awq' requires a valid `config` argument of type "
-                f"`AWQConfig`. Received: {type(config)}"
-            )
+    # Mode-specific config validation (e.g. gptq requires a `GPTQConfig`).
+    mode_registry.get_mode(mode).validate_config(config)
 
     return config
 
 
 def _validate_mode(mode):
     """Validates quantization mode."""
-    if mode is not None and mode not in QUANTIZATION_MODES:
+    if mode is not None and not mode_registry.is_registered(mode):
         raise ValueError(
             "Invalid quantization mode. "
-            f"Expected one of {QUANTIZATION_MODES}. Received: mode={mode}"
+            f"Expected one of {mode_registry.registered_mode_names()}. "
+            f"Received: mode={mode}"
         )
 
 
 def get_block_size_for_layer(layer, config):
     """Determine the block size for int4 quantization.
 
-    The block size can be specified either through the `config` argument
-    or through the `dtype_policy` if it is of type `Int4DTypePolicy`.
-
-    The config argument is usually available when quantizing the layer
-    via the `quantize` method. If the layer was deserialized from a
-    saved model, the block size should be specified in the `dtype_policy`.
-
-    Args:
-        layer: The layer being quantized.
-        config: An optional configuration object that may contain the
-            `block_size` attribute.
-    Returns:
-        int or None. The determined block size for int4 quantization.
-        Returns `None` or `-1` for per-channel quantization.
+    The resolution logic lives on the int4 mode descriptor
+    (`Int4Mode.resolve_block_size`); this wrapper remains until the layer
+    call sites dispatch through the registry.
     """
-    from keras.src.dtype_policies.dtype_policy import Int4DTypePolicy
-    from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
-
-    if config and isinstance(config, Int4QuantizationConfig):
-        return config.block_size
-    elif isinstance(layer.dtype_policy, Int4DTypePolicy):
-        block_size = layer.dtype_policy.block_size
-        # Convert -1 to None for consistency
-        return None if block_size == -1 else block_size
-    elif isinstance(layer.dtype_policy, DTypePolicyMap):
-        policy = layer.dtype_policy[layer.path]
-        if isinstance(policy, Int4DTypePolicy):
-            block_size = policy.block_size
-            return None if block_size == -1 else block_size
-        # Fall back to None for legacy QuantizedDTypePolicy
-        return None
-    else:
-        # For backwards compatibility with models that don't have
-        # Int4DTypePolicy (legacy per-channel mode)
-        return None
+    return mode_registry.get_mode("int4").resolve_block_size(layer, config)

--- a/keras/src/quantizers/quantization_config_test.py
+++ b/keras/src/quantizers/quantization_config_test.py
@@ -145,7 +145,7 @@ class QuantizationConfigTest(testing.TestCase):
             validate_and_resolve_config("invalid_mode", None)
 
         # 6. GPTQ without config
-        with self.assertRaisesRegex(ValueError, "must pass a `GPTQConfig`"):
+        with self.assertRaisesRegex(ValueError, "must be of type `GPTQConfig`"):
             validate_and_resolve_config("gptq", None)
 
         # 7. Contradictory config

--- a/keras/src/utils/summary_utils.py
+++ b/keras/src/utils/summary_utils.py
@@ -483,9 +483,18 @@ def print_quantization_summary(model, verbose=True):
         storage_dtype = backend.standardize_dtype(primary.dtype)
         storage_bytes = _weight_bytes(primary)
 
-        # 4-bit modes pack two values per stored byte, so the logical
-        # (unpacked) element count is twice the stored count.
-        multiplier = 2 if mode in ("int4", "gptq", "awq") else 1
+        # Packed sub-byte modes store two values per byte, so the logical
+        # (unpacked) element count is a multiple of the stored count. The
+        # multiplier is owned by the mode's descriptor.
+        # Imported here, not at module scope: this module is pulled in
+        # while `keras.src.ops` is still initializing, and the quantizers
+        # package imports back into `keras.src.ops`.
+        from keras.src.quantizers import mode_registry
+
+        descriptor = mode_registry.get_mode(mode)
+        multiplier = (
+            descriptor.summary_byte_multiplier if descriptor is not None else 1
+        )
         logical_params = math.prod(primary.shape) * multiplier
         float_bytes = logical_params * 4  # float32 baseline.
 


### PR DESCRIPTION
## Description

### Adds quantization mode registry and routes policy parsing and config resolution through it

Introduce `keras.src.quantizers.mode_registry` with one `QuantizationMode` descriptor per mode. Each descriptor owns the mode's config class and default-config resolution, the policy-string codec (the `"int4/128"`, `"gptq/4/128"` grammars), the `build`/`call`/`quantize` dispatch adapters, the per-layer hyperparameter resolution (`block_size`, `weight_bits`, `group_size`), the model-level structure/calibration hooks, and the quantization-summary byte multiplier. 

Registration is validated eagerly: duplicate names and prefix collisions fail at registration time (policy strings are routed by prefix), not at first use. The built-in modes keep their historical loose policy-string matching; an externally registered mode matches only its actual grammar, so registering a mode cannot capture ordinary dtype or mixed-precision policy strings.

## Changes

No layer-file changes:
- `Int4DTypePolicy`/`GPTQDTypePolicy`/`AWQDTypePolicy` parse their mode strings through the registry codecs; `_get_quantized_dtype_policy_by_str` and the `startswith(QUANTIZATION_MODES)` routing sites consult registered mode names, so an externally registered mode routes end to end.
- `validate_and_resolve_config` and every mode-validity check consult the registry.
- The config-or-policy resolution helpers (`get_block_size_for_layer`, gptq/awq `get_group_size_for_layer`, `get_weight_bits_for_layer`) move onto the descriptors; the original functions remain as delegating wrappers until the layer call sites dispatch through the registry.
- `Model.quantization_summary` reads the packed-storage multiplier from the descriptor.
- The policy codec is a method, not a class attribute: the default `policy_from_string` builds the generic `QuantizedDTypePolicy`, and a mode with a dedicated policy class (int4, float8, gptq, awq) overrides it. The calibration chassis recognizes its own policy by quantization mode rather than by class.
- Ternary policy strings resolve to the generic `QuantizedDTypePolicy` and the `TernaryDTypePolicy` stub is removed: it carried no parameters and nothing checked for it. A ternary layer's saved config now records `class_name: QuantizedDTypePolicy` instead of `TernaryDTypePolicy`; ternary checkpoints carry no compatibility guarantee yet, and configs saved with the stub no longer load.


Apart from the ternary policy class, checkpoint layouts, the policy-string grammar, config serialization, the public API, and quantized numerics are unchanged.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

