### PR TITLE
Match the backend test exclusions exactly

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -91,11 +91,8 @@ def pytest_collection_modifyitems(config, items):
         if requires_multiple_devices and "multi_device" in item.keywords:
             item.add_marker(requires_multiple_devices)
 
-        # An entry is the whole node id or a trailing part of it, cut at a `/`.
-        parts = item.nodeid.split("/")
-        if backend_skipped_tests.intersection(
-            "/".join(parts[i:]) for i in range(len(parts))
-        ):
+        # Skip concrete tests listed in the backend specific file.
+        if item.nodeid in backend_skipped_tests:
             item.add_marker(
                 skip_if_backend(
                     backend(),

--- a/conftest.py
+++ b/conftest.py
@@ -42,7 +42,7 @@ def pytest_configure(config):
 def pytest_collection_modifyitems(config, items):
     has_multiple_devices = False
 
-    backend_skipped_tests = []
+    backend_skipped_tests = set()
     if backend() in ("mlx", "openvino", "paddle"):
         if backend() == "mlx":
             import keras_mlx
@@ -63,13 +63,12 @@ def pytest_collection_modifyitems(config, items):
             "excluded_tests.txt",
         )
         with open(exclusions_path, "r") as file:
-            backend_skipped_tests = file.readlines()
             # Exclude empty lines and comments.
-            backend_skipped_tests = [
+            backend_skipped_tests = {
                 stripped
-                for line in backend_skipped_tests
+                for line in file.readlines()
                 if (stripped := line.strip()) and not stripped.startswith("#")
-            ]
+            }
 
     if backend() == "jax":
         import jax
@@ -92,15 +91,17 @@ def pytest_collection_modifyitems(config, items):
         if requires_multiple_devices and "multi_device" in item.keywords:
             item.add_marker(requires_multiple_devices)
 
-        # Skip concrete tests listed in the backend specific file.
-        for skipped_test in backend_skipped_tests:
-            if skipped_test in item.nodeid:
-                item.add_marker(
-                    skip_if_backend(
-                        backend(),
-                        f"Not supported operation by {backend()} backend",
-                    )
+        # An entry is the whole node id or a trailing part of it, cut at a `/`.
+        parts = item.nodeid.split("/")
+        if backend_skipped_tests.intersection(
+            "/".join(parts[i:]) for i in range(len(parts))
+        ):
+            item.add_marker(
+                skip_if_backend(
+                    backend(),
+                    f"Not supported operation by {backend()} backend",
                 )
+            )
 
 
 def skip_if_backend(given_backend, reason):


### PR DESCRIPTION
## Description

`pytest_collection_modifyitems` selects the tests to skip for a backend with `if skipped_test in item.nodeid`. That is a substring test, so a line that reads like one test id silently gates everything it is a prefix of. In the mlx file `DenseTest::test_quantize_float8` also skipped `test_quantize_float8_fitting`, `test_quantize_float8_inference` and the three `EinsumDenseTest` equivalents, and in the openvino file `MathDtypeTest::test_gammainc` names no test of its own and gates 36. None of that is visible when reading the file, which makes the exclusions hard to trust and hard to retire. This matches the whole node id instead, or a trailing part of it cut at a directory boundary, so both the full path and the shorter `image_test.py::Test::test_x` form work and a bare `Class::test` no longer does.

The exclusion files have to be exact before this lands. keras-team/keras-mlx#55 and keras-team/keras-openvino#22 do that, and both are safe to merge on their own because full node ids are still correct under today's substring match. paddle needs no format change, but 15 of its entries are relying on the prefix behaviour and would unskip, listed in a comment below.

Verified against the ids pytest collects on each backend, 14538 for mlx and 14402 for openvino. The set of skipped tests is identical between the old files under the old match and the new files under this one. `dense_test.py` and `adam_test.py` on mlx give 91 passed and 8 skipped either way, and this match against the old bare name file unskips 5 tests and fails them, which is what the plugin PRs landing first avoids.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
