### PR TITLE
Migrate to OIDC Trusted Publishing and add auto-publish workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,6 +86,10 @@ jobs:
     name: Build Wheel file and upload
     needs: [build, format]
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -103,8 +107,7 @@ jobs:
         run: |
           python pip_build.py --nightly
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2 # zizmor: ignore[use-trusted-publishing]
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
-          password: ${{ secrets.PYPI_NIGHTLY_API_TOKEN }}
           packages-dir: dist/
           verbose: true

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: pip cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('requirements.txt') }}
+      - name: Install dependencies
+        run: |
+          pip install build
+          pip install -r requirements.txt --progress-bar off --upgrade
+      - name: Build wheel file
+        run: |
+          python pip_build.py
+      - name: Publish Keras to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          verbose: true


### PR DESCRIPTION
## Description of the change

Migrates the PyPI publishing workflow from long-lived API tokens to OIDC
Trusted Publishing, eliminating the need for stored secrets
(`PYPI_NIGHTLY_API_TOKEN`).

### Changes

**`nightly.yml`**
- Added `environment: pypi` and `id-token: write` permission to the
  `nightly` job for OIDC authentication.
- Removed `password: ${{ secrets.PYPI_NIGHTLY_API_TOKEN }}` from the
  publish step.
- Removed `# zizmor: ignore[use-trusted-publishing]` suppression.

**`publish-to-pypi.yml` (NEW)**
- Added a new workflow to auto-publish stable releases to PyPI,
  triggered on GitHub Release creation.
- Uses OIDC Trusted Publishing (no secrets required).

### Prerequisites (PyPI Admin)

Before merging, a PyPI admin must configure Trusted Publishing:
1. [keras](https://pypi.org/manage/project/keras/settings/publishing/) →
   Add GitHub publisher: `keras-team/keras`, workflow `publish-to-pypi.yml`,
   environment `pypi`
2. [keras-nightly](https://pypi.org/manage/project/keras-nightly/settings/publishing/) →
   Add GitHub publisher: `keras-team/keras`, workflow `nightly.yml`,
   environment `pypi`
3. Create a `pypi` GitHub Environment in repo settings.

### Reference PRs
- keras-rs: https://github.com/keras-team/keras-rs/pull/201
- keras-hub: https://github.com/keras-team/keras-hub/pull/3017


## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
