### PR TITLE
Add backend-agnostic lgamma op

### DIFF
--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -60,6 +60,7 @@ from keras.src.ops.math import ifft2 as ifft2
 from keras.src.ops.math import in_top_k as in_top_k
 from keras.src.ops.math import irfft as irfft
 from keras.src.ops.math import istft as istft
+from keras.src.ops.math import lgamma as lgamma
 from keras.src.ops.math import logdet as logdet
 from keras.src.ops.math import logsumexp as logsumexp
 from keras.src.ops.math import rfft as rfft

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -60,6 +60,7 @@ from keras.src.ops.math import ifft2 as ifft2
 from keras.src.ops.math import in_top_k as in_top_k
 from keras.src.ops.math import irfft as irfft
 from keras.src.ops.math import istft as istft
+from keras.src.ops.math import lgamma as lgamma
 from keras.src.ops.math import logdet as logdet
 from keras.src.ops.math import logsumexp as logsumexp
 from keras.src.ops.math import rfft as rfft

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -1,9 +1,11 @@
 """Commonly used math operations not included in NumPy."""
 
 from keras.src import backend
+from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.backend import KerasTensor
 from keras.src.backend import any_symbolic_tensors
+from keras.src.backend import config
 from keras.src.backend.common.dtypes import result_type
 from keras.src.ops.operation import Operation
 from keras.src.ops.operation_utils import broadcast_shapes
@@ -1381,3 +1383,110 @@ def view_as_real(x):
     real_part = backend.numpy.real(x)
     imag_part = backend.numpy.imag(x)
     return backend.numpy.stack((real_part, imag_part), axis=-1)
+
+
+class Lgamma(Operation):
+    def compute_output_spec(self, x):
+        return KerasTensor(shape=x.shape, dtype=result_type(x.dtype, float))
+
+    def call(self, x):
+        return _lgamma(x)
+
+
+@keras_export("keras.ops.lgamma")
+def lgamma(x):
+    """Computes the natural log of the absolute value of the Gamma function.
+
+    `lgamma(x) = log(|Gamma(x)|)`
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        A tensor with the same shape and floating-point dtype as `x`.
+
+    Example:
+
+    >>> x = np.array([1.0, 2.0, 3.0, 4.0])
+    >>> keras.ops.lgamma(x)
+    array([0.       , 0.       , 0.6931472, 1.7917595], dtype=float32)
+    """
+    if any_symbolic_tensors((x,)):
+        return Lgamma().symbolic_call(x)
+    return _lgamma(x)
+
+
+# Lanczos approximation parameters
+_LANCZOS_GAMMA = 7.0
+_BASE_LANCZOS_COEFF = 0.99999999999980993227684700473478
+_LANCZOS_COEFFICIENTS = (
+    676.520368121885098567009190444019,
+    -1259.13921672240287047156078755283,
+    771.3234287776530788486528258894,
+    -176.61502916214059906584551354,
+    12.507343278686904814458936853,
+    -0.13857109526572011689554707,
+    9.984369578019570859563e-6,
+    1.50563273514931155834e-7,
+)
+_PI = 3.14159265358979323846
+
+
+def _lgamma(x):
+    if not config._use_backend_agnostic_ops() and hasattr(
+        backend.math, "lgamma"
+    ):
+        return backend.math.lgamma(x)
+
+    x = backend.convert_to_tensor(x)
+    orig_dtype = x.dtype
+    target_dtype = result_type(orig_dtype, float)
+    compute_dtype = (
+        "float32" if target_dtype in ("float16", "bfloat16") else target_dtype
+    )
+    x = backend.cast(x, compute_dtype)
+
+    # If the input is less than 0.5 use Euler's reflection formula:
+    # gamma(x) = pi / (sin(pi * x) * gamma(1 - x))
+    need_to_reflect = x < 0.5
+    z = ops.where(need_to_reflect, -x, x - 1.0)
+
+    series = ops.cast(_BASE_LANCZOS_COEFF, compute_dtype)
+    for i, coeff in enumerate(_LANCZOS_COEFFICIENTS):
+        series = series + ops.cast(coeff, compute_dtype) / (z + float(i + 1))
+
+    _LANCZOS_GAMMA_PLUS_HALF = _LANCZOS_GAMMA + 0.5
+    _LOG_LANCZOS_GAMMA_PLUS_HALF = ops.cast(
+        ops.log(_LANCZOS_GAMMA_PLUS_HALF), compute_dtype
+    )
+
+    t = z + _LANCZOS_GAMMA_PLUS_HALF
+    log_t = _LOG_LANCZOS_GAMMA_PLUS_HALF + ops.log1p(
+        z / _LANCZOS_GAMMA_PLUS_HALF
+    )
+
+    # log(sqrt(2π)) = (log(2) + log(pi)) / 2
+    log_sqrt_two_pi = ops.cast(
+        (ops.log(2.0) + ops.log(_PI)) / 2.0, compute_dtype
+    )
+    log_y = log_sqrt_two_pi + (z + 0.5 - t / log_t) * log_t + ops.log(series)
+
+    abs_x = ops.abs(x)
+    abs_frac_x = abs_x - ops.floor(abs_x)
+    reduced_frac_x = ops.where(abs_frac_x > 0.5, 1.0 - abs_frac_x, abs_frac_x)
+    reflection_denom = ops.log(ops.sin(_PI * reduced_frac_x))
+
+    reflection = ops.where(
+        ops.isfinite(reflection_denom),
+        ops.cast(ops.log(_PI), compute_dtype) - reflection_denom - log_y,
+        -reflection_denom,
+    )
+    result = ops.where(need_to_reflect, reflection, log_y)
+
+    # Handle +/-inf edge cases: lgamma(+/-inf) = +inf
+    inf_val = ops.cast(float("inf"), compute_dtype)
+    result = ops.where(ops.isinf(x), inf_val, result)
+
+    if compute_dtype != target_dtype:
+        result = backend.cast(result, target_dtype)
+    return result

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -1,5 +1,7 @@
 """Commonly used math operations not included in NumPy."""
 
