### PR TITLE
Fix Duplicate variables in SavedModel export

### DIFF
--- a/keras/src/export/saved_model_export_archive.py
+++ b/keras/src/export/saved_model_export_archive.py
@@ -329,15 +329,30 @@ class SavedModelExportArchive:
     def _filter_and_track_resources(self):
         """Track resources used by endpoints / referenced in `track()` calls."""
         # Start by extracting variables from endpoints.
-        fns = [self._get_concrete_fn(name) for name in self._endpoint_names]
+        fns = [
+            self._get_connected_fn(name)
+            if hasattr(self, "_get_connected_fn")
+            else self._get_concrete_fn(name)
+            for name in self._endpoint_names
+        ]
         tvs, ntvs = _list_variables_used_by_fns(fns)
-        self._tf_trackable._all_variables = list(tvs + ntvs)
+        tracked_variable_handles = {
+            v.handle.ref()
+            for v in self._tf_trackable.variables
+            if hasattr(v, "handle") and v.handle is not None
+        }
+
+        # Filter out duplicates
+        self._tf_trackable._all_variables = [
+            v
+            for v in tvs + ntvs
+            if not hasattr(v, "handle")
+            or v.handle is None
+            or v.handle.ref() not in tracked_variable_handles
+        ]
 
         # TF < 2.21 fix: see `_patch_tf_is_tf_type_for_object_proxy`.
         with _patch_tf_is_tf_type_for_object_proxy():
-            # `tf.train.TrackableView` hardcodes the `save_type` to
-            # "checkpoint". We need to subclass to use a `save_type` of
-            # "savedmodel".
             savedmodel_cache = {}
 
             class SavedModelTrackableView(tf.train.TrackableView):

--- a/keras/src/export/saved_model_test.py
+++ b/keras/src/export/saved_model_test.py
@@ -458,6 +458,31 @@ class ExportArchiveTest(testing.TestCase):
         # Test with a different batch size
         revived_model.call(tf.random.normal((6, 10)))
 
+    @pytest.mark.skipif(
+        backend.backend() != "tensorflow",
+        reason="This test is native to the TF backend.",
+    )
+    def test_model_export_does_not_duplicate_variables(self):
+        temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
+
+        model = get_model()
+        model_input = tf.random.normal((3, 10))
+        model(model_input)  # Build the model.
+
+        model.export(temp_filepath, **self.add_endpoint_kwargs)
+
+        checkpoint_path = os.path.join(temp_filepath, "variables", "variables")
+        reader = tf.train.load_checkpoint(checkpoint_path)
+        variable_shapes = reader.get_variable_to_shape_map()
+
+        num_saved_parameters = sum(
+            np.prod(shape)
+            for name, shape in variable_shapes.items()
+            if "CHECKPOINTABLE" not in name
+        )
+
+        self.assertEqual(num_saved_parameters, model.count_params())
+
     def test_low_level_model_export_with_alias(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
 


### PR DESCRIPTION
SavedModel export could serialize the same model variables twice through `variables` and `_all_variables`, resulting in unnecessarily large export artifacts.

* Compared endpoint variables with already-tracked variables using `handle.ref()`.
* Filtered out duplicate variables before adding them to `_all_variables`.
* Preserved endpoint-only variables.
* Added a regression test that verifies the number of parameters stored in the exported checkpoint matches `model.count_params()`, ensuring variables are serialized only once.

Previously, model variables could be serialized twice. With this fix, already-tracked variables are saved only once.

Fixes: #23553 

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
