### PR TITLE
Add lgamma backend-specific implementations

### DIFF
--- a/keras/src/backend/jax/math.py
+++ b/keras/src/backend/jax/math.py
@@ -320,3 +320,8 @@ def gammainc(x1, x2):
     x1 = convert_to_tensor(x1)
     x2 = convert_to_tensor(x2)
     return jax.scipy.special.gammainc(x1, x2)
+
+
+def lgamma(x):
+    x = convert_to_tensor(x)
+    return jax.scipy.special.gammaln(x)

--- a/keras/src/backend/numpy/math.py
+++ b/keras/src/backend/numpy/math.py
@@ -351,3 +351,9 @@ def gammainc(x1, x2):
     x2 = convert_to_tensor(x2)
     dtype = dtypes.result_type(x1.dtype, x2.dtype, float)
     return scipy.special.gammainc(x1, x2).astype(dtype)
+
+
+def lgamma(x):
+    x = convert_to_tensor(x)
+    dtype = dtypes.result_type(x.dtype, float)
+    return scipy.special.gammaln(x).astype(dtype)

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -346,3 +346,13 @@ def gammainc(x1, x2):
     x2 = cast(x2, compute_dtype)
 
     return cast(tf.math.igamma(x1, x2), dtype)
+
+
+def lgamma(x):
+    x = convert_to_tensor(x)
+    dtype = dtypes.result_type(x.dtype, float)
+    if standardize_dtype(dtype) == "bfloat16":
+        return cast(tf.math.lgamma(cast(x, "float32")), dtype)
+    if not tf.as_dtype(x.dtype).is_floating:
+        x = cast(x, dtype)
+    return tf.math.lgamma(x)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -448,4 +448,9 @@ def gammainc(x1, x2):
 
 def lgamma(x):
     x = convert_to_tensor(x)
-    return torch.lgamma(x)
+    dtype = dtypes.result_type(x.dtype, float)
+    compute_dtype = dtype
+    if standardize_dtype(dtype) in ("float16", "bfloat16"):
+        compute_dtype = "float32"
+    x = cast(x, compute_dtype)
+    return cast(torch.lgamma(x), dtype)

--- a/keras/src/backend/torch/math.py
+++ b/keras/src/backend/torch/math.py
@@ -444,3 +444,8 @@ def gammainc(x1, x2):
     x1 = cast(x1, compute_dtype)
     x2 = cast(x2, compute_dtype)
     return cast(torch.special.gammainc(x1, x2), dtype)
+
+
+def lgamma(x):
+    x = convert_to_tensor(x)
+    return torch.lgamma(x)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1223,21 +1223,6 @@ class MathOpsCorrectnessTest(testing.TestCase):
         self.assertEqual(out.shape, (2, 2))
 
     @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
-    def test_lgamma_operation_basic(self, backend_agnostic_ops):
-        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
-        try:
-            sample_values = np.array(
-                [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0]
-            )
-            expected_output = scipy.special.gammaln(sample_values)
-            output_from_lgamma_op = kmath.lgamma(sample_values)
-            self.assertAllClose(
-                output_from_lgamma_op, expected_output, atol=1e-4
-            )
-        finally:
-            backend.config._set_use_backend_agnostic_ops(False)
-
-    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
     def test_lgamma_operation_dtype(self, backend_agnostic_ops):
         backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
         try:
