### PR TITLE
Prevent dependabot from upgrading minimum version of `litert-torch`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,5 @@ updates:
       - dependency-name: "tensorflow-tpu"
       # 2.20.0 is required by our TensorFlow GPU setup (2.21 won't work)
       - dependency-name: "tensorflow[and-cuda]"
+      # 0.9.1 is a minimum version, no need to update as we pick up the latest.
+      - dependency-name: "litert-torch"


### PR DESCRIPTION
We want to prevent PRs like https://github.com/keras-team/keras/pull/23484

We have `litert-torch>=0.9.1` is requirements files. We already automatically pick up the latest version of `litert-torch`. The `>=0.9.1` is here to tell users that it's the minimum version needed. Updating the minimum version needed doesn't make sense, so prevent it.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
