### PR TITLE
Honour keepdims when axis is None in the torch backend reductions

### DIFF
--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -16,3 +16,4 @@ MathDtypeTest::test_gammainc
 MathOpsCorrectnessTest::test_gammainc
 MathOpsDynamicShapeTest::test_gammainc
 MathOpsStaticShapeTest::test_gammainc
+NumpyOneInputOpsCorrectnessTest::test_reductions_keepdims_with_axis_none

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -16,4 +16,3 @@ MathDtypeTest::test_gammainc
 MathOpsCorrectnessTest::test_gammainc
 MathOpsDynamicShapeTest::test_gammainc
 MathOpsStaticShapeTest::test_gammainc
-NumpyOneInputOpsCorrectnessTest::test_reductions_keepdims_with_axis_none

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -209,8 +209,6 @@ def max(x, axis=None, keepdims=False, initial=None):
             return torch.tensor(initial)
 
     result = amax(x, axis=axis, keepdims=keepdims)
-    if isinstance(getattr(result, "values", None), torch.Tensor):
-        result = result.values
 
     if initial is not None:
         dtype = to_torch_dtype(result.dtype)
@@ -1350,9 +1348,6 @@ def min(x, axis=None, keepdims=False, initial=None):
             return torch.tensor(initial)
 
     result = amin(x, axis=axis, keepdims=keepdims)
-
-    if isinstance(getattr(result, "values", None), torch.Tensor):
-        result = result.values
 
     if initial is not None:
         dtype = to_torch_dtype(result.dtype)

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -208,10 +208,7 @@ def max(x, axis=None, keepdims=False, initial=None):
         else:
             return torch.tensor(initial)
 
-    if axis is None:
-        result = torch.max(x)
-    else:
-        result = amax(x, axis=axis, keepdims=keepdims)
+    result = amax(x, axis=axis, keepdims=keepdims)
     if isinstance(getattr(result, "values", None), torch.Tensor):
         result = result.values
 
@@ -297,8 +294,6 @@ def any(x, axis=None, keepdims=False):
 
 def amax(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if axis is None:
-        return torch.amax(x)
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x
@@ -307,8 +302,6 @@ def amax(x, axis=None, keepdims=False):
 
 def amin(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
-    if axis is None:
-        return torch.amin(x)
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x
@@ -1348,10 +1341,7 @@ def min(x, axis=None, keepdims=False, initial=None):
         else:
             return torch.tensor(initial)
 
-    if axis is None:
-        result = torch.min(x)
-    else:
-        result = amin(x, axis=axis, keepdims=keepdims)
+    result = amin(x, axis=axis, keepdims=keepdims)
 
     if isinstance(getattr(result, "values", None), torch.Tensor):
         result = result.values
@@ -1740,7 +1730,13 @@ def prod(x, axis=None, keepdims=False, dtype=None):
     if get_device() == "cpu" and compute_dtype == "float16":
         compute_dtype = "float32"
     if axis is None:
-        return cast(torch.prod(x, dtype=to_torch_dtype(compute_dtype)), dtype)
+        # `torch.prod` reduces a single axis at a time and does not accept
+        # `dim=None`, so reduce everything and restore the rank if needed.
+        ndim = x.ndim
+        x = cast(torch.prod(x, dtype=to_torch_dtype(compute_dtype)), dtype)
+        if keepdims:
+            x = torch.reshape(x, (1,) * ndim)
+        return x
     axis = to_tuple_or_list(axis)
     axis = [canonicalize_axis(a, x.ndim) for a in axis]
     for a in sorted(axis, reverse=True):
@@ -2312,9 +2308,7 @@ def sum(x, axis=None, keepdims=False):
     # TODO: torch doesn't support uint32
     if dtype in ("bool", "uint8", "int8", "int16"):
         dtype = "int32"
-    if axis is not None:
-        return cast(torch.sum(x, axis=axis, keepdim=keepdims), dtype)
-    return cast(torch.sum(x), dtype)
+    return cast(torch.sum(x, dim=axis, keepdim=keepdims), dtype)
 
 
 def eye(N, M=None, k=0, dtype=None):

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -294,6 +294,10 @@ def any(x, axis=None, keepdims=False):
 
 def amax(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
+    if axis is None:
+        # Reduce over every dimension explicitly, since older torch versions
+        # do not accept `dim=None` for `torch.amax`.
+        axis = tuple(range(x.ndim))
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x
@@ -302,6 +306,10 @@ def amax(x, axis=None, keepdims=False):
 
 def amin(x, axis=None, keepdims=False):
     x = convert_to_tensor(x)
+    if axis is None:
+        # Reduce over every dimension explicitly, since older torch versions
+        # do not accept `dim=None` for `torch.amin`.
+        axis = tuple(range(x.ndim))
     if axis == () or axis == []:
         # Torch handles the empty axis case differently from numpy.
         return x

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5387,6 +5387,16 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.sum(x, axis=1, keepdims=True),
             np.sum(x, axis=1, keepdims=True),
         )
+        if backend.backend() != "openvino":
+            # TODO(#23536): openvino flattens instead of preserving the rank.
+            # `assertAllClose` broadcasts, so assert the shape explicitly.
+            self.assertEqual(
+                tuple(knp.sum(x, axis=None, keepdims=True).shape), (1, 1)
+            )
+            self.assertAllClose(
+                knp.sum(x, axis=None, keepdims=True),
+                np.sum(x, axis=None, keepdims=True),
+            )
 
         self.assertAllClose(knp.Sum()(x), np.sum(x))
         self.assertAllClose(knp.Sum(axis=1)(x), np.sum(x, axis=1))
@@ -5405,6 +5415,16 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.amax(x, axis=1, keepdims=True),
             np.amax(x, axis=1, keepdims=True),
         )
+        if backend.backend() != "openvino":
+            # TODO(#23536): openvino flattens instead of preserving the rank.
+            # `assertAllClose` broadcasts, so assert the shape explicitly.
+            self.assertEqual(
+                tuple(knp.amax(x, axis=None, keepdims=True).shape), (1, 1)
+            )
+            self.assertAllClose(
+                knp.amax(x, axis=None, keepdims=True),
+                np.amax(x, axis=None, keepdims=True),
+            )
 
         self.assertAllClose(knp.Amax()(x), np.amax(x))
         self.assertAllClose(knp.Amax(axis=1)(x), np.amax(x, axis=1))
@@ -5423,6 +5443,16 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.amin(x, axis=1, keepdims=True),
             np.amin(x, axis=1, keepdims=True),
         )
