### PR TITLE
Fix gaussian_blur ignoring the default data_format

### DIFF
--- a/keras/src/backend/jax/image.py
+++ b/keras/src/backend/jax/image.py
@@ -705,6 +705,7 @@ def gaussian_blur(
         ]
         return kernel
 
+    data_format = backend.standardize_data_format(data_format)
     images = convert_to_tensor(images)
     dtype = backend.standardize_dtype(images.dtype)
     sigma = convert_to_tensor(sigma, dtype=dtype)

--- a/keras/src/backend/numpy/image.py
+++ b/keras/src/backend/numpy/image.py
@@ -995,6 +995,7 @@ def gaussian_blur(
         kernel = np.tile(kernel, (1, 1, num_channels))
         return kernel.astype(dtype)
 
+    data_format = backend.standardize_data_format(data_format)
     images = convert_to_tensor(images)
     kernel_size = convert_to_tensor(kernel_size)
     sigma = convert_to_tensor(sigma)

--- a/keras/src/backend/tensorflow/image.py
+++ b/keras/src/backend/tensorflow/image.py
@@ -767,6 +767,7 @@ def gaussian_blur(
         kernel = tf.cast(kernel, dtype)
         return kernel
 
+    data_format = backend.standardize_data_format(data_format)
     images = convert_to_tensor(images)
     dtype = backend.standardize_dtype(images.dtype)
     kernel_size = convert_to_tensor(kernel_size, dtype=dtype)

--- a/keras/src/backend/torch/image.py
+++ b/keras/src/backend/torch/image.py
@@ -866,6 +866,7 @@ def gaussian_blur(
         kernel = kernel.view(1, 1, kernel_size[0], kernel_size[1])
         return kernel
 
+    data_format = backend.standardize_data_format(data_format)
     images = convert_to_tensor(images)
     kernel_size = convert_to_tensor(kernel_size)
     sigma = convert_to_tensor(sigma)

--- a/keras/src/ops/image_test.py
+++ b/keras/src/ops/image_test.py
@@ -2519,6 +2519,47 @@ class ImageOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
         self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
 
+    def test_gaussian_blur_default_data_format(self):
+        # Omitting `data_format` must behave exactly like passing the
+        # configured `image_data_format` explicitly.
+        np.random.seed(42)
+        kernel_size = np.array([3, 3])
+        sigma = np.array([1.0, 2.0]).astype("float32")
+
+        # Test channels_last
+        backend.set_image_data_format("channels_last")
+        x = np.random.uniform(size=(20, 20, 3)).astype("float32")
+
+        out = kimage.gaussian_blur(x, kernel_size, sigma)
+        ref_out = gaussian_blur_np(
+            x,
+            kernel_size,
+            sigma,
+            data_format="channels_last",
+        )
+
+        self.assertEqual(tuple(out.shape), (20, 20, 3))
+        self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
+
+        # Test channels_first
+        backend.set_image_data_format("channels_first")
+        x = np.random.uniform(size=(3, 20, 20)).astype("float32")
+
+        out = kimage.gaussian_blur(x, kernel_size, sigma)
+        ref_out = gaussian_blur_np(
+            x,
+            kernel_size,
+            sigma,
+            data_format="channels_first",
+        )
+
+        self.assertEqual(tuple(out.shape), (3, 20, 20))
+        self.assertEqual(tuple(out.shape), tuple(ref_out.shape))
+        self.assertAllClose(out, ref_out, atol=1e-2, rtol=1e-2)
+
+        backend.set_image_data_format("channels_last")
+
     def test_elastic_transform(self):
         # Test channels_last
         backend.set_image_data_format("channels_last")


### PR DESCRIPTION
keras.ops.image.gaussian_blur passes data_format straight through to the backend in the eager path, so the backend receives None whenever the caller does not name a format. The numpy and tensorflow implementations branch on data_format == "channels_first" and the torch and jax implementations branch on data_format == "channels_last", so None always takes the wrong branch on one pair or the other depending on the configured image_data_format.

With the default channels_last configuration, torch and jax skip the permute to NCHW and blur across the batch and height axes instead of height and width. With channels_first configured, numpy and tensorflow make the mirror image mistake. A non-square kernel_size also changes the output shape on torch because the wrong axes get padded.

Resolve data_format at the top of each implementation with standardize_data_format, which is what every other image function in these backends already does and what the openvino implementation of gaussian_blur already did.

The existing tests all passed data_format explicitly, so none of them exercised the default. Add a test that blurs with data_format omitted under both image_data_format settings and compares against the numpy reference.

## Description
<!-- Describe your changes here -->

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