@@ -1266,6 +1251,21 @@ class MathOpsCorrectnessTest(testing.TestCase):
             output_from_edge_lgamma_op = kmath.lgamma(edge_values)
             self.assertAllClose(
                 output_from_edge_lgamma_op, expected_output, atol=1e-4
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
+
+    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
+    def test_lgamma_operation_basic(self, backend_agnostic_ops):
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
+        try:
+            sample_values = np.array(
+                [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0]
+            )
+            expected_output = scipy.special.gammaln(sample_values)
+            output_from_lgamma_op = kmath.lgamma(sample_values)
+            self.assertAllClose(
+                output_from_lgamma_op, expected_output, atol=1e-4
             )
         finally:
             backend.config._set_use_backend_agnostic_ops(False)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -557,6 +557,12 @@ class MathOpsStaticShapeTest(testing.TestCase):
         self.assertEqual(out.shape, (2, 4))
 
 
+BACKEND_AGNOSTIC_OPS = [
+    {"testcase_name": "backend_specific", "backend_agnostic_ops": False},
+    {"testcase_name": "backend_agnostic", "backend_agnostic_ops": True},
+]
+
+
 class MathOpsCorrectnessTest(testing.TestCase):
     def run_segment_reduce_test(
         self,
@@ -1216,39 +1222,9 @@ class MathOpsCorrectnessTest(testing.TestCase):
         self.assertAllClose(out, expected)
         self.assertEqual(out.shape, (2, 2))
 
-    def test_lgamma_operation_basic(self):
-        sample_values = np.array(
-            [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0]
-        )
-        expected_output = scipy.special.gammaln(sample_values)
-        output_from_lgamma_op = kmath.lgamma(sample_values)
-        self.assertAllClose(output_from_lgamma_op, expected_output, atol=1e-4)
-
-    def test_lgamma_operation_dtype(self):
-        for dtype in ("float32", "float64"):
-            sample_values = np.array(
-                [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0],
-                dtype=dtype,
-            )
-            expected_output = scipy.special.gammaln(sample_values)
-            output_from_lgamma_op = kmath.lgamma(sample_values)
-            self.assertAllClose(
-                output_from_lgamma_op, expected_output, atol=1e-4
-            )
-
-    def test_lgamma_operation_edge_cases(self):
-        edge_values = np.array(
-            [-0.5, -1.5, -2.5, 1e-5, 50.0, 100.0, float("inf")],
-            dtype=np.float64,
-        )
-        expected_output = scipy.special.gammaln(edge_values)
-        output_from_edge_lgamma_op = kmath.lgamma(edge_values)
-        self.assertAllClose(
-            output_from_edge_lgamma_op, expected_output, atol=1e-4
-        )
-
-    def test_lgamma_backend_agnostic_basic(self):
-        backend.config._set_use_backend_agnostic_ops(True)
+    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
+    def test_lgamma_operation_basic(self, backend_agnostic_ops):
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
         try:
             sample_values = np.array(
                 [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0]
@@ -1261,8 +1237,9 @@ class MathOpsCorrectnessTest(testing.TestCase):
         finally:
             backend.config._set_use_backend_agnostic_ops(False)
 
-    def test_lgamma_backend_agnostic_dtype(self):
-        backend.config._set_use_backend_agnostic_ops(True)
+    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
+    def test_lgamma_operation_dtype(self, backend_agnostic_ops):
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
         try:
             for dtype in ("float32", "float64"):
                 sample_values = np.array(
@@ -1277,15 +1254,15 @@ class MathOpsCorrectnessTest(testing.TestCase):
         finally:
             backend.config._set_use_backend_agnostic_ops(False)
 
-    def test_lgamma_backend_agnostic_edge_cases(self):
-        edge_values = np.array(
-            [-0.5, -1.5, -2.5, 1e-5, 50.0, 100.0, float("inf")],
-            dtype=np.float64,
-        )
-        expected_output = scipy.special.gammaln(edge_values)
-
-        backend.config._set_use_backend_agnostic_ops(True)
+    @parameterized.named_parameters(named_product(BACKEND_AGNOSTIC_OPS))
+    def test_lgamma_operation_edge_cases(self, backend_agnostic_ops):
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
         try:
+            edge_values = np.array(
+                [-0.5, -1.5, -2.5, 1e-5, 50.0, 100.0, float("inf")],
+                dtype=np.float64,
+            )
+            expected_output = scipy.special.gammaln(edge_values)
             output_from_edge_lgamma_op = kmath.lgamma(edge_values)
             self.assertAllClose(
                 output_from_edge_lgamma_op, expected_output, atol=1e-4
@@ -1435,8 +1412,10 @@ class MathDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
-    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
-    def test_lgamma(self, dtype):
+    @parameterized.named_parameters(
+        named_product(BACKEND_AGNOSTIC_OPS, dtype=FLOAT_DTYPES)
+    )
+    def test_lgamma(self, backend_agnostic_ops, dtype):
         import jax.lax as lax
         import jax.numpy as jnp
 
@@ -1445,28 +1424,14 @@ class MathDtypeTest(testing.TestCase):
 
         expected_dtype = standardize_dtype(lax.lgamma(x_jax).dtype)
 
-        self.assertEqual(
-            standardize_dtype(kmath.lgamma(x).dtype), expected_dtype
-        )
-        self.assertEqual(
-            standardize_dtype(kmath.Lgamma().symbolic_call(x).dtype),
-            expected_dtype,
-        )
-
-    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
-    def test_lgamma_backend_agnostic(self, dtype):
-        import jax.lax as lax
-        import jax.numpy as jnp
-
-        x = knp.ones((1,), dtype=dtype)
-        x_jax = jnp.ones((1,), dtype=dtype)
-
-        expected_dtype = standardize_dtype(lax.lgamma(x_jax).dtype)
-
-        backend.config._set_use_backend_agnostic_ops(True)
+        backend.config._set_use_backend_agnostic_ops(backend_agnostic_ops)
         try:
             self.assertEqual(
                 standardize_dtype(kmath.lgamma(x).dtype), expected_dtype
+            )
+            self.assertEqual(
+                standardize_dtype(kmath.Lgamma().symbolic_call(x).dtype),
+                expected_dtype,
             )
         finally:
             backend.config._set_use_backend_agnostic_ops(False)

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -187,15 +187,6 @@ class MathOpsDynamicShapeTest(testing.TestCase):
         y = kmath.lgamma(x)
         self.assertEqual(y.shape, (None, 2, 3))
 
-    def test_lgamma_backend_agnostic(self):
-        backend.config._set_use_backend_agnostic_ops(True)
-        try:
-            x = KerasTensor((None, 2, 3))
-            y = kmath.lgamma(x)
-            self.assertEqual(y.shape, (None, 2, 3))
-        finally:
-            backend.config._set_use_backend_agnostic_ops(False)
-
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     def test_segment_reduce(self, segment_reduce_op):
         # 1D case
@@ -422,15 +413,6 @@ class MathOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((1, 2, 3))
         y = kmath.lgamma(x)
         self.assertEqual(y.shape, (1, 2, 3))
-
-    def test_lgamma_backend_agnostic(self):
-        backend.config._set_use_backend_agnostic_ops(True)
-        try:
-            x = KerasTensor((1, 2, 3))
-            y = kmath.lgamma(x)
-            self.assertEqual(y.shape, (1, 2, 3))
-        finally:
-            backend.config._set_use_backend_agnostic_ops(False)
 
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     @pytest.mark.skipif(

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -1308,32 +1308,6 @@ class MathOpsCorrectnessTest(testing.TestCase):
             self.assertAllClose(
                 output_from_edge_lgamma_op, expected_output, atol=1e-4
             )
-
-            # Negative infinity: lgamma(+/-inf) = +inf
-            neg_inf = np.array([-float("inf")], dtype=np.float64)
-            output_neg_inf = kmath.lgamma(neg_inf)
-            self.assertAllClose(output_neg_inf, [float("inf")])
-
-            # Non-positive integer poles: lgamma(0) = lgamma(-1) = ... = inf
-            poles = np.array([0.0, -1.0, -2.0], dtype=np.float64)
-            output_poles = kmath.lgamma(poles)
-            self.assertAllClose(
-                output_poles, [float("inf"), float("inf"), float("inf")]
-            )
-        finally:
-            backend.config._set_use_backend_agnostic_ops(False)
-
-    def test_lgamma_backend_agnostic_multidimensional(self):
-        sample_values = np.array(
-            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32"
-        )
-        expected_output = scipy.special.gammaln(sample_values)
-
-        backend.config._set_use_backend_agnostic_ops(True)
-        try:
-            agnostic_output = kmath.lgamma(sample_values)
-            self.assertAllClose(agnostic_output, expected_output, atol=1e-4)
-            self.assertEqual(agnostic_output.shape, (2, 3))
         finally:
             backend.config._set_use_backend_agnostic_ops(False)
 

--- a/keras/src/ops/math_test.py
+++ b/keras/src/ops/math_test.py
@@ -187,6 +187,15 @@ class MathOpsDynamicShapeTest(testing.TestCase):
         y = kmath.lgamma(x)
         self.assertEqual(y.shape, (None, 2, 3))
 
+    def test_lgamma_backend_agnostic(self):
+        backend.config._set_use_backend_agnostic_ops(True)
+        try:
+            x = KerasTensor((None, 2, 3))
+            y = kmath.lgamma(x)
+            self.assertEqual(y.shape, (None, 2, 3))
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
+
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     def test_segment_reduce(self, segment_reduce_op):
         # 1D case
@@ -413,6 +422,15 @@ class MathOpsStaticShapeTest(testing.TestCase):
         x = KerasTensor((1, 2, 3))
         y = kmath.lgamma(x)
         self.assertEqual(y.shape, (1, 2, 3))
+
+    def test_lgamma_backend_agnostic(self):
+        backend.config._set_use_backend_agnostic_ops(True)
+        try:
+            x = KerasTensor((1, 2, 3))
+            y = kmath.lgamma(x)
+            self.assertEqual(y.shape, (1, 2, 3))
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     @parameterized.parameters([(kmath.segment_sum,), (kmath.segment_max,)])
     @pytest.mark.skipif(
@@ -1247,6 +1265,78 @@ class MathOpsCorrectnessTest(testing.TestCase):
             output_from_edge_lgamma_op, expected_output, atol=1e-4
         )
 
+    def test_lgamma_backend_agnostic_basic(self):
+        backend.config._set_use_backend_agnostic_ops(True)
+        try:
+            sample_values = np.array(
+                [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0]
+            )
+            expected_output = scipy.special.gammaln(sample_values)
+            output_from_lgamma_op = kmath.lgamma(sample_values)
+            self.assertAllClose(
+                output_from_lgamma_op, expected_output, atol=1e-4
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
+
+    def test_lgamma_backend_agnostic_dtype(self):
+        backend.config._set_use_backend_agnostic_ops(True)
+        try:
+            for dtype in ("float32", "float64"):
+                sample_values = np.array(
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 0.5, 1.5, 2.5, 3.5, 10.0],
+                    dtype=dtype,
+                )
+                expected_output = scipy.special.gammaln(sample_values)
+                output_from_lgamma_op = kmath.lgamma(sample_values)
+                self.assertAllClose(
+                    output_from_lgamma_op, expected_output, atol=1e-4
+                )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
+
+    def test_lgamma_backend_agnostic_edge_cases(self):
+        edge_values = np.array(
+            [-0.5, -1.5, -2.5, 1e-5, 50.0, 100.0, float("inf")],
+            dtype=np.float64,
+        )
+        expected_output = scipy.special.gammaln(edge_values)
+
+        backend.config._set_use_backend_agnostic_ops(True)
+        try:
+            output_from_edge_lgamma_op = kmath.lgamma(edge_values)
+            self.assertAllClose(
+                output_from_edge_lgamma_op, expected_output, atol=1e-4
+            )
+
+            # Negative infinity: lgamma(+/-inf) = +inf
+            neg_inf = np.array([-float("inf")], dtype=np.float64)
+            output_neg_inf = kmath.lgamma(neg_inf)
+            self.assertAllClose(output_neg_inf, [float("inf")])
+
+            # Non-positive integer poles: lgamma(0) = lgamma(-1) = ... = inf
+            poles = np.array([0.0, -1.0, -2.0], dtype=np.float64)
+            output_poles = kmath.lgamma(poles)
+            self.assertAllClose(
+                output_poles, [float("inf"), float("inf"), float("inf")]
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
+
+    def test_lgamma_backend_agnostic_multidimensional(self):
+        sample_values = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="float32"
+        )
+        expected_output = scipy.special.gammaln(sample_values)
+
+        backend.config._set_use_backend_agnostic_ops(True)
+        try:
+            agnostic_output = kmath.lgamma(sample_values)
+            self.assertAllClose(agnostic_output, expected_output, atol=1e-4)
+            self.assertEqual(agnostic_output.shape, (2, 3))
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
+
 
 class MathDtypeTest(testing.TestCase):
     """Test the floating dtype to verify that the behavior matches JAX."""
@@ -1406,6 +1496,24 @@ class MathDtypeTest(testing.TestCase):
             standardize_dtype(kmath.Lgamma().symbolic_call(x).dtype),
             expected_dtype,
         )
+
+    @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
+    def test_lgamma_backend_agnostic(self, dtype):
+        import jax.lax as lax
+        import jax.numpy as jnp
+
+        x = knp.ones((1,), dtype=dtype)
+        x_jax = jnp.ones((1,), dtype=dtype)
+
+        expected_dtype = standardize_dtype(lax.lgamma(x_jax).dtype)
+
+        backend.config._set_use_backend_agnostic_ops(True)
+        try:
+            self.assertEqual(
+                standardize_dtype(kmath.lgamma(x).dtype), expected_dtype
+            )
+        finally:
+            backend.config._set_use_backend_agnostic_ops(False)
 
     @parameterized.named_parameters(named_product(dtype=FLOAT_DTYPES))
     def test_logsumexp(self, dtype):


### PR DESCRIPTION
## Description
This PR adds backend-specific implementations of `lgamma` op for JAX, TF, PyTorch and Numpy. OpenVino will continue using the backend-agnostic implementation.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [ x] I am a human, and not a bot.
- [ x] I will be responsible for responding to review comments in a timely manner.
- [ x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
