### PR TITLE
[PLUGGABLE_BACKEND] Remove incorrect exception message matching.

### DIFF
--- a/keras/src/models/model_test.py
+++ b/keras/src/models/model_test.py
@@ -1552,11 +1552,5 @@ class ModelTest(testing.TestCase):
 
         # Bad backend
         if backend.backend() not in ("tensorflow", "jax", "torch"):
-            with self.assertRaisesRegex(
-                NotImplementedError,
-                (
-                    r"`export_saved_model` only currently supports the "
-                    r"tensorflow, jax and torch backends."
-                ),
-            ):
+            with self.assertRaises(NotImplementedError):
                 model.export(temp_filepath, format="tf_saved_model")


### PR DESCRIPTION
The exception comes from here: https://github.com/keras-team/keras/blob/pluggable_backend/keras/src/export/saved_model_export_archive.py#L27-L28

The message matched in the unit tests was incorrect. However, this never came up because this test only runs from trainable backends. PaddlePaddle and MLX are the first trainable backends that do not support saved_model export.

Context: https://github.com/keras-team/keras-paddle/pull/4

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
