### PR TITLE
Dampen a singular Hessian before Cholesky in gptq_quantize_matrix

### DIFF
--- a/keras/src/quantizers/gptq.py
+++ b/keras/src/quantizers/gptq.py
@@ -11,6 +11,16 @@ from keras.src.quantizers.quantizers import compute_quantization_parameters
 from keras.src.quantizers.quantizers import dequantize_with_zero_point
 from keras.src.quantizers.quantizers import quantize_with_zero_point
 
+# Relative floor added to the Hessian diagonal before it is factorized. Callers
+# are expected to pass an already-dampened Hessian, but a "dead" feature (a
+# calibration column that is always zero) or plain float underflow can still
+# leave a diagonal entry at (or fractionally below) zero, which makes the
+# Cholesky factorization below fail outright instead of degrading gracefully.
+# Lifting the diagonal by this fraction of its own mean mirrors the reference
+# GPTQ `percdamp` step and keeps the factorization well defined without
+# meaningfully perturbing a Hessian that was already conditioned by the caller.
+CHOLESKY_DIAGONAL_DAMPING = 1e-6
+
 
 def _stable_permutation(metric):
     """Return a stable permutation that sorts `metric` in descending order.
@@ -105,6 +115,17 @@ def gptq_quantize_matrix(
         hessian = ops.take(ops.take(hessian, perm, axis=0), perm, axis=1)
     else:
         perm = inv_perm = None
+
+    # Keep the factorization well defined even if the supplied Hessian is
+    # singular or has underflowed to a non-positive-definite state: lift the
+    # diagonal by a small fraction of its mean (see CHOLESKY_DIAGONAL_DAMPING).
+    diagonal_mean = ops.mean(ops.diagonal(hessian))
+    damping = ops.maximum(
+        ops.multiply(CHOLESKY_DIAGONAL_DAMPING, diagonal_mean),
+        CHOLESKY_DIAGONAL_DAMPING,
+    )
+    identity = ops.eye(in_features, dtype=hessian.dtype)
+    hessian = ops.add(hessian, ops.multiply(damping, identity))
 
     # Reference GPTQ/AutoGPTQ inverse-Hessian factorization. Compute `H^-1`
     # from its lower Cholesky factor using triangular solves (no dense inverse),

--- a/keras/src/quantizers/gptq_test.py
+++ b/keras/src/quantizers/gptq_test.py
@@ -485,13 +485,20 @@ class GPTQTest(testing.TestCase):
         )
 
     def test_inv_hessian_zero_diagonal_stability(self):
-        """Test zero diagonal in inverse Hessian does not crash."""
+        """A singular Hessian must not crash or corrupt the quantized weights.
+
+        A "dead" calibration feature leaves a zero on the Hessian diagonal,
+        which makes the matrix non-positive-definite. `gptq_quantize_matrix`
+        must dampen it back to a factorizable state rather than letting the
+        Cholesky raise or propagate NaNs into later columns (see #23413,
+        #23531).
+        """
         out_features, in_features = 4, 4
         weights = ops.ones((out_features, in_features), dtype="float32")
 
-        inv_hessian = np.eye(in_features, dtype=np.float32)
-        inv_hessian[2, 2] = 0.0  # Zero-diagonal underflow trigger
-        inv_hessian = ops.convert_to_tensor(inv_hessian)
+        hessian = np.eye(in_features, dtype=np.float32)
+        hessian[2, 2] = 0.0  # Dead feature -> singular Hessian.
+        hessian = ops.convert_to_tensor(hessian)
 
         config = GPTQConfig(
             dataset=None, tokenizer=None, weight_bits=4, group_size=-1
@@ -500,14 +507,19 @@ class GPTQTest(testing.TestCase):
 
         quantized, scale, zero, g_idx = gptq_quantize_matrix(
             weights,
-            inv_hessian,
+            hessian,
             blocksize=2,
             group_size=-1,
             compute_scale_zero=quantizer.find_params,
         )
 
-        # All values should be finite and successfully quantized.
-        self.assertFalse(np.isnan(ops.convert_to_numpy(quantized)).any())
+        # Every output is finite: no column is skipped and no NaN/Inf from
+        # the zero-influence feature leaks into the columns after it.
+        quantized = ops.convert_to_numpy(quantized)
+        self.assertTrue(np.isfinite(quantized).all())
+        self.assertTrue(np.isfinite(ops.convert_to_numpy(scale)).all())
+        # Identical input columns must still quantize identically.
+        self.assertTrue((quantized == quantized[:, :1]).all())
 
     def test_find_layers_in_block_includes_layers_with_sub_layers(self):
         """`Dense`/`EinsumDense` are collected even when they own sub-layers.


### PR DESCRIPTION
## Description

### Problem

`gptq_quantize_matrix` factorizes its `hessian` argument directly:

```python
cholesky_lower = linalg.cholesky(hessian)   # keras/src/quantizers/gptq.py
```

If a calibration feature is "dead" (an input column that is always zero), or a
diagonal entry underflows, the Hessian ends up with a zero on its diagonal and
is no longer positive-definite. The Cholesky then fails hard on every trainable
backend:

- **torch:** `linalg.cholesky: The factorization could not be completed because
  the input is not positive-definite (the leading minor of order 3 is not
  positive-definite).`
- **jax:** `Cholesky decomposition failed. The input might not be a valid
  positive definite matrix.`
- **tensorflow:** `Cholesky : Tensor had NaN values [Op:CheckNumerics]`

`GPTQTest::test_inv_hessian_zero_diagonal_stability`, added in #23415, feeds
exactly this kind of matrix, so it has been failing on `master` for jax, torch
and tensorflow since that PR merged. It does not show up on the numpy and
openvino jobs because the whole `GPTQTest` class is `requires_trainable_backend`
and skipped there.

The GPTQ pipeline does dampen the Hessian, but only in the caller
(`GPTQ.quantize_and_correct_layer`). The `gptq_quantize_matrix` primitive itself
does no conditioning, so a singular or underflowed Hessian reaches the
factorization unguarded. This is the robustness gap originally raised in #23413.

### Fix

Before factorizing, lift the Hessian diagonal by a small, floored fraction of
its mean:

```python
damping = max(1e-6 * mean(diag(H)), 1e-6)
H = H + damping * I
```

This mirrors the `percdamp` step in the reference GPTQ implementation. It is
numerically negligible on a Hessian the caller has already dampened, and it is
enough to pull a singular one back to a factorizable state, so the routine
degrades gracefully instead of raising or letting `NaN`/`Inf` from the
zero-influence feature propagate into the columns quantized after it.

The regression test is also tightened: it now checks that every quantized value
and the returned `scale` are finite, and that identical input columns still
quantize identically (in #23413 the columns after the dead feature were
corrupted to `0` / `-2147483648`).

### Testing

Run locally on Linux (WSL), CPU only, Python 3.12, with `tensorflow-cpu`,
`torch` (CPU) and `jax[cpu]`:

- `gptq_test.py::GPTQTest::test_inv_hessian_zero_diagonal_stability` — passes on
  torch, jax and tensorflow (previously failed on all three).
- Full `keras/src/quantizers/gptq_test.py` — jax: 55 passed / 1 skipped;
  tensorflow: 55 passed / 1 skipped; torch: 28 passed / 28 skipped (the skips
  are the pre-existing `skipif(backend == "torch")` cases).
- Full `keras/src/quantizers/` on torch — 267 passed / 28 skipped.
- The reproduction script from #23413 now returns a finite, uncorrupted result.
- `ruff check` and `ruff format --check` are clean.

Fixes #23531. Also addresses the underlying concern in #23413.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
