### PR TITLE
Fix `-inf` gradients in `normalize()` for float16 inputs (compute L2 norm in float32)

### DIFF
--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -2736,13 +2736,19 @@ def _normalize(x, axis=-1, order=2, epsilon=None):
         # A special case: L2 normalization with `x * rsqrt(...)`
         # instead of `x / sqrt(...)`. Clamp the squared norm before the
         # rsqrt so zero vectors get a finite gradient.
+        original_dtype = backend.standardize_dtype(x.dtype)
+        # Computes in at least float32 precision: in float16, `epsilon**2`
+        # underflows to zero and the derivative of `rsqrt` overflows for
+        # small norms, producing inf/NaN gradients (see #23546).
+        compute_dtype = backend.result_type(x.dtype, "float32")
+        x = backend.cast(x, compute_dtype)
         square_sum = backend.numpy.sum(
             backend.numpy.square(x), axis=axis, keepdims=True
         )
         inv_norm = backend.math.rsqrt(
             backend.numpy.maximum(square_sum, epsilon * epsilon)
         )
-        return x * inv_norm
+        return backend.cast(x * inv_norm, original_dtype)
     norm = backend.linalg.norm(x, ord=order, axis=axis, keepdims=True)
     denom = backend.numpy.maximum(norm, epsilon)
     return backend.numpy.divide(x, denom)

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -2733,6 +2733,46 @@ class NNOpsCorrectnessTest(testing.TestCase):
         self.assertFalse(np.isnan(x_grad).any())
         self.assertAllClose(x_grad, expected_grad)
 
+    def test_normalize_l2_half_precision_gradients(self):
+        # The L2 (order=2) fast path must compute the squared norm, epsilon
+        # clamp and rsqrt in at least float32: for float16 inputs, epsilon**2
+        # underflows to zero and the derivative of rsqrt overflows even for
+        # small non-zero vectors, producing -inf gradients (see #23546).
+        x_np = np.full((4, 2), 0.01, dtype=np.float16)
+
+        if backend.backend() == "tensorflow":
+            import tensorflow as tf
+
+            x = tf.Variable(x_np)
+            with tf.GradientTape() as tape:
+                y = knn.normalize(x, axis=-1, order=2)
+                loss = tf.reduce_sum(y)
+            x_grad = tape.gradient(loss, x)
+        elif backend.backend() == "jax":
+            import jax
+            import jax.numpy as jnp
+
+            def f(x):
+                return jnp.sum(knn.normalize(x, axis=-1, order=2))
+
+            x_grad = jax.grad(f)(jnp.array(x_np))
+        elif backend.backend() == "torch":
+            import torch
+
+            x = torch.tensor(x_np, requires_grad=True)
+            y = knn.normalize(x, axis=-1, order=2)
+            y.sum().backward()
+            x_grad = x.grad
+        else:
+            self.skipTest("Gradient test requires tensorflow, jax or torch.")
+
+        x_grad = ops.convert_to_numpy(x_grad)
+        self.assertFalse(np.isnan(x_grad).any())
+        self.assertFalse(np.isinf(x_grad).any())
+        # The analytic gradient is zero; anything above noise means the
+        # intermediates were computed in half precision.
+        self.assertAllClose(x_grad, np.zeros_like(x_grad), atol=1e-4)
+
     def test_psnr(self):
         x1 = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
         x2 = np.array([[0.2, 0.2, 0.3], [0.4, 0.6, 0.6]])


### PR DESCRIPTION
Body:

Fixes #23546

## Summary

`normalize()`'s L2 fast path computed the squared-norm, epsilon clamp, and
`rsqrt` in the **input dtype**. For float16, `epsilon**2` underflows to `0`
and the `rsqrt` derivative (`-0.5·s^-1.5`) overflows float16 range for small
squared-norms, so backward passes yield `-inf` gradients for inputs as small
as `0.01` — reproduced on the torch CPU backend with the issue's repro
before fixing.

The fix computes the L2 intermediates in float32 and casts the result back
to the original dtype, via `backend.result_type(x.dtype, "float32")` /
`backend.cast(...)` — the exact convention already used by
`_rms_normalization` and `_layer_normalization` in the same file. It is
placed in the core op (not the torch backend) so every backend benefits;
the non-L2 path is untouched, and the zero-vector gradient behavior from
#23075 is preserved.

## Repro (torch 2.14.0 CPU, before → after)

- before: gradient `[[-inf -inf] ...]`, `grad finite: False`
- after: gradient `[[-7.6e-06 ...]]` (float16 rounding of `-7.6293945e-06`),
  `grad finite: True`; output dtype still float16; float32 inputs unchanged

## Testing

- new regression test `test_normalize_l2_half_precision_gradients` in
  `keras/src/ops/nn_test.py`, modeled on the existing
  `test_normalize_l2_zero_vector_gradients`
- `KERAS_BACKEND=torch pytest keras/src/ops/nn_test.py -k normalize` → 7 passed
- `KERAS_BACKEND=numpy` → 5 passed, 2 skipped (gradient tests skip on numpy, per existing pattern)
- `KERAS_BACKEND=jax` → 7 passed
- full `nn_test.py` delta vs pristine master on this machine: exactly +1 passing test (pre-existing MPS float64 failures identical before/after)
- `ruff check` + `ruff format --check` clean on both changed files

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

## AI Assistance Disclosure

This pull request was prepared with AI coding assistance (an agent implemented
the fix and tests from issue #23546 under my direction). I have reviewed the
full diff, reproduced the bug and the fix locally on the torch CPU backend,
and verified the test results described below; I take responsibility for this
contribution and will drive it through review.