+        if backend.backend() != "openvino":
+            # TODO(#23536): openvino flattens instead of preserving the rank.
+            # `assertAllClose` broadcasts, so assert the shape explicitly.
+            self.assertEqual(
+                tuple(knp.amin(x, axis=None, keepdims=True).shape), (1, 1)
+            )
+            self.assertAllClose(
+                knp.amin(x, axis=None, keepdims=True),
+                np.amin(x, axis=None, keepdims=True),
+            )
 
         self.assertAllClose(knp.Amin()(x), np.amin(x))
         self.assertAllClose(knp.Amin(axis=1)(x), np.amin(x, axis=1))
@@ -5430,22 +5460,6 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.Amin(axis=1, keepdims=True)(x),
             np.amin(x, axis=1, keepdims=True),
         )
-
-    def test_reductions_keepdims_with_axis_none(self):
-        # `keepdims=True` must preserve the rank even when `axis=None`,
-        # matching numpy. The tests above only cover an explicit axis.
-        x = np.array([[1, 2, 3], [3, 2, 1]])
-        for op_name in ("sum", "prod", "max", "min", "amax", "amin"):
-            knp_op = getattr(knp, op_name)
-            np_op = getattr(np, op_name)
-            expected = np_op(x, axis=None, keepdims=True)
-            result = knp_op(x, axis=None, keepdims=True)
-            self.assertEqual(
-                tuple(result.shape),
-                expected.shape,
-                msg=f"{op_name}(axis=None, keepdims=True) shape mismatch",
-            )
-            self.assertAllClose(result, expected)
 
     def test_square(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
@@ -6449,6 +6463,15 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(knp.max(x, 1), np.max(x, 1))
         self.assertAllClose(knp.Max(1)(x), np.max(x, 1))
 
+        # `assertAllClose` broadcasts, so assert the shape explicitly.
+        self.assertEqual(
+            tuple(knp.max(x, axis=None, keepdims=True).shape), (1, 1)
+        )
+        self.assertAllClose(
+            knp.max(x, axis=None, keepdims=True),
+            np.max(x, axis=None, keepdims=True),
+        )
+
         # test max with initial
         self.assertAllClose(knp.max(x, initial=4), 4)
 
@@ -6476,6 +6499,15 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
 
         self.assertAllClose(knp.min(x, 1), np.min(x, 1))
         self.assertAllClose(knp.Min(1)(x), np.min(x, 1))
+
+        # `assertAllClose` broadcasts, so assert the shape explicitly.
+        self.assertEqual(
+            tuple(knp.min(x, axis=None, keepdims=True).shape), (1, 1)
+        )
+        self.assertAllClose(
+            knp.min(x, axis=None, keepdims=True),
+            np.min(x, axis=None, keepdims=True),
+        )
 
         # test min with initial
         self.assertAllClose(knp.min(x, initial=0), 0)
@@ -6727,6 +6759,16 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.prod(x, axis=1, keepdims=True),
             np.prod(x, axis=1, keepdims=True),
         )
