### PR TITLE
Fix PyTorch multiprocessing segmentation fault by using spawn context

### DIFF
--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -392,26 +392,21 @@ _FORCE_THREADPOOL = False
 _MP_CONTEXT = None
 
 
-def reset_mp_state():
-    global _SEQUENCE_COUNTER
-    global _WORKER_ID_QUEUE
-    global _SHARED_SEQUENCES
-    global _MP_CONTEXT
-    _SEQUENCE_COUNTER = None
-    _WORKER_ID_QUEUE = None
-    _SHARED_SEQUENCES = {}
-    _MP_CONTEXT = None
-
-
 def _get_mp_context():
     global _MP_CONTEXT
+    if _MP_CONTEXT is not None:
+        return _MP_CONTEXT
+
     from keras.src.backend import backend
 
+    mp_module = multiprocessing
     use_spawn = False
     if backend() == "torch":
         import torch
+        import torch.multiprocessing as torch_mp
 
-        if (torch.cuda.is_available() and torch.cuda.is_initialized()) or (
+        mp_module = torch_mp
+        if torch.cuda.is_available() or (
             torch.distributed.is_available()
             and torch.distributed.is_initialized()
         ):
@@ -419,18 +414,13 @@ def _get_mp_context():
 
     if use_spawn:
         try:
-            new_context = multiprocessing.get_context("spawn")
+            _MP_CONTEXT = mp_module.get_context("spawn")
         except ValueError:
             # 'spawn' might not be available on some systems
-            new_context = multiprocessing.get_context()
+            _MP_CONTEXT = mp_module.get_context()
     else:
-        new_context = multiprocessing.get_context()
+        _MP_CONTEXT = mp_module.get_context()
 
-    if _MP_CONTEXT is not None and type(_MP_CONTEXT) is not type(new_context):
-        # Context changed, must reset stateful objects like Queue and Value
-        reset_mp_state()
-
-    _MP_CONTEXT = new_context
     return _MP_CONTEXT
 
 
@@ -501,7 +491,7 @@ class PyDatasetEnqueuer:
         global _SEQUENCE_COUNTER
         if _SEQUENCE_COUNTER is None:
             try:
-                _SEQUENCE_COUNTER = multiprocessing.Value("i", 0)
+                _SEQUENCE_COUNTER = _get_mp_context().Value("i", 0)
             except OSError:
                 # In this case the OS does not allow us to use
                 # multiprocessing. We resort to an int

--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -1,4 +1,5 @@
 import itertools
+import multiprocessing
 import multiprocessing.dummy
 import queue
 import random
@@ -388,20 +389,63 @@ _SEQUENCE_COUNTER = None
 _DATA_POOLS = weakref.WeakSet()
 _WORKER_ID_QUEUE = None  # Only created if needed.
 _FORCE_THREADPOOL = False
+_MP_CONTEXT = None
+
+
+def reset_mp_state():
+    global _SEQUENCE_COUNTER
+    global _WORKER_ID_QUEUE
+    global _SHARED_SEQUENCES
+    global _MP_CONTEXT
+    _SEQUENCE_COUNTER = None
+    _WORKER_ID_QUEUE = None
+    _SHARED_SEQUENCES = {}
+    _MP_CONTEXT = None
+
+
+def _get_mp_context():
+    global _MP_CONTEXT
+    from keras.src.backend import backend
+
+    use_spawn = False
+    if backend() == "torch":
+        import torch
+
+        if (torch.cuda.is_available() and torch.cuda.is_initialized()) or (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        ):
+            use_spawn = True
+
+    if use_spawn:
+        try:
+            new_context = multiprocessing.get_context("spawn")
+        except ValueError:
+            # 'spawn' might not be available on some systems
+            new_context = multiprocessing.get_context()
+    else:
+        new_context = multiprocessing.get_context()
+
+    if _MP_CONTEXT is not None and type(_MP_CONTEXT) is not type(new_context):
+        # Context changed, must reset stateful objects like Queue and Value
+        reset_mp_state()
+
+    _MP_CONTEXT = new_context
+    return _MP_CONTEXT
 
 
 def get_pool_class(use_multiprocessing):
     global _FORCE_THREADPOOL
     if not use_multiprocessing or _FORCE_THREADPOOL:
         return multiprocessing.dummy.Pool  # ThreadPool
-    return multiprocessing.Pool
+    return _get_mp_context().Pool
 
 
 def get_worker_id_queue():
     """Lazily create the queue to track worker ids."""
     global _WORKER_ID_QUEUE
     if _WORKER_ID_QUEUE is None:
-        _WORKER_ID_QUEUE = multiprocessing.Queue()
+        _WORKER_ID_QUEUE = _get_mp_context().Queue()
     return _WORKER_ID_QUEUE
 
 


### PR DESCRIPTION
## Description
 When using PyTorch to train models, if you try to speed up data loading by using multiple workers (use_multiprocessing=True), the program would often crash with a "segmentation fault" or just freeze.

### Why did this happen?
  This happened because of how the device creates new processes. By default, it "clones" the main process. If the main process was already using the GPU, the "clones" would get confused and try to access the same GPU memory in a way that isn't allowed, causing a crash.

### The Solution

The implementation introduces a backend-aware multiprocessing context selector in py_dataset_adapter.py:

- Switches to `torch.multiprocessing`: When the backend is PyTorch, the adapter now uses torch.multiprocessing, which is a drop-in replacement that handles the sharing of tensor data across processes.
- Enforces `spawn` context: If CUDA is available or torch.distributed is initialized, the adapter now uses the spawn start method. spawn avoids inheriting initialized CUDA states from the parent, preventing the primary cause of segfaults.
 - Unified Context Access: Introduced _get_mp_context() to ensure that Pool, Queue, and Value primitives all originate from the same consistent multiprocessing context.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
