### PR TITLE
Accept NumPy scalar regularizer coefficients

### DIFF
--- a/keras/src/regularizers/regularizers.py
+++ b/keras/src/regularizers/regularizers.py
@@ -1,4 +1,5 @@
 import math
+import numbers
 
 from keras.src import ops
 from keras.src.api_export import keras_export
@@ -339,14 +340,16 @@ class OrthogonalRegularizer(Regularizer):
 
 
 def validate_float_arg(value, name):
-    """check penalty number availability, raise ValueError if failed."""
-    if (
-        not isinstance(value, (float, int))
-        or (math.isinf(value) or math.isnan(value))
-        or value < 0
-    ):
+    """Check penalty number availability, raise ValueError if failed."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
         raise ValueError(
             f"Invalid value for argument {name}: expected a non-negative float."
             f"Received: {name}={value}"
         )
-    return float(value)
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(
+            f"Invalid value for argument {name}: expected a non-negative float."
+            f"Received: {name}={value}"
+        )
+    return value

--- a/keras/src/regularizers/regularizers_test.py
+++ b/keras/src/regularizers/regularizers_test.py
@@ -211,12 +211,20 @@ class ValidateFloatArgTest(testing.TestCase):
     def test_validate_float_with_valid_args(self):
         self.assertEqual(validate_float_arg(1, "test"), 1.0)
         self.assertEqual(validate_float_arg(1.0, "test"), 1.0)
+        self.assertAlmostEqual(
+            validate_float_arg(np.float32(0.1), "test"), 0.1
+        )
+        self.assertEqual(validate_float_arg(np.int32(1), "test"), 1.0)
 
     def test_validate_float_with_invalid_types(self):
         with self.assertRaisesRegex(
             ValueError, "expected a non-negative float"
         ):
             validate_float_arg("not_a_number", "test")
+        with self.assertRaisesRegex(
+            ValueError, "expected a non-negative float"
+        ):
+            validate_float_arg(np.bool_(True), "test")
 
     def test_validate_float_with_nan(self):
         with self.assertRaisesRegex(

--- a/keras/src/regularizers/regularizers_test.py
+++ b/keras/src/regularizers/regularizers_test.py
@@ -211,9 +211,7 @@ class ValidateFloatArgTest(testing.TestCase):
     def test_validate_float_with_valid_args(self):
         self.assertEqual(validate_float_arg(1, "test"), 1.0)
         self.assertEqual(validate_float_arg(1.0, "test"), 1.0)
-        self.assertAlmostEqual(
-            validate_float_arg(np.float32(0.1), "test"), 0.1
-        )
+        self.assertAlmostEqual(validate_float_arg(np.float32(0.1), "test"), 0.1)
         self.assertEqual(validate_float_arg(np.int32(1), "test"), 1.0)
 
     def test_validate_float_with_invalid_types(self):


### PR DESCRIPTION
## Summary

- Accept real NumPy scalar values in regularizer coefficient validation.
- Continue rejecting booleans, non-finite values, negative values, and unsupported types.
- Add regression coverage for NumPy real and boolean scalar inputs.

## Validation

- ruff check keras/src/regularizers/regularizers.py keras/src/regularizers/regularizers_test.py
- python -m compileall -q keras/src/regularizers/regularizers.py keras/src/regularizers/regularizers_test.py

The focused pytest could not run locally because the checkout is missing the optree dependency.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.