### PR TITLE
Promote mixed dtypes in the Torch einsum backend and drop the EinsumDense workarounds

### DIFF
--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -100,6 +100,18 @@ def einsum(subscripts, *operands, **kwargs):
         # prevent overflow
         operands = [cast(operand, compute_dtype) for operand in operands]
         return cast(torch.einsum(subscripts, *operands), "int32")
+    if len(dtypes_to_resolve) > 1:
+        # `torch.einsum` does not promote mixed dtypes (e.g. a float input
+        # against an int8 kernel), unlike `matmul` above and the other
+        # backends. Resolve the result dtype the way the op's output spec
+        # does and cast the operands to it.
+        result_dtype = dtypes.result_type(*dtypes_to_resolve)
+        compute_dtype = result_dtype
+        # TODO: torch.einsum doesn't support integer types with cuda
+        if get_device() == "cuda" and "int" in compute_dtype:
+            compute_dtype = config.floatx()
+        operands = [cast(operand, compute_dtype) for operand in operands]
+        return cast(torch.einsum(subscripts, *operands), result_dtype)
     return torch.einsum(subscripts, *operands)
 
 

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -6,7 +6,6 @@ import ml_dtypes
 import numpy as np
 
 from keras.src import activations
-from keras.src import backend
 from keras.src import constraints
 from keras.src import dtype_policies
 from keras.src import initializers
@@ -1083,22 +1082,11 @@ class EinsumDense(Layer):
                 x = ops.cast(x, self.compute_dtype)
                 x = ops.divide(x, ops.multiply(inputs_scale, kernel_scale))
             else:
