### PR TITLE
Fix division by zero NaN in categorical_crossentropy

### DIFF
--- a/keras/src/backend/jax/nn.py
+++ b/keras/src/backend/jax/nn.py
@@ -29,6 +29,7 @@ from keras.src.backend.common.backend_utils import (
 )
 from keras.src.backend.jax.core import cast
 from keras.src.backend.jax.core import convert_to_tensor
+from keras.src.backend.jax.numpy import divide_no_nan
 
 
 def relu(x):
@@ -982,8 +983,9 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         log_prob = jax.nn.log_softmax(output, axis=axis)
     else:
-        output = output / jnp.sum(output, axis, keepdims=True)
-        output = jnp.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
+        epsilon_ = convert_to_tensor(backend.epsilon(), dtype=output.dtype)
+        output = divide_no_nan(output, jnp.sum(output, axis, keepdims=True))
+        output = jnp.clip(output, epsilon_, 1.0 - epsilon_)
         log_prob = jnp.log(output)
     return -jnp.sum(target * log_prob, axis=axis)
 
@@ -1009,8 +1011,9 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         log_prob = jax.nn.log_softmax(output, axis=axis)
     else:
-        output = output / jnp.sum(output, axis, keepdims=True)
-        output = jnp.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
+        epsilon_ = convert_to_tensor(backend.epsilon(), dtype=output.dtype)
+        output = divide_no_nan(output, jnp.sum(output, axis, keepdims=True))
+        output = jnp.clip(output, epsilon_, 1.0 - epsilon_)
         log_prob = jnp.log(output)
     target = jnn.one_hot(target, output.shape[axis], axis=axis)
     return -jnp.sum(target * log_prob, axis=axis)

--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -877,8 +877,12 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         log_prob = log_softmax(output, axis=axis)
     else:
-        output = output / np.sum(output, axis, keepdims=True)
-        output = np.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
+        epsilon_ = convert_to_tensor(backend.epsilon(), dtype=output.dtype)
+
+        output = output / np.maximum(
+            np.sum(output, axis, keepdims=True), epsilon_
+        )
+        output = np.clip(output, epsilon_, 1.0 - epsilon_)
         log_prob = np.log(output)
     return -np.sum(target * log_prob, axis=axis)
 
@@ -904,8 +908,12 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         log_prob = log_softmax(output, axis=axis)
     else:
-        output = output / np.sum(output, axis, keepdims=True)
-        output = np.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
+        epsilon_ = convert_to_tensor(backend.epsilon(), dtype=output.dtype)
+
+        output = output / np.maximum(
+            np.sum(output, axis, keepdims=True), epsilon_
+        )
+        output = np.clip(output, epsilon_, 1.0 - epsilon_)
         log_prob = np.log(output)
     target = one_hot(target, output.shape[axis], axis=axis)
     return -np.sum(target * log_prob, axis=axis)

--- a/keras/src/backend/openvino/nn.py
+++ b/keras/src/backend/openvino/nn.py
@@ -802,11 +802,19 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         log_prob = ov_opset.log_softmax(output, axis).output(0)
     else:
+        output_type = output.get_element_type()
         sum_result = ov_opset.reduce_sum(output, axis, keep_dims=True).output(0)