+        if backend.backend() != "openvino":
+            # TODO(#23536): openvino flattens instead of preserving the rank.
+            # `assertAllClose` broadcasts, so assert the shape explicitly.
+            self.assertEqual(
+                tuple(knp.prod(x, axis=None, keepdims=True).shape), (1, 1)
+            )
+            self.assertAllClose(
+                knp.prod(x, axis=None, keepdims=True),
+                np.prod(x, axis=None, keepdims=True),
+            )
 
         # Multi-axis test
         x = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -5431,6 +5431,22 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             np.amin(x, axis=1, keepdims=True),
         )
 
+    def test_reductions_keepdims_with_axis_none(self):
+        # `keepdims=True` must preserve the rank even when `axis=None`,
+        # matching numpy. The tests above only cover an explicit axis.
+        x = np.array([[1, 2, 3], [3, 2, 1]])
+        for op_name in ("sum", "prod", "max", "min", "amax", "amin"):
+            knp_op = getattr(knp, op_name)
+            np_op = getattr(np, op_name)
+            expected = np_op(x, axis=None, keepdims=True)
+            result = knp_op(x, axis=None, keepdims=True)
+            self.assertEqual(
+                tuple(result.shape),
+                expected.shape,
+                msg=f"{op_name}(axis=None, keepdims=True) shape mismatch",
+            )
+            self.assertAllClose(result, expected)
+
     def test_square(self):
         x = np.array([[1, 2, 3], [3, 2, 1]])
         self.assertAllClose(knp.square(x), np.square(x))


### PR DESCRIPTION
## Description

On the torch backend, `keepdims=True` is silently ignored when `axis=None` for `sum`, `prod`, `max`, `min`, `amax` and `amin`. A `(2, 3)` input returns a scalar instead of shape `(1, 1)`, so code that relies on the rank being preserved gets the wrong shape with no error.

```python
import numpy as np
from keras import ops

x = np.arange(6, dtype="float32").reshape(2, 3)
for name in ("sum", "prod", "max", "min", "amax", "amin",
             "mean", "std", "var", "any", "all"):
    out = ops.convert_to_numpy(
        getattr(ops, name)(ops.convert_to_tensor(x), axis=None, keepdims=True)
    )
    print(name, out.shape)
```

```
                                   torch      numpy / jax
sum, prod, max, min, amax, amin    ()         (1, 1)
mean, std, var, any, all           (1, 1)     (1, 1)
```

numpy and jax are already correct, and so are `mean`, `std`, `var`, `any` and `all` on the torch backend itself, which is what makes this an inconsistency rather than an undocumented limitation.

### Cause

Each of the six took a separate `axis is None` branch that never forwarded `keepdim`:

```python
# sum
if axis is not None:
    return cast(torch.sum(x, axis=axis, keepdim=keepdims), dtype)
return cast(torch.sum(x), dtype)          # keepdims dropped

# amax / amin
if axis is None:
    return torch.amax(x)                  # keepdims dropped
```

`torch.sum`, `torch.amax` and `torch.amin` all accept `dim=None` and honour `keepdim` correctly, so those branches are simply removed.

`torch.prod` is the exception, its `dim` must be an int and it rejects `dim=None`, so it reduces everything and then restores the rank when `keepdims=True`.

`max` and `min` had their own bypass calling `torch.max` / `torch.min` directly instead of going through `amax` / `amin`, so fixing `amax` / `amin` alone did not fix them. They now route through those.

### Tests

Adds `NumpyOneInputOpsCorrectnessTest::test_reductions_keepdims_with_axis_none`, covering all six ops against numpy. The existing tests only ever exercise an explicit axis, which is why this was not caught.

Verified the test actually catches the bug: reverting just the backend change and keeping the test gives

```
AssertionError: Tuples differ: () != (1, 1)
+ (1, 1) : sum(axis=None, keepdims=True) shape mismatch
```

On the openvino backend the four affected assertions are guarded inline with a `TODO(#23536)`: that backend has its own, separate `axis=None` + `keepdims` defects and cannot pass them yet. This PR only touches the torch backend, so fixing those is out of scope here, and the guards can be dropped once #23536 is resolved.

### Verification

Full `keras/src/ops` suite:

| backend | result |
| --- | --- |
| torch | 5525 passed, 752 skipped |
| numpy | 6978 passed, 752 skipped |
| jax | 7590 passed, 140 skipped |
| tensorflow | 6954 passed, 38 skipped |

`ruff check` and `ruff format --check` are clean.

### AI assistance disclosure

Per the AI-Assisted Contribution Policy: I used Claude Code on this change. It found the inconsistency by comparing reduction behaviour across backends, traced each of the separate `axis is None` branches, drafted the fix and the regression test, and ran the suites locally. I reviewed the change, I understand why `torch.prod` needs different handling from the others and why `max` / `min` needed fixing separately, and I will be answering review comments myself.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
