### PR TITLE
Add MeanSquaredError config round-trip test

### DIFF
--- a/keras/src/metrics/regression_metrics_test.py
+++ b/keras/src/metrics/regression_metrics_test.py
@@ -7,8 +7,14 @@ from keras.src.metrics import regression_metrics as metrics
 
 class MeanSquaredErrorTest(testing.TestCase):
     def test_config(self):
-        # TODO
-        pass
+        mse_obj = metrics.MeanSquaredError(name="my_mse", dtype="int32")
+        self.assertEqual(mse_obj.name, "my_mse")
+        self.assertEqual(mse_obj._dtype, "int32")
+
+        # Check save and restore config
+        mse_obj2 = metrics.MeanSquaredError.from_config(mse_obj.get_config())
+        self.assertEqual(mse_obj2.name, "my_mse")
+        self.assertEqual(mse_obj2._dtype, "int32")
 
     def test_unweighted(self):
         mse_obj = metrics.MeanSquaredError()

--- a/keras/src/metrics/regression_metrics_test.py
+++ b/keras/src/metrics/regression_metrics_test.py
@@ -9,12 +9,12 @@ class MeanSquaredErrorTest(testing.TestCase):
     def test_config(self):
         mse_obj = metrics.MeanSquaredError(name="my_mse", dtype="int32")
         self.assertEqual(mse_obj.name, "my_mse")
-        self.assertEqual(mse_obj._dtype, "int32")
+        self.assertEqual(mse_obj.dtype, "int32")
 
         # Check save and restore config
         mse_obj2 = metrics.MeanSquaredError.from_config(mse_obj.get_config())
         self.assertEqual(mse_obj2.name, "my_mse")
-        self.assertEqual(mse_obj2._dtype, "int32")
+        self.assertEqual(mse_obj2.dtype, "int32")
 
     def test_unweighted(self):
         mse_obj = metrics.MeanSquaredError()


### PR DESCRIPTION
## Description

Replace the empty `MeanSquaredError.test_config` placeholder with configuration assertions and a serialization round-trip test.

This is an AI-assisted contribution. I reviewed the change, understand it, and accept responsibility for it. Automated tests and formatting checks were run locally.

Verification:

- `MeanSquaredErrorTest`: 3 passed with the Torch backend.
- Ruff 0.9.2 lint and format checks passed.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
