### PR TITLE
Fix ops.gelu integer input handling in NumPy backend (#23528)

### DIFF
--- a/keras/src/backend/numpy/nn.py
+++ b/keras/src/backend/numpy/nn.py
@@ -144,6 +144,9 @@ def selu(x):
 
 def gelu(x, approximate=True):
     x = convert_to_tensor(x)
+    # Cast integer inputs to float for consistent behavior across backends
+    if np.issubdtype(x.dtype, np.integer):
+        x = x.astype("float32")
     # followed by JAX's implementation
     if approximate:
         sqrt_2_over_pi = np.sqrt(2 / np.pi).astype(x.dtype)


### PR DESCRIPTION
This PR fixes issue #23528 - inconsistent ops.gelu behavior for integer inputs across backends.

## Problem
The NumPy backend's gelu function was silently returning zeros for integer inputs because float constants like 0.5 and 0.044715 were truncated to 0 when cast to integer dtype.

## Solution
Cast integer inputs to float32 before computing gelu, matching the behavior of the JAX backend which promotes integers to float automatically.

## Changes
- Added integer type check and cast to float32 in keras/src/backend/numpy/nn.py

## Testing
- Verified that gelu now returns correct values for integer inputs
- Checked that the fix doesn't break existing float input behavior

---

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

---

This pull request includes code written with the assistance of AI.
The code has **not yet been reviewed** by a human.