### PR TITLE
Add @core team to CODEOWNERS for .github workflow changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Reviewers for GitHub Actions workflows and repository configuration.
-/.github/ @jeffcarp @divyashreepathihalli
+/.github/ @keras-team/core @jeffcarp @divyashreepathihalli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Reviewers for GitHub Actions workflows and repository configuration.
-/.github/ @keras-team/core @jeffcarp @divyashreepathihalli
+/.github/ @keras-team/core @divyashreepathihalli @hertschuh @jeffcarp


### PR DESCRIPTION
Otherwise this prevents other team members from merging PRs in this dir.