-                # Weight-only quantization: dequantize kernel and use float
-                # einsum. This is a workaround for PyTorch's einsum which
-                # doesn't support mixed-precision inputs (float input,
-                # int8 kernel).
-                if backend.backend() == "torch":
-                    kernel_scale = self._adjust_scale_for_dequant(kernel_scale)
-                    float_kernel = ops.divide(
-                        ops.cast(kernel, dtype=self.compute_dtype),
-                        kernel_scale,
-                    )
-                    x = ops.einsum(self.equation, inputs, float_kernel)
-                else:
-                    x = ops.einsum(self.equation, inputs, kernel)
-                    # De-scale outputs
-                    x = ops.cast(x, self.compute_dtype)
-                    x = ops.divide(x, kernel_scale)
+                # Weight-only quantization: contract against the int8
+                # kernel and de-scale the outputs.
+                x = ops.einsum(self.equation, inputs, kernel)
+                x = ops.cast(x, self.compute_dtype)
+                x = ops.divide(x, kernel_scale)
             return x, grad_fn
 
         x = einsum_with_inputs_gradient(
@@ -1171,20 +1159,9 @@ class EinsumDense(Layer):
                     inputs_scale = self._adjust_scale_for_quant(
                         inputs_scale, "input"
                     )
-                    # Cast inputs to float for einsum. This is a workaround
-                    # for PyTorch's einsum which doesn't support
-                    # mixed-precision inputs (int8 input, float kernel).
-                    if backend.backend() == "torch":
-                        x = ops.einsum(
-                            self.equation,
-                            ops.cast(inputs_q, self.compute_dtype),
-                            float_kernel,
-                        )
-                        x = ops.divide(x, inputs_scale)
-                    else:
-                        x = ops.einsum(self.equation, inputs_q, float_kernel)
-                        x = ops.cast(x, self.compute_dtype)
-                        x = ops.divide(x, inputs_scale)
+                    x = ops.einsum(self.equation, inputs_q, float_kernel)
+                    x = ops.cast(x, self.compute_dtype)
+                    x = ops.divide(x, inputs_scale)
                 else:
                     # Weight-only per-channel quantization
                     float_kernel = _dequantize_kernel(

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -2090,3 +2090,30 @@ class EinsumDenseTest(testing.TestCase):
 
         x = np.random.random((2, input_dim)).astype("float32")
         self.assertEqual(tuple(layer(x).shape), (2, output_dim))
+
+    def test_int8_weight_only_matches_dense(self):
+        """Weight-only int8 `EinsumDense` and `Dense` agree on every backend.
+
+        Both contract the float inputs against the int8 kernel and de-scale
+        the outputs, so the two layers must produce the same values from the
+        same float kernel and bias."""
+        input_dim, units = 16, 8
+        dense = layers.Dense(units)
+        dense.build((None, input_dim))
+        dense.bias.assign(np.random.random((units,)).astype("float32"))
+        einsum_dense = layers.EinsumDense(
+            "ab,bc->ac", output_shape=(units,), bias_axes="c"
+        )
+        einsum_dense.build((None, input_dim))
+        einsum_dense.kernel.assign(dense.kernel)
+        einsum_dense.bias.assign(dense.bias)
+
+        dense.quantize(
+            "int8", config=Int8QuantizationConfig(activation_quantizer=None)
+        )
+        einsum_dense.quantize(
+            "int8", config=Int8QuantizationConfig(activation_quantizer=None)
+        )
+
+        x = np.random.random((4, input_dim)).astype("float32")
+        self.assertAllClose(einsum_dense(x), dense(x), atol=1e-6, rtol=1e-6)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -10342,6 +10342,41 @@ class NumpyDtypeTest(testing.TestCase):
 
     @parameterized.named_parameters(
         named_product(
+            dtypes=[
+                ("float32", "int8"),
+                ("float16", "int8"),
+                ("bfloat16", "int8"),
+                ("int8", "float32"),
+            ]
+        )
+    )
+    def test_einsum_mixed_dtypes_at_real_shapes(self, dtypes):
+        # `test_einsum` above uses size-1 operands, which `torch.einsum`
+        # accepts for mixed dtypes even though it rejects them at any real
+        # shape. Check the promotion where it matters: a float operand
+        # against an int8 operand, e.g. an int8 kernel in a quantized layer.
+        dtype1, dtype2 = dtypes
+        if "bfloat16" in dtypes and testing.torch_uses_gpu():
+            self.skipTest("Torch cuda does not support bfloat16")
+
+        subscripts = "abc,cde->abde"
+        rng = np.random.default_rng(0)
+        x1 = knp.array(rng.integers(-4, 5, size=(2, 5, 8)), dtype=dtype1)
+        x2 = knp.array(rng.integers(-4, 5, size=(8, 4, 16)), dtype=dtype2)
+        expected_dtype = backend.result_type(dtype1, dtype2)
+
+        result = knp.einsum(subscripts, x1, x2)
+        self.assertEqual(standardize_dtype(result.dtype), expected_dtype)
+
+        # Values must match a contraction where the int8 operand is cast to
+        # the result dtype explicitly.
+        x1_ref = ops.cast(x1, expected_dtype) if dtype1 == "int8" else x1
+        x2_ref = ops.cast(x2, expected_dtype) if dtype2 == "int8" else x2
+        expected = knp.einsum(subscripts, x1_ref, x2_ref)
+        self.assertAllClose(result, expected)
+
+    @parameterized.named_parameters(
+        named_product(
             dtypes=list(itertools.combinations(ALL_DTYPES, 2))
             + [("int8", "int8")]
         )


### PR DESCRIPTION
## Summary

`torch.einsum` rejects a float operand against an int8 operand at every real shape; only size-1 shapes pass, which is what the existing dtype test used. `keras.ops.matmul` already resolves the result dtype and casts on Torch, but `einsum` did not, while TensorFlow resolves `result_type`, JAX promotes natively, and `Einsum.compute_output_spec` already promises `result_type`.

This PR makes the Torch `einsum` backend promote mixed operand dtypes to the same `result_type` the other backends produce, and removes the two `backend.backend() == "torch"` branches in `EinsumDense` that existed only for this gap.

## Layer logic changes

In PyTorch, EinsumDense previously used a different computation order for two quantization paths (int8 weight-only, and per-channel int4 with activation quantization): it converted the weights back to floating point before multiplying.

With this fix, all backends now follow the same unified approach: multiply the quantized weights directly, then scale the output.

Torch `EinsumDense` int8 weight-only outputs move at rounding level as a result (they now match TensorFlow and JAX, which always contracted against the int8 kernel). Stored checkpoints are unaffected: no variable, dtype policy or config changes.


## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
