### PR TITLE
[OpenVINO] Fix tile when repeats contains a symbolic dimension

### DIFF
--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -4671,10 +4671,12 @@ def trunc(x):
 def tile(x, repeats):
     x = get_ov_output(x)
 
-    if isinstance(repeats, (int, OpenVINOKerasTensor)):
+    if isinstance(repeats, int) or (
+        isinstance(repeats, OpenVINOKerasTensor) and repeats.ndim == 0
+    ):
         repeats = [repeats]
     if isinstance(repeats, (list, tuple)):
-        # `repeats` may mix Python ints with symbolic dimensions, 
+        # `repeats` may mix Python ints with symbolic dimensions,
         # which cannot be folded into a single constant.
         repeats = shape_to_ov_output(list(repeats))
     else:

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -4671,12 +4671,17 @@ def trunc(x):
 def tile(x, repeats):
     x = get_ov_output(x)
 
-    if isinstance(repeats, int):
+    if isinstance(repeats, (int, OpenVINOKerasTensor)):
         repeats = [repeats]
-    repeats = get_ov_output(repeats)
+    if isinstance(repeats, (list, tuple)):
+        # `repeats` may mix Python ints with symbolic dimensions, 
+        # which cannot be folded into a single constant.
+        repeats = shape_to_ov_output(list(repeats))
+    else:
+        repeats = get_ov_output(repeats)
 
     if repeats.get_element_type() != Type.i64:
-        repeats = ov_opset.convert(repeats, Type.i64)
+        repeats = ov_opset.convert(repeats, Type.i64).output(0)
 
     if len(repeats.get_partial_shape()) != 1:
         repeats = ov_opset.reshape(repeats, [-1], False)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -13139,3 +13139,27 @@ class TileTest(testing.TestCase):
         output = TileLayer()(inputs)
 
         self.assertEqual(output.shape, (None, 6, 2, 2))
+
+    def test_tile_with_symbolic_repeats(self):
+        # `repeats` mixes Python ints with a symbolic batch dim
+        # used to broadcast a class token across a dynamic batch.
+        class TileClsToken(keras.layers.Layer):
+            def build(self, input_shape):
+                self.token = self.add_weight(
+                    shape=(1, 1, 8), initializer="ones"
+                )
+
+            def call(self, x):
+                batch_size = ops.shape(x)[0]
+                token = knp.tile(self.token, (batch_size, 1, 1))
+                return knp.concatenate([token, x], axis=1)
+
+        x = np.zeros((2, 4, 8), dtype="float32")
+        expected = np.concatenate([np.ones((2, 1, 8), "float32"), x], axis=1)
+
+        self.assertAllClose(TileClsToken()(x), expected)
+
+        inputs = keras.Input(shape=(4, 8))
+        model = keras.Model(inputs, TileClsToken()(inputs))
+
+        self.assertAllClose(model.predict(x), expected)


### PR DESCRIPTION
## Description
This PR fixes `ops.tile(x, (batch_size, 1, 1))` , where a symbolic batch_size from ops.shape() made tracing fail. This broadcasts a class token in most keras-hub vision models tests, which all broke under `predict()`'s dynamic batch. The .output(0) additionally fixes a crash on any non-i64 `repeats` (e.g. an int32 array), previously masked because `get_ov_output` usually happens to yield i64.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
