### PR TITLE
Promote integer inputs to float in gelu across backends

### DIFF
--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -5,6 +5,7 @@ import numpy as np
 from jax import lax
 
 from keras.src import backend
+from keras.src.backend.common import dtypes
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
@@ -144,6 +145,10 @@ def selu(x):
 
 def gelu(x, approximate=True):
     x = convert_to_tensor(x)
+    # Promote integer dtypes to float, otherwise the float constants below
+    # would truncate to 0 in the input dtype.
+    dtype = dtypes.result_type(x.dtype, float)
+    x = x.astype(dtype)
     # followed by JAX's implementation
     if approximate:
         sqrt_2_over_pi = np.sqrt(2 / np.pi).astype(x.dtype)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -147,8 +147,7 @@ def gelu(x, approximate=True):
     x = convert_to_tensor(x)
     # Promote integer dtypes to float, otherwise the float constants below
     # would truncate to 0 in the input dtype.
-    dtype = dtypes.result_type(x.dtype, float)
-    x = x.astype(dtype)
+    x = cast(x, dtypes.result_type(x.dtype, float))
     # followed by JAX's implementation
     if approximate:
         sqrt_2_over_pi = np.sqrt(2 / np.pi).astype(x.dtype)

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -4,6 +4,7 @@ from openvino import Type
 
 import keras.src.backend.openvino.numpy as onp
 from keras.src import backend
+from keras.src.backend.common import dtypes
 from keras.src.backend.common.backend_utils import (
     _get_output_shape_given_tf_padding,
 )
@@ -157,6 +158,12 @@ def selu(x):
 
 def gelu(x, approximate=True):
     x = get_ov_output(x)
+    # `ov_opset.gelu` doesn't support integer dtypes, so promote them to
+    # float.
+    x_type = ov_to_keras_type(x.get_element_type())
+    result_type = dtypes.result_type(x_type, float)
+    if x_type != result_type:
+        x = ov_opset.convert(x, OPENVINO_DTYPES[result_type]).output(0)
     approximate_mode = "erf"
     if approximate:
         approximate_mode = "tanh"

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -5,6 +5,7 @@ import warnings
 import tensorflow as tf
 
 from keras.src import backend
+from keras.src.backend.common import dtypes
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
@@ -129,6 +130,8 @@ def selu(x):
 
 def gelu(x, approximate=True):
     x = convert_to_tensor(x)
+    # `tf.nn.gelu` doesn't support integer dtypes, so promote them to float.
+    x = cast(x, dtypes.result_type(x.dtype, float))
     return tf.nn.gelu(x, approximate=approximate)
 
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as tnn
 
 from keras.src import backend
+from keras.src.backend.common import dtypes
 from keras.src.backend.common.backend_utils import canonicalize_axis
 from keras.src.backend.common.backend_utils import check_conv_input_channels
 from keras.src.backend.common.backend_utils import (
@@ -125,6 +126,8 @@ def selu(x):
 def gelu(x, approximate=True):
     # TODO: torch.nn.gelu expects string approximate of `"none"` or `"tanh"`
     x = convert_to_tensor(x)
+    # `tnn.gelu` doesn't support integer dtypes, so promote them to float.
+    x = cast(x, dtypes.result_type(x.dtype, float))
     if approximate:
         return tnn.gelu(x, approximate="tanh")
     return tnn.gelu(x)

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -639,7 +639,8 @@ class Gelu(Operation):
         return backend.nn.gelu(x, self.approximate)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        dtype = backend.result_type(x.dtype, float)
+        return KerasTensor(x.shape, dtype=dtype)
 
 
 @keras_export(["keras.ops.gelu", "keras.ops.nn.gelu"])

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1526,6 +1526,16 @@ class NNOpsCorrectnessTest(testing.TestCase):
             knn.gelu(x),
             [-0.15880796, 0.0, 0.841192, 1.9545977, 2.9963627],
         )
+        # Integer inputs are promoted to float and compute the same values.
+        x_int = np.array([-1, 0, 1, 2, 3], dtype=np.int32)
+        self.assertAllClose(
+            knn.gelu(x_int),
+            [-0.15880796, 0.0, 0.841192, 1.9545977, 2.9963627],
+        )
+        self.assertAllClose(
+            knn.gelu(x_int, approximate=False),
+            [-0.15865525, 0.0, 0.8413447, 1.9544997, 2.9959502],
+        )
 
     def test_celu(self):
         x = np.array([-1, 0, 1, 2, 3], dtype=np.float32)
@@ -2878,6 +2888,12 @@ class NNOpsDtypeTest(testing.TestCase):
     """Test the floating dtype to verify that the behavior matches JAX."""
 
     FLOAT_DTYPES = [x for x in dtypes.FLOAT_TYPES if x not in ("float64",)]
+    INT_DTYPES = [x for x in dtypes.INT_TYPES if x not in ("uint64", "int64")]
+
+    if backend.backend() == "torch":
+        INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint16", "uint32")]
+    elif backend.backend() == "tensorflow":
+        INT_DTYPES = [x for x in INT_DTYPES if x not in ("uint32",)]
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_elu(self, dtype):
@@ -2897,7 +2913,9 @@ class NNOpsDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
-    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    @parameterized.named_parameters(
+        named_product(dtype=FLOAT_DTYPES + INT_DTYPES)
+    )
     def test_gelu(self, dtype):
         import jax.nn as jnn
         import jax.numpy as jnp


### PR DESCRIPTION
## Description

Fixes #23528.

`keras.ops.gelu` behaved differently on every backend for integer inputs: the NumPy backend silently returned all zeros (the float constants `0.5`, `0.044715` and `sqrt(2/pi)` in the tanh approximation truncate to 0 when cast to an integer dtype), Torch and TensorFlow raised, and JAX promoted to float and computed correct values.

This PR makes all backends match JAX's behavior:

- **numpy, torch, tensorflow, openvino backends**: promote integer inputs to `dtypes.result_type(x.dtype, float)` before computing, using each backend's existing promotion idiom. Float inputs are unaffected (`result_type(float16, float)` is still `float16`).
- **`Gelu.compute_output_spec`**: infer the promoted dtype so the symbolic dtype matches eager execution (previously it claimed `int32` out for `int32` in).
- **Tests**: `NNOpsDtypeTest::test_gelu` now also runs over integer dtypes (following the `INT_DTYPES` convention and per-backend exclusions from `numpy_test.py`), and `NNOpsCorrectnessTest::test_gelu` checks integer inputs for both `approximate` modes.

Verified locally: all gelu tests pass on numpy, jax, torch, tensorflow and openvino; full `keras/src/ops/nn_test.py` and `keras/src/activations` suites show no regressions on any backend; `pre-commit` (ruff, ruff-format) passes and `api_gen.py` produces no changes.

**Disclosure per the AI-Assisted Contribution Policy:** I used an AI coding agent (Claude Code) to help develop this fix. I have reviewed, understood, and tested the change and take full responsibility for it.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
