### PR TITLE
Promote integer inputs to float in hard_sigmoid and hard_silu

### DIFF
--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -114,6 +114,11 @@ def leaky_relu(x, negative_slope=0.2):
 
 
 def hard_sigmoid(x):
+    x = convert_to_tensor(x)
+    # `hard_sigmoid` is a float op. Promote integer and bool inputs the way
+    # the JAX backend already does, otherwise `0.5` below is cast to the
+    # input's integer dtype, truncates to 0, and the offset is lost.
+    x = cast(x, backend.result_type(x.dtype, float))
     # python numbers will be promoted to float64 by np, so it's necessary to
     # first convert the python numbers to np scalars
     x = x / np.array(6.0, x.dtype) + np.array(0.5, x.dtype)
@@ -125,6 +130,8 @@ def hard_sigmoid(x):
 
 
 def hard_silu(x):
+    x = convert_to_tensor(x)
+    x = cast(x, backend.result_type(x.dtype, float))
     return x * hard_sigmoid(x)
 
 

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -129,8 +129,20 @@ def sparse_sigmoid(x):
     return OpenVINOKerasTensor(out.output(0))
 
 
+def _cast_to_float(x):
+    """Promote an integer or bool OpenVINO output to a float element type."""
+    keras_dtype = ov_to_keras_type(x.get_element_type())
+    dtype = backend.result_type(keras_dtype, float)
+    if keras_dtype == dtype:
+        return x
+    return ov_opset.convert(x, OPENVINO_DTYPES[dtype]).output(0)
+
+
 def hard_sigmoid(x):
     x = get_ov_output(x)
+    # `ov_opset.hard_sigmoid` only accepts real element types. Promote
+    # integer and bool inputs the way the JAX backend already does.
+    x = _cast_to_float(x)
     alpha = get_ov_output(1.0 / 6.0, x.get_element_type())
     beta = get_ov_output(0.5, x.get_element_type())
     return OpenVINOKerasTensor(ov_opset.hard_sigmoid(x, alpha, beta).output(0))
@@ -138,6 +150,7 @@ def hard_sigmoid(x):
 
 def hard_silu(x):
     x = get_ov_output(x)
+    x = _cast_to_float(x)
     return OpenVINOKerasTensor(ov_opset.hswish(x).output(0))
 
 

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -108,10 +108,15 @@ def leaky_relu(x, negative_slope=0.2):
 
 def hard_sigmoid(x):
     x = convert_to_tensor(x)
+    # `hard_sigmoid` is a float op. Promote integer and bool inputs the way
+    # the JAX backend already does.
+    x = cast(x, backend.result_type(x.dtype, float))
     return relu6(x + tf.constant(3.0, x.dtype)) / tf.constant(6.0, x.dtype)
 
 
 def hard_silu(x):
+    x = convert_to_tensor(x)
+    x = cast(x, backend.result_type(x.dtype, float))
     return x * hard_sigmoid(x)
 
 

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -104,11 +104,15 @@ def leaky_relu(x, negative_slope=0.2):
 
 def hard_sigmoid(x):
     x = convert_to_tensor(x)
+    # `tnn.hardsigmoid` is not implemented for integer or bool dtypes.
+    # Promote the way the JAX backend already does.
+    x = cast(x, backend.result_type(x.dtype, float))
     return tnn.hardsigmoid(x)
 
 
 def hard_silu(x):
     x = convert_to_tensor(x)
+    x = cast(x, backend.result_type(x.dtype, float))
     return tnn.hardswish(x)
 
 

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -474,7 +474,9 @@ class HardSigmoid(Operation):
         return backend.nn.hard_sigmoid(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        # `hard_sigmoid` promotes integer and bool inputs to float, so the
+        # symbolic dtype has to match what eager execution returns.
+        return KerasTensor(x.shape, dtype=backend.result_type(x.dtype, float))
 
 
 @keras_export(
@@ -514,7 +516,7 @@ class HardSilu(Operation):
         return backend.nn.hard_silu(x)
 
     def compute_output_spec(self, x):
-        return KerasTensor(x.shape, dtype=x.dtype)
+        return KerasTensor(x.shape, dtype=backend.result_type(x.dtype, float))
 
 
 @keras_export(

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -1494,12 +1494,39 @@ class NNOpsCorrectnessTest(testing.TestCase):
             knn.hard_sigmoid(x),
             [0.33333334, 0.5, 0.6666667, 0.8333334, 1.0],
         )
+        # Integer input is promoted to float. Previously the numpy backend
+        # cast `0.5` to the input dtype, truncating it to 0, so the result
+        # was `x / 6` instead of `clip(x / 6 + 0.5, 0, 1)`.
+        x_int = np.array([-1, 0, 1, 2, 3], dtype="int32")
+        self.assertAllClose(
+            knn.hard_sigmoid(x_int),
+            [0.33333334, 0.5, 0.6666667, 0.8333334, 1.0],
+        )
+        self.assertEqual(
+            standardize_dtype(
+                knn.HardSigmoid()
+                .symbolic_call(KerasTensor((5,), "int32"))
+                .dtype
+            ),
+            standardize_dtype(knn.hard_sigmoid(x_int).dtype),
+        )
 
     def test_hard_silu(self):
         x = np.array([-3, -2, -1, 0, 1, 2, 3], dtype=np.float32)
         self.assertAllClose(
             knn.hard_silu(x),
             [-0.0, -0.333333, -0.333333, 0.0, 0.6666667, 1.6666667, 3.0],
+        )
+        x_int = np.array([-3, -2, -1, 0, 1, 2, 3], dtype="int32")
+        self.assertAllClose(
+            knn.hard_silu(x_int),
+            [-0.0, -0.333333, -0.333333, 0.0, 0.6666667, 1.6666667, 3.0],
+        )
+        self.assertEqual(
+            standardize_dtype(
+                knn.HardSilu().symbolic_call(KerasTensor((7,), "int32")).dtype
+            ),
+            standardize_dtype(knn.hard_silu(x_int).dtype),
         )
 
     def test_elu(self):


### PR DESCRIPTION
## Description

Fixes #23544.

`hard_sigmoid` on the numpy backend builds its constants with `np.array(0.5, x.dtype)`, so for an integer dtype the offset truncates to 0 and the op computes `clip(x / 6, 0, 1)` instead of `clip(x / 6 + 0.5, 0, 1)`. Nothing raises and the values still look like activations, which is how it survived: `NNOpsDtypeTest` defines only `FLOAT_DTYPES`, so no test has ever put an integer through it.

`hard_silu` multiplies by `hard_sigmoid` and inherits the same error. The other backends fail differently. `tnn.hardsigmoid` raises `"hardsigmoid_cpu" not implemented for 'Int'`, and `ov_opset.hard_sigmoid` only accepts real element types, while jax promotes and returns the right answer. The same call gives a wrong number on one backend, an exception on two, and the correct result on one.

This promotes integer and bool input to float in the backends that don't, matching what jax already does. Float input is untouched, since `result_type(float16, float)` is still `float16`.

`compute_output_spec` returned `x.dtype`, which disagrees with what jax and tensorflow actually hand back, so a functional model advertised int32 and produced float32. That is fixed here too, otherwise the promotion would trade one inconsistency for another.

Same underlying issue as #23530 and #23574, on different ops.

## Contributor Agreement

**Please review our [PR Contribution Policy](https://github.com/keras-team/keras/issues/23601) and [AI-Assisted Contribution Policy](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ ] This PR is linked to an issue that has been assigned to me (see `Fixes #xxx` above).
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed. PRs without a linked, assigned issue will be converted to draft.
