### PR TITLE
Update backend.is_tensor to backend.ops.is_tensor

### DIFF
--- a/keras/src/callbacks/model_checkpoint.py
+++ b/keras/src/callbacks/model_checkpoint.py
@@ -281,7 +281,7 @@ class ModelCheckpoint(MonitorCallback):
                 )
                 return True
             elif (
-                isinstance(current, np.ndarray) or backend.is_tensor(current)
+                isinstance(current, np.ndarray) or backend.ops.is_tensor(current)
             ) and len(current.shape) > 0:
                 warnings.warn(
                     "Can save best model only when `monitor` is "

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -156,7 +156,7 @@ class DTypePolicy:
         """
 
         dtype = backend.standardize_dtype(dtype)
-        if backend.is_tensor(x):
+        if backend.ops.is_tensor(x):
             if self._should_cast(x, autocast, dtype):
                 x = backend.cast(x, dtype=dtype)
             return x

--- a/keras/src/export/export_utils.py
+++ b/keras/src/export/export_utils.py
@@ -90,7 +90,7 @@ def make_input_spec(x):
         shape = (None,) + backend.standardize_shape(x.shape)[1:]
         dtype = backend.standardize_dtype(x.dtype)
         input_spec = layers.InputSpec(dtype=dtype, shape=shape, name=x.name)
-    elif backend.is_tensor(x):
+    elif backend.ops.is_tensor(x):
         shape = (None,) + backend.standardize_shape(x.shape)[1:]
         dtype = backend.standardize_dtype(x.dtype)
         input_spec = layers.InputSpec(dtype=dtype, shape=shape, name=None)

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1018,7 +1018,7 @@ class Layer(BackendLayer, Operation):
                 # Record activity regularizer loss.
                 if self.activity_regularizer is not None:
                     for output in tree.flatten(outputs):
-                        if backend.is_tensor(output):
+                        if backend.ops.is_tensor(output):
                             loss = self.activity_regularizer(output)
                             if output.ndim > 0:
                                 # Normalize by batch size to ensure consistent
@@ -1288,7 +1288,7 @@ class Layer(BackendLayer, Operation):
         # Eager only.
         losses = tree.flatten(loss)
         for x in losses:
-            if not backend.is_tensor(x):
+            if not backend.ops.is_tensor(x):
                 raise ValueError(
                     "`add_loss()` can only be called from inside `build()` or "
                     f"`call()`, on a tensor input. Received invalid value: {x}"
@@ -1891,7 +1891,7 @@ class Layer(BackendLayer, Operation):
 def is_backend_tensor_or_symbolic(x, allow_none=False):
     if allow_none and x is None:
         return True
-    return backend.is_tensor(x) or isinstance(x, backend.KerasTensor)
+    return backend.ops.is_tensor(x) or isinstance(x, backend.KerasTensor)
 
 
 class CallSpec:
@@ -1948,7 +1948,7 @@ class CallSpec:
         self.nested_tensor_argument_names = nested_tensor_arg_names
         self.first_arg = arg_dict[arg_names[0]]
         if all(
-            backend.is_tensor(x) for x in self.tensor_arguments_dict.values()
+            backend.ops.is_tensor(x) for x in self.tensor_arguments_dict.values()
         ):
             self.eager = True
         else:

--- a/keras/src/layers/preprocessing/discretization.py
+++ b/keras/src/layers/preprocessing/discretization.py
@@ -207,7 +207,7 @@ class Discretization(DataLayer):
             progbar.update(steps if steps is not None else i + 1, finalize=True)
         elif hasattr(data, "__iter__") and not (
             isinstance(data, np.ndarray)
-            or backend.is_tensor(data)
+            or backend.ops.is_tensor(data)
             or tf.is_tensor(data)
         ):
             progbar = Progbar(target=steps, unit_name="step")

--- a/keras/src/layers/preprocessing/discretization_test.py
+++ b/keras/src/layers/preprocessing/discretization_test.py
@@ -152,7 +152,7 @@ class DiscretizationTest(testing.TestCase):
         )
         output = layer(input_array)
         self.assertSparse(output, sparse)
-        self.assertTrue(backend.is_tensor(output))
+        self.assertTrue(backend.ops.is_tensor(output))
         self.assertAllClose(output, expected_output)
 
     def test_tf_data_compatibility(self):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5608,8 +5608,8 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.array(x), np.array(x))
         self.assertAllClose(knp.Array()(x), np.array(x))
-        self.assertTrue(backend.is_tensor(knp.array(x)))
-        self.assertTrue(backend.is_tensor(knp.Array()(x)))
+        self.assertTrue(backend.ops.is_tensor(knp.array(x)))
+        self.assertTrue(backend.ops.is_tensor(knp.Array()(x)))
 
         # Check dtype conversion.
         x = [[1, 0, 1], [1, 1, 0]]

--- a/keras/src/ops/operation_test.py
+++ b/keras/src/ops/operation_test.py
@@ -185,25 +185,25 @@ class OperationTest(testing.TestCase):
 
         # Positional arguments
         out = op(x, y, z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(backend.ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Keyword arguments
         out = op(x=x, y=y, z=z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(backend.ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Mixed arguments
         out = op(x, y=y, z=z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(backend.ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Test multiple outputs
         op = OpWithMultipleOutputs()
         out = op(x)
         self.assertEqual(len(out), 2)
-        self.assertTrue(backend.is_tensor(out[0]))
-        self.assertTrue(backend.is_tensor(out[1]))
+        self.assertTrue(backend.ops.is_tensor(out[0]))
+        self.assertTrue(backend.ops.is_tensor(out[1]))
         self.assertAllClose(out[0], np.ones((2, 3)))
         self.assertAllClose(out[1], np.ones((2, 3)) + 1)
 
@@ -216,7 +216,7 @@ class OperationTest(testing.TestCase):
         with RematScope(mode="full"):
             op = OpWithMultipleInputs(name="test_op")
         out = op(x, x, x)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(backend.ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2, 3)))
 
         # Test quantized rematerialized call
@@ -224,7 +224,7 @@ class OperationTest(testing.TestCase):
             op_q = OpWithQuantizedCall(name="test_op_q")
         op_q.quantization_mode = object()
         out = op_q(x)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(backend.ops.is_tensor(out))
         self.assertAllClose(out, 2 * np.ones((2, 3)))
 
         # Test traceback filtering branch
@@ -235,7 +235,7 @@ class OperationTest(testing.TestCase):
             with RematScope(mode="full"):
                 op = OpWithMultipleInputs(name="test_op_traceback")
             out = op(x, x, x)
-            self.assertTrue(backend.is_tensor(out))
+            self.assertTrue(backend.ops.is_tensor(out))
             self.assertAllClose(out, 6 * np.ones((2, 3)))
 
             # Quantized rematerialized
@@ -243,7 +243,7 @@ class OperationTest(testing.TestCase):
                 op_q = OpWithQuantizedCall(name="test_op_q_traceback")
             op_q.quantization_mode = object()
             out = op_q(x)
-            self.assertTrue(backend.is_tensor(out))
+            self.assertTrue(backend.ops.is_tensor(out))
             self.assertAllClose(out, 2 * np.ones((2, 3)))
         finally:
             if not was_enabled:
@@ -375,7 +375,7 @@ class OperationTest(testing.TestCase):
             z = z.cpu()
         op = OpWithMultipleInputs()
         out = op(x, y, z)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(backend.ops.is_tensor(out))
         self.assertAllClose(out, 6 * np.ones((2,)))
 
     def test_valid_naming(self):

--- a/keras/src/random/seed_generator_test.py
+++ b/keras/src/random/seed_generator_test.py
@@ -50,11 +50,11 @@ class SeedGeneratorTest(testing.TestCase):
     def test_draw_seed_from_seed_generator(self):
         gen = seed_generator.SeedGenerator(seed=42)
         seed1 = seed_generator.draw_seed(gen)
-        self.assertTrue(backend.is_tensor(seed1))
+        self.assertTrue(backend.ops.is_tensor(seed1))
 
     def test_draw_seed_from_integer(self):
         seed2 = seed_generator.draw_seed(12345)
-        self.assertTrue(backend.is_tensor(seed2))
+        self.assertTrue(backend.ops.is_tensor(seed2))
         self.assertEqual(
             backend.standardize_dtype(seed2.dtype), backend.random_seed_dtype()
         )
@@ -64,7 +64,7 @@ class SeedGeneratorTest(testing.TestCase):
         # 2**31 is where signed-int32 wraps; 2**32 - 1 is the max uint32 value.
         for s in [2**31 - 1, 2**31, 2**32 - 1]:
             seed = seed_generator.draw_seed(s)
-            self.assertTrue(backend.is_tensor(seed))
+            self.assertTrue(backend.ops.is_tensor(seed))
             self.assertEqual(
                 backend.standardize_dtype(seed.dtype),
                 backend.random_seed_dtype(),
@@ -75,7 +75,7 @@ class SeedGeneratorTest(testing.TestCase):
 
     def test_draw_seed_from_none(self):
         seed3 = seed_generator.draw_seed(None)
-        self.assertTrue(backend.is_tensor(seed3))
+        self.assertTrue(backend.ops.is_tensor(seed3))
 
     def test_draw_seed_invalid(self):
         with self.assertRaisesRegex(

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -216,7 +216,7 @@ def serialize_keras_object(obj):
         }
     if tf.available and isinstance(obj, tf.TensorShape):
         return obj.as_list() if obj._dims is not None else None
-    if backend.is_tensor(obj):
+    if backend.ops.is_tensor(obj):
         return {
             "class_name": "__tensor__",
             "config": {

--- a/keras/src/testing/test_case.py
+++ b/keras/src/testing/test_case.py
@@ -41,7 +41,7 @@ class TestCase(parameterized.TestCase):
     def convert_to_numpy(self, x):
         if isinstance(x, np.ndarray):
             return x
-        elif backend.is_tensor(x) or isinstance(x, backend.Variable):
+        elif backend.ops.is_tensor(x) or isinstance(x, backend.Variable):
             return backend.convert_to_numpy(x)
         return np.array(x)
 

--- a/keras/src/utils/jax_layer.py
+++ b/keras/src/utils/jax_layer.py
@@ -419,7 +419,7 @@ class JaxLayer(Layer):
         """
 
         def create_variable(value):
-            if backend.is_tensor(value) or isinstance(
+            if backend.ops.is_tensor(value) or isinstance(
                 value, (np.ndarray, np.generic, jax.Array)
             ):
                 dtype = value.dtype

--- a/keras/src/utils/numerical_utils.py
+++ b/keras/src/utils/numerical_utils.py
@@ -74,7 +74,7 @@ def to_categorical(x, num_classes=None):
     >>> print(np.around(loss, 5))
     [0. 0. 0. 0.]
     """
-    if backend.is_tensor(x):
+    if backend.ops.is_tensor(x):
         input_shape = backend.core.shape(x)
         # Shrink the last dimension if the shape is (..., 1).
         if (

--- a/keras/src/utils/numerical_utils_test.py
+++ b/keras/src/utils/numerical_utils_test.py
@@ -50,7 +50,7 @@ class TestNumericalUtils(testing.TestCase):
             )
         )
         one_hot = numerical_utils.to_categorical(label, NUM_CLASSES)
-        self.assertTrue(backend.is_tensor(one_hot))
+        self.assertTrue(backend.ops.is_tensor(one_hot))
         self.assertAllClose(one_hot, expected)
 
     @parameterized.parameters([1, 2, 3])
@@ -70,7 +70,7 @@ class TestNumericalUtils(testing.TestCase):
 
         # Test backend
         out = numerical_utils.normalize(xb, axis=-1, order=order)
-        self.assertTrue(backend.is_tensor(out))
+        self.assertTrue(backend.ops.is_tensor(out))
         self.assertAllClose(backend.convert_to_numpy(out), expected)
 
     def test_normalize_numpy_axis_zero(self):

--- a/keras/src/utils/python_utils.py
+++ b/keras/src/utils/python_utils.py
@@ -185,7 +185,7 @@ def pythonify_logs(logs):
         else:
             try:
                 # Prevent torch compiler from breaking the graph.
-                if backend.is_tensor(value):
+                if backend.ops.is_tensor(value):
                     value = backend.convert_to_numpy(value)
                 value = float(value)
             except:

--- a/keras/src/utils/tf_utils.py
+++ b/keras/src/utils/tf_utils.py
@@ -31,7 +31,7 @@ def get_tensor_spec(t, dynamic_batch=False, name=None):
 def ensure_tensor(inputs, dtype=None):
     """Ensures the input is a Tensor, SparseTensor or RaggedTensor."""
     if not isinstance(inputs, (tf.Tensor, tf.SparseTensor, tf.RaggedTensor)):
-        if backend.backend() == "torch" and backend.is_tensor(inputs):
+        if backend.backend() == "torch" and backend.ops.is_tensor(inputs):
             # Plain `np.asarray()` conversion fails with PyTorch.
             inputs = backend.convert_to_numpy(inputs)
         inputs = tf.convert_to_tensor(inputs, dtype)

--- a/keras/src/utils/traceback_utils.py
+++ b/keras/src/utils/traceback_utils.py
@@ -269,7 +269,7 @@ def inject_argument_info_in_error(e, fn, args, kwargs, object_name=None):
 
 
 def format_argument_value(value):
-    if backend.is_tensor(value):
+    if backend.ops.is_tensor(value):
         # Simplified representation for eager / graph tensors
         # to keep messages readable
         if backend.backend() == "tensorflow":


### PR DESCRIPTION
This PR updates all instances of `backend.is_tensor` to `backend.ops.is_tensor` as part of the Keras backend API migration.