### PR TITLE
Fix float16 L2 normalize gradients via float32 accumulation

### DIFF
--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -2735,14 +2735,19 @@ def _normalize(x, axis=-1, order=2, epsilon=None):
     if 2 == order:
         # A special case: L2 normalization with `x * rsqrt(...)`
         # instead of `x / sqrt(...)`. Clamp the squared norm before the
-        # rsqrt so zero vectors get a finite gradient.
+        # rsqrt so zero vectors get a finite gradient. Compute in at least
+        # float32 so half-precision inputs do not underflow `epsilon**2` or
+        # overflow the rsqrt derivative (see #23546).
+        original_dtype = backend.standardize_dtype(x.dtype)
+        compute_dtype = backend.result_type(x.dtype, "float32")
+        x = backend.cast(x, compute_dtype)
         square_sum = backend.numpy.sum(
             backend.numpy.square(x), axis=axis, keepdims=True
         )
         inv_norm = backend.math.rsqrt(
             backend.numpy.maximum(square_sum, epsilon * epsilon)
         )
-        return x * inv_norm
+        return backend.cast(x * inv_norm, original_dtype)
     norm = backend.linalg.norm(x, ord=order, axis=axis, keepdims=True)
     denom = backend.numpy.maximum(norm, epsilon)
     return backend.numpy.divide(x, denom)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2733,6 +2733,55 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self.assertFalse(np.isnan(x_grad).any())
         self.assertAllClose(x_grad, expected_grad)
 
+    def test_normalize_l2_float16_gradients(self):
+        # Half-precision L2 normalize must keep finite gradients for ordinary
+        # magnitudes (see #23546). Without an upcast, rsqrt's derivative
+        # overflows float16 for inputs like 0.01.
+        x_np = np.full((4, 2), 0.01, dtype="float16")
+
+        if backend.backend() == "tensorflow":
+            import tensorflow as tf
+
+            x = tf.Variable(x_np)
+            with tf.GradientTape() as tape:
+                y = knn.normalize(x, axis=-1, order=2)
+                loss = tf.reduce_sum(y)
+            x_grad = tape.gradient(loss, x)
+
+            x32 = tf.Variable(x_np.astype("float32"))
+            with tf.GradientTape() as tape:
+                y32 = knn.normalize(x32, axis=-1, order=2)
+                loss32 = tf.reduce_sum(y32)
+            expected_grad = tape.gradient(loss32, x32)
+        elif backend.backend() == "jax":
+            import jax
+            import jax.numpy as jnp
+
+            def f(x):
+                return jnp.sum(knn.normalize(x, axis=-1, order=2))
+
+            x_grad = jax.grad(f)(jnp.array(x_np))
+            expected_grad = jax.grad(f)(jnp.array(x_np.astype("float32")))
+        elif backend.backend() == "torch":
+            import torch
+
+            x = torch.tensor(x_np, requires_grad=True)
+            y = knn.normalize(x, axis=-1, order=2)
+            y.sum().backward()
+            x_grad = x.grad
+
+            x32 = torch.tensor(x_np.astype("float32"), requires_grad=True)
+            y32 = knn.normalize(x32, axis=-1, order=2)
+            y32.sum().backward()
+            expected_grad = x32.grad
+        else:
+            self.skipTest("Gradient test requires tensorflow, jax or torch.")
+
+        x_grad = ops.convert_to_numpy(x_grad)
+        expected_grad = ops.convert_to_numpy(expected_grad)
+        self.assertTrue(np.isfinite(x_grad).all())
+        self.assertAllClose(x_grad.astype("float32"), expected_grad, atol=1e-3)
+
     def test_psnr(self):
         x1 = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
         x2 = np.array([[0.2, 0.2, 0.3], [0.4, 0.6, 0.6]])


### PR DESCRIPTION
## Summary

Fixes #23546.

`ops.normalize(..., order=2)` computed `square` / `epsilon**2` / `rsqrt` in the input dtype. On `float16`, the `rsqrt` derivative overflows for ordinary magnitudes (e.g. arrays filled with `0.01`), so Torch (and other autodiff backends) return `-inf` gradients. The same values stay finite in `float32`.

#23093 already clamped before `rsqrt` to fix zero-vector NaNs, but the half-precision upcast never landed. This PR applies the same pattern Keras already uses in `_rms_normalization` / layer norm:

- `compute_dtype = result_type(x.dtype, "float32")`
- run the L2 path in `compute_dtype`
- cast the output back to the input dtype

Also adds `test_normalize_l2_float16_gradients`, which checks that float16 grads are finite and match the float32 reference.

## Test plan

- [x] Existing `test_normalize_l2_zero_vector_gradients` still covers the #23075 case
- [x] New float16 gradient test for tensorflow / jax / torch
- [x] CI: `keras/src/ops/nn_test.py` on torch / tensorflow / jax

## Contributor Agreement

**Please review our [PR Contribution Policy](https://github.com/keras-team/keras/issues/23601) and [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] This PR is linked to an issue that has been assigned to me (see `Fixes #xxx` above).
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed. PRs without a linked, assigned issue will be converted to draft.