+import math as python_math
+
 from keras.src import backend
 from keras.src import ops
 from keras.src.api_export import keras_export
@@ -1430,6 +1432,9 @@ _LANCZOS_COEFFICIENTS = (
     1.50563273514931155834e-7,
 )
 _PI = 3.14159265358979323846
+_LOG_SQRT_TWO_PI = (python_math.log(2.0) + python_math.log(_PI)) / 2.0
+_LANCZOS_GAMMA_PLUS_HALF = _LANCZOS_GAMMA + 0.5
+_LOG_LANCZOS_GAMMA_PLUS_HALF = python_math.log(_LANCZOS_GAMMA_PLUS_HALF)
 
 
 def _lgamma(x):
@@ -1448,37 +1453,34 @@ def _lgamma(x):
 
     # If the input is less than 0.5 use Euler's reflection formula:
     # gamma(x) = pi / (sin(pi * x) * gamma(1 - x))
-    need_to_reflect = x < 0.5
+    need_to_reflect = ops.less(x, 0.5)
     z = ops.where(need_to_reflect, -x, x - 1.0)
 
     series = ops.cast(_BASE_LANCZOS_COEFF, compute_dtype)
     for i, coeff in enumerate(_LANCZOS_COEFFICIENTS):
         series = series + ops.cast(coeff, compute_dtype) / (z + float(i + 1))
 