-        output = ov_opset.divide(output, sum_result).output(0)
-        output = ov_opset.clamp(
-            output, min_value=backend.epsilon(), max_value=1 - backend.epsilon()
+        epsilon_node = ov_opset.constant(
+            backend.epsilon(), dtype=output_type
         ).output(0)
+        sum_result = ov_opset.maximum(sum_result, epsilon_node).output(0)
+        output = ov_opset.divide(output, sum_result).output(0)
+
+        one_minus_epsilon_node = ov_opset.constant(
+            1.0 - backend.epsilon(), dtype=output_type
+        ).output(0)
+        output = ov_opset.maximum(output, epsilon_node).output(0)
+        output = ov_opset.minimum(output, one_minus_epsilon_node).output(0)
         log_prob = ov_opset.log(output).output(0)
     result = ov_opset.multiply(target, log_prob).output(0)
     loss = ov_opset.reduce_sum(result, axis).output(0)
@@ -844,11 +852,19 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         log_prob = ov_opset.log_softmax(output, axis).output(0)
     else:
-        sum = ov_opset.reduce_sum(output, axis, keep_dims=True).output(0)
-        output = ov_opset.divide(output, sum).output(0)
-        output = ov_opset.clamp(
-            output, min_value=backend.epsilon(), max_value=1 - backend.epsilon()
+        output_type = output.get_element_type()
+        sum_result = ov_opset.reduce_sum(output, axis, keep_dims=True).output(0)
+        epsilon_node = ov_opset.constant(
+            backend.epsilon(), dtype=output_type
         ).output(0)
+        sum_result = ov_opset.maximum(sum_result, epsilon_node).output(0)
+        output = ov_opset.divide(output, sum_result).output(0)
+
+        one_minus_epsilon_node = ov_opset.constant(
+            1.0 - backend.epsilon(), dtype=output_type
+        ).output(0)
+        output = ov_opset.maximum(output, epsilon_node).output(0)
+        output = ov_opset.minimum(output, one_minus_epsilon_node).output(0)
         log_prob = ov_opset.log(output).output(0)
 
     output_type = output.get_element_type()
@@ -894,9 +910,16 @@ def binary_crossentropy(target, output, from_logits=False):
         ).output(0)
         return OpenVINOKerasTensor(bce)
 
-    output = ov_opset.clamp(
-        output, min_value=backend.epsilon(), max_value=1 - backend.epsilon()
+    output_type = output.get_element_type()
+    epsilon_node = ov_opset.constant(
+        backend.epsilon(), dtype=output_type
     ).output(0)
+    one_minus_epsilon_node = ov_opset.constant(
+        1.0 - backend.epsilon(), dtype=output_type
+    ).output(0)
+    output = ov_opset.maximum(output, epsilon_node).output(0)
+    output = ov_opset.minimum(output, one_minus_epsilon_node).output(0)
+
     one = ov_opset.constant(1, target.get_element_type()).output(0)
 
     minus_output = ov_opset.subtract(one, output).output(0)

--- a/keras/src/backend/tensorflow/nn.py
+++ b/keras/src/backend/tensorflow/nn.py
@@ -1444,12 +1444,13 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
     # each class for every sample adds up to 1
     # This is needed to ensure that the cross entropy is
     # computed correctly.
-    output = output / tf.reduce_sum(output, axis, keepdims=True)
+    epsilon_ = convert_to_tensor(backend.epsilon(), dtype=output.dtype)
 
-    # Compute cross entropy from probabilities.
-    output = tf.clip_by_value(
-        output, backend.epsilon(), 1.0 - backend.epsilon()
+    output = output / tf.maximum(
+        tf.reduce_sum(output, axis, keepdims=True), epsilon_
     )
+
+    output = tf.clip_by_value(output, epsilon_, 1.0 - epsilon_)
     return -tf.reduce_sum(target * tf.math.log(output), axis)
 
 
@@ -1505,9 +1506,9 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
             )
 
     if not from_logits:
-        output = tf.clip_by_value(
-            output, backend.epsilon(), 1 - backend.epsilon()
-        )
+        epsilon_ = convert_to_tensor(backend.epsilon(), dtype=output.dtype)
+
+        output = tf.clip_by_value(output, epsilon_, 1.0 - epsilon_)
         output = tf.math.log(output)
 
     result = tf.nn.sparse_softmax_cross_entropy_with_logits(

--- a/keras/src/backend/torch/nn.py
+++ b/keras/src/backend/torch/nn.py
@@ -927,8 +927,15 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         log_prob = tnn.log_softmax(output, dim=axis)
     else:
-        output = output / torch.sum(output, dim=axis, keepdim=True)
-        output = torch.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
+        epsilon_ = torch.tensor(
+            backend.epsilon(), dtype=output.dtype, device=output.device
+        )
+
+        output = output / torch.maximum(
+            torch.sum(output, dim=axis, keepdim=True),
+            epsilon_,
+        )
+        output = torch.clip(output, epsilon_, 1.0 - epsilon_)
         log_prob = torch.log(output)
     return -torch.sum(target * log_prob, dim=axis)
 
@@ -972,8 +979,14 @@ def sparse_categorical_crossentropy(target, output, from_logits=False, axis=-1):
     if from_logits:
         result = tnn.cross_entropy(output, target, reduction="none")
     else:
-        output = output / torch.sum(output, dim=1, keepdim=True)
-        output = torch.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
+        epsilon_ = torch.tensor(
+            backend.epsilon(), dtype=output.dtype, device=output.device
+        )
+
+        output = output / torch.maximum(
+            torch.sum(output, dim=1, keepdim=True), epsilon_
+        )
+        output = torch.clip(output, epsilon_, 1.0 - epsilon_)
         log_prob = torch.log(output)
         result = tnn.nll_loss(log_prob, target, reduction="none")
 

--- a/keras/src/legacy/backend.py
+++ b/keras/src/legacy/backend.py
@@ -342,10 +342,10 @@ def categorical_crossentropy(target, output, from_logits=False, axis=-1):
     # each class for every sample adds up to 1
     # This is needed to ensure that the cross entropy is
     # computed correctly.
-    output = output / tf.reduce_sum(output, axis, True)
+    epsilon_ = tf.convert_to_tensor(backend.epsilon(), output.dtype)
+    output = output / tf.maximum(tf.reduce_sum(output, axis, True), epsilon_)
 
     # Compute cross entropy from probabilities.
-    epsilon_ = tf.convert_to_tensor(backend.epsilon(), output.dtype)
     output = tf.clip_by_value(output, epsilon_, 1.0 - epsilon_)
     return -tf.reduce_sum(target * tf.math.log(output), axis)
 
@@ -371,9 +371,10 @@ def categorical_focal_crossentropy(
     # each class for every sample adds up to 1
     # This is needed to ensure that the cross entropy is
     # computed correctly.
-    output = output / tf.reduce_sum(output, axis=axis, keepdims=True)
-
     epsilon_ = tf.convert_to_tensor(backend.epsilon(), output.dtype)
+    output = output / tf.maximum(
+        tf.reduce_sum(output, axis=axis, keepdims=True), epsilon_
+    )
     output = tf.clip_by_value(output, epsilon_, 1.0 - epsilon_)
 
     # Calculate cross entropy

--- a/keras/src/losses/losses.py
+++ b/keras/src/losses/losses.py
@@ -2291,7 +2291,9 @@ def categorical_focal_crossentropy(
     # each class for every sample adds up to 1
     # This is needed to ensure that the cross entropy is
     # computed correctly.
-    output = y_pred / ops.sum(y_pred, axis=axis, keepdims=True)
+    output = y_pred / ops.maximum(
+        ops.sum(y_pred, axis=axis, keepdims=True), backend.epsilon()
+    )
     output = ops.clip(output, backend.epsilon(), 1.0 - backend.epsilon())
 
     # Calculate cross entropy

--- a/keras/src/losses/losses_test.py
+++ b/keras/src/losses/losses_test.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from keras.src import backend
+from keras.src import ops
 from keras.src import testing
 from keras.src.losses import losses
 
@@ -1115,6 +1116,17 @@ class CategoricalCrossentropyTest(testing.TestCase):
         self.run_class_serialization_test(
             losses.CategoricalCrossentropy(name="cce", axis=-1)
         )
+
+    def test_no_nan_when_zero_predictions(self):
+        target = np.array([[1.0, 0.0, 0.0]])
+
+        output_float16 = np.array([[0.0, 0.0, 0.0]], dtype=np.float16)
+        loss_float16 = losses.categorical_crossentropy(target, output_float16)
+        self.assertFalse(np.any(np.isnan(ops.convert_to_numpy(loss_float16))))
+
+        output_float32 = np.array([[0.0, 0.0, 0.0]], dtype=np.float32)
+        loss_float32 = losses.categorical_crossentropy(target, output_float32)
+        self.assertFalse(np.any(np.isnan(ops.convert_to_numpy(loss_float32))))
 
     def test_all_correct_unweighted(self):
         y_true = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype="int64")


### PR DESCRIPTION
This PR fixes the zero-day division by zero NaN vulnerability described in #23551. 

By adding `backend.epsilon()` to the denominator when normalizing predictions across all backends (Legacy, TF, Torch, JAX, NumPy, OpenVINO), we prevent catastrophic gradient poisoning when predictions sum to exactly zero.

This issue was originally identified and patched in TensorFlow (https://github.com/tensorflow/tensorflow/pull/123494) and is being ported upstream here per the maintainers' request.

Fixes #23551

## Contributor Agreement
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