-    _LANCZOS_GAMMA_PLUS_HALF = _LANCZOS_GAMMA + 0.5
-    _LOG_LANCZOS_GAMMA_PLUS_HALF = ops.cast(
-        ops.log(_LANCZOS_GAMMA_PLUS_HALF), compute_dtype
+    lanczos_gamma_plus_half = ops.cast(_LANCZOS_GAMMA_PLUS_HALF, compute_dtype)
+    log_lanczos_gamma_plus_half = ops.cast(
+        _LOG_LANCZOS_GAMMA_PLUS_HALF, compute_dtype
     )
+    pi = ops.cast(_PI, compute_dtype)
+    t = z + lanczos_gamma_plus_half
+    log_t = log_lanczos_gamma_plus_half + ops.log1p(z / lanczos_gamma_plus_half)
 
-    t = z + _LANCZOS_GAMMA_PLUS_HALF
-    log_t = _LOG_LANCZOS_GAMMA_PLUS_HALF + ops.log1p(
-        z / _LANCZOS_GAMMA_PLUS_HALF
-    )
-
-    # log(sqrt(2π)) = (log(2) + log(pi)) / 2
-    log_sqrt_two_pi = ops.cast(
-        (ops.log(2.0) + ops.log(_PI)) / 2.0, compute_dtype
-    )
+    log_sqrt_two_pi = ops.cast(_LOG_SQRT_TWO_PI, compute_dtype)
     log_y = log_sqrt_two_pi + (z + 0.5 - t / log_t) * log_t + ops.log(series)
 
     abs_x = ops.abs(x)
     abs_frac_x = abs_x - ops.floor(abs_x)
-    reduced_frac_x = ops.where(abs_frac_x > 0.5, 1.0 - abs_frac_x, abs_frac_x)
-    reflection_denom = ops.log(ops.sin(_PI * reduced_frac_x))
+    reduced_frac_x = ops.where(
+        ops.greater(abs_frac_x, 0.5), 1.0 - abs_frac_x, abs_frac_x
+    )
+    reflection_denom = ops.log(ops.sin(pi * reduced_frac_x))
 
     reflection = ops.where(
         ops.isfinite(reflection_denom),
-        ops.cast(ops.log(_PI), compute_dtype) - reflection_denom - log_y,
+        ops.cast(ops.log(pi), compute_dtype) - reflection_denom - log_y,
         -reflection_denom,
     )
     result = ops.where(need_to_reflect, reflection, log_y)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 import scipy.signal
+import scipy.special
 from absl.testing import parameterized
 
 from keras.src import backend

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -181,6 +181,11 @@ class MathOpsDynamicShapeTest(testing.TestCase):
         z = kmath.gammainc(x1, x2)
         self.assertEqual(z.shape, (None, 2, 3))
 
+    def test_lgamma(self):
+        x = KerasTensor((None, 2, 3))
+        y = kmath.lgamma(x)
+        self.assertEqual(y.shape, (None, 2, 3))
+
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     def test_segment_reduce(self, segment_reduce_op):
         # 1D case
@@ -402,6 +407,11 @@ class MathOpsStaticShapeTest(testing.TestCase):
 
         z = kmath.gammainc(x1, x2)
         self.assertEqual(z.shape, (1, 2, 3))
+
+    def test_lgamma(self):
+        x = KerasTensor((1, 2, 3))
+        y = kmath.lgamma(x)
+        self.assertEqual(y.shape, (1, 2, 3))
 
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     @pytest.mark.skipif(
@@ -1194,6 +1204,37 @@ class MathOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(out, expected)
         self.assertEqual(out.shape, (2, 2))
 
+    def test_lgamma_operation_basic(self):
+        sample_values = np.array(
+            [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0]
+        )
+        expected_output = scipy.special.gammaln(sample_values)
+        output_from_lgamma_op = kmath.lgamma(sample_values)
+        self.assertAllClose(output_from_lgamma_op, expected_output, atol=1e-4)
+
+    def test_lgamma_operation_dtype(self):
+        for dtype in ("float32", "float64"):
+            sample_values = np.array(
+                [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0],
+                dtype=dtype,
+            )
+            expected_output = scipy.special.gammaln(sample_values)
+            output_from_lgamma_op = kmath.lgamma(sample_values)
+            self.assertAllClose(
+                output_from_lgamma_op, expected_output, atol=1e-4
+            )
+
+    def test_lgamma_operation_edge_cases(self):
+        edge_values = np.array(
+            [-0.5, -1.5, -2.5, 1e-5, 50.0, 100.0, float("inf")],
+            dtype=np.float64,
+        )
+        expected_output = scipy.special.gammaln(edge_values)
+        output_from_edge_lgamma_op = kmath.lgamma(edge_values)
+        self.assertAllClose(
+            output_from_edge_lgamma_op, expected_output, atol=1e-4
+        )
+
 
 class MathDtypeTest(testing.TestCase):
     """Test the floating dtype to verify that the behavior matches JAX."""
@@ -1333,6 +1374,24 @@ class MathDtypeTest(testing.TestCase):
         )
         self.assertEqual(
             standardize_dtype(kmath.Gammainc().symbolic_call(x1, x2).dtype),
+            expected_dtype,
+        )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_lgamma(self, dtype):
+        import jax.lax as lax
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+
+        expected_dtype = standardize_dtype(lax.lgamma(x_jax).dtype)
+
+        self.assertEqual(
+            standardize_dtype(kmath.lgamma(x).dtype), expected_dtype
+        )
+        self.assertEqual(
+            standardize_dtype(kmath.Lgamma().symbolic_call(x).dtype),
             expected_dtype,
         )
 


### PR DESCRIPTION
## Description
This PR adds backend-agnostic `lgamma` op. Note that the `lgamma` op doesn't have backend-specific implementations.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x ] I am a human, and not a bot.
- [x ] I will be responsible for responding to review comments in a timely manner.
- [ x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
