### PR TITLE
Rename QuantizationMode to QuantizationStrategy

### DIFF
--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -6,16 +6,16 @@ from keras.src.backend.common import global_state
 QUANTIZATION_MODES = ("int8", "float8", "int4", "ternary", "gptq", "awq")
 
 
-def _mode_registry():
+def _strategy_registry():
     """Returns the quantization mode registry, imported on first use.
 
     The import must be deferred: `keras.src.quantizers` registers the
     built-in modes on import, and those mode modules import the policy
     classes defined below, so a module-level import here would be a cycle.
     """
-    from keras.src.quantizers import mode_registry
+    from keras.src.quantizers import strategy_registry
 
-    return mode_registry
+    return strategy_registry
 
 
 def _parse_int4_mode(mode_str):
@@ -370,10 +370,10 @@ class QuantizedDTypePolicy(DTypePolicy):
         }
 
     def _check_quantization_mode(self, mode, compute_dtype):
-        if not _mode_registry().is_registered(mode):
+        if not _strategy_registry().is_registered(mode):
             raise ValueError(
                 "Invalid quantization mode. "
-                f"Expected one of {_mode_registry().registered_mode_names()}. "
+                f"Expected one of {_strategy_registry().registered_modes()}. "
                 f"Received: mode={mode}"
             )
         if compute_dtype == "float16" and mode == "int8":
@@ -647,15 +647,15 @@ def _is_quantized_policy_string(policy):
     """Whether a policy string belongs to a registered quantization mode."""
     return any(
         _matches_quantized_mode(policy, name)
-        for name in _mode_registry().registered_mode_names()
+        for name in _strategy_registry().registered_modes()
     )
 
 
 def _get_quantized_dtype_policy_by_str(policy):
     if not isinstance(policy, str):
         raise TypeError(f"`policy` must be a string. Received: policy={policy}")
-    registry = _mode_registry()
-    for name in registry.registered_mode_names():
+    registry = _strategy_registry()
+    for name in registry.registered_modes():
         if _matches_quantized_mode(policy, name):
             break
     else:
@@ -670,4 +670,4 @@ def _get_quantized_dtype_policy_by_str(policy):
             f"Received: policy={policy}"
         )
     mode, source_name = split_name
-    return registry.get_mode(name).policy_from_string(mode, source_name)
+    return registry.get_strategy(name).policy_from_string(mode, source_name)

--- a/keras/src/quantizers/__init__.py
+++ b/keras/src/quantizers/__init__.py
@@ -1,8 +1,8 @@
 import inspect
 
 from keras.src.api_export import keras_export
-from keras.src.quantizers import mode_registry  # noqa: F401
 from keras.src.quantizers import modes  # noqa: F401 (registers modes)
+from keras.src.quantizers import strategy_registry  # noqa: F401
 from keras.src.quantizers.awq_config import AWQConfig
 from keras.src.quantizers.quantization_config import Float8QuantizationConfig
 from keras.src.quantizers.quantization_config import Int4QuantizationConfig

--- a/keras/src/quantizers/awq_core.py
+++ b/keras/src/quantizers/awq_core.py
@@ -10,7 +10,7 @@ from absl import logging
 
 from keras.src import ops
 from keras.src import utils as keras_utils
-from keras.src.quantizers import mode_registry
+from keras.src.quantizers import strategy_registry
 from keras.src.quantizers.awq import AWQ
 from keras.src.quantizers.gptq_core import _execution_stages
 from keras.src.quantizers.gptq_core import calibration_no_grad_scope
@@ -239,8 +239,10 @@ def awq_quantize(config, quantization_layer_structure, filters=None):
 def get_group_size_for_layer(layer, config):
     """Get group size from config or dtype policy.
 
-    The resolution logic lives on the awq mode descriptor
-    (`AWQMode.resolve_group_size`); this wrapper remains until the layer
+    The resolution logic lives on the awq strategy
+    (`AWQStrategy.resolve_group_size`); this wrapper remains until the layer
     call sites dispatch through the registry.
     """
-    return mode_registry.get_mode("awq").resolve_group_size(layer, config)
+    return strategy_registry.get_strategy("awq").resolve_group_size(
+        layer, config
+    )

--- a/keras/src/quantizers/gptq_core.py
+++ b/keras/src/quantizers/gptq_core.py
@@ -11,7 +11,7 @@ from keras.src import ops
 from keras.src import utils as keras_utils
 from keras.src.layers import Dense
 from keras.src.layers import EinsumDense
-from keras.src.quantizers import mode_registry
+from keras.src.quantizers import strategy_registry
 from keras.src.quantizers.gptq import GPTQ
 from keras.src.quantizers.utils import should_quantize_layer
 
@@ -576,18 +576,22 @@ def gptq_quantize(config, quantization_layer_structure, filters=None):
 def get_group_size_for_layer(layer, config):
     """Determine the group size for GPTQ quantization.
 
-    The resolution logic lives on the gptq mode descriptor
-    (`GPTQMode.resolve_group_size`); this wrapper remains until the layer
+    The resolution logic lives on the gptq strategy
+    (`GPTQStrategy.resolve_group_size`); this wrapper remains until the layer
     call sites dispatch through the registry.
     """
-    return mode_registry.get_mode("gptq").resolve_group_size(layer, config)
+    return strategy_registry.get_strategy("gptq").resolve_group_size(
+        layer, config
+    )
 
 
 def get_weight_bits_for_layer(layer, config):
     """Determine the number of weight bits for GPTQ quantization.
 
-    The resolution logic lives on the gptq mode descriptor
-    (`GPTQMode.resolve_weight_bits`); this wrapper remains until the layer
+    The resolution logic lives on the gptq strategy
+    (`GPTQStrategy.resolve_weight_bits`); this wrapper remains until the layer
     call sites dispatch through the registry.
     """
-    return mode_registry.get_mode("gptq").resolve_weight_bits(layer, config)
+    return strategy_registry.get_strategy("gptq").resolve_weight_bits(
+        layer, config
+    )

--- a/keras/src/quantizers/modes/__init__.py
+++ b/keras/src/quantizers/modes/__init__.py
@@ -1,23 +1,25 @@
-"""Built-in quantization mode descriptors.
+"""Built-in quantization strategies.
 
 Importing this package registers the built-in modes. They register here,
-explicitly, rather than by decorating each descriptor: registration order
+explicitly, rather than by decorating each strategy: registration order
 is the canonical `QUANTIZATION_MODES` order, validation error messages
 render the registered-names tuple, and decorating would instead tie that
 order to the (alphabetical) import order.
 """
 
-from keras.src.quantizers.mode_registry import register_quantization_mode
-from keras.src.quantizers.modes.awq import AWQMode
-from keras.src.quantizers.modes.float8 import Float8Mode
-from keras.src.quantizers.modes.gptq import GPTQMode
-from keras.src.quantizers.modes.int4 import Int4Mode
-from keras.src.quantizers.modes.int8 import Int8Mode
-from keras.src.quantizers.modes.ternary import TernaryMode
+from keras.src.quantizers.modes.awq import AWQStrategy
+from keras.src.quantizers.modes.float8 import Float8Strategy
+from keras.src.quantizers.modes.gptq import GPTQStrategy
+from keras.src.quantizers.modes.int4 import Int4Strategy
+from keras.src.quantizers.modes.int8 import Int8Strategy
+from keras.src.quantizers.modes.ternary import TernaryStrategy
+from keras.src.quantizers.strategy_registry import (
+    register_quantization_strategy,
+)
 
-register_quantization_mode(Int8Mode)
-register_quantization_mode(Float8Mode)
-register_quantization_mode(Int4Mode)
-register_quantization_mode(TernaryMode)
-register_quantization_mode(GPTQMode)
-register_quantization_mode(AWQMode)
+register_quantization_strategy(Int8Strategy)
+register_quantization_strategy(Float8Strategy)
+register_quantization_strategy(Int4Strategy)
+register_quantization_strategy(TernaryStrategy)
+register_quantization_strategy(GPTQStrategy)
+register_quantization_strategy(AWQStrategy)

--- a/keras/src/quantizers/modes/awq.py
+++ b/keras/src/quantizers/modes/awq.py
@@ -1,9 +1,9 @@
 from keras.src.dtype_policies.dtype_policy import AWQDTypePolicy
 from keras.src.quantizers.awq_config import AWQConfig
-from keras.src.quantizers.modes.calibration import CalibrationMode
+from keras.src.quantizers.modes.calibration import CalibrationStrategy
 
 
-class AWQMode(CalibrationMode):
+class AWQStrategy(CalibrationStrategy):
     """AWQ post-training quantization (activation-aware, 4-bit).
 
     AWQ uses 4-bit quantization with per-channel AWQ scales that protect

--- a/keras/src/quantizers/modes/calibration.py
+++ b/keras/src/quantizers/modes/calibration.py
@@ -7,11 +7,11 @@ hooks below.
 """
 
 from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
-from keras.src.quantizers.mode_registry import QuantizationMode
+from keras.src.quantizers.strategy_registry import QuantizationStrategy
 
 
-class CalibrationMode(QuantizationMode):
-    """A post-training mode whose values arrive from a calibration pass."""
+class CalibrationStrategy(QuantizationStrategy):
+    """A post-training strategy whose values arrive from a calibration pass."""
 
     requires_config = True
     requires_layer_structure = True

--- a/keras/src/quantizers/modes/float8.py
+++ b/keras/src/quantizers/modes/float8.py
@@ -1,9 +1,9 @@
 from keras.src.dtype_policies.dtype_policy import QuantizedFloat8DTypePolicy
-from keras.src.quantizers.mode_registry import QuantizationMode
 from keras.src.quantizers.quantization_config import Float8QuantizationConfig
+from keras.src.quantizers.strategy_registry import QuantizationStrategy
 
 
-class Float8Mode(QuantizationMode):
+class Float8Strategy(QuantizationStrategy):
     """Float8 QDQ mixed-precision training.
 
     Quantizing only allocates the scale/amax-history variables; the float

--- a/keras/src/quantizers/modes/gptq.py
+++ b/keras/src/quantizers/modes/gptq.py
@@ -1,9 +1,9 @@
 from keras.src.dtype_policies.dtype_policy import GPTQDTypePolicy
 from keras.src.quantizers.gptq_config import GPTQConfig
-from keras.src.quantizers.modes.calibration import CalibrationMode
+from keras.src.quantizers.modes.calibration import CalibrationStrategy
 
 
-class GPTQMode(CalibrationMode):
+class GPTQStrategy(CalibrationStrategy):
     """GPTQ post-training quantization (calibration-based, 2/3/4/8-bit)."""
 
     name = "gptq"

--- a/keras/src/quantizers/modes/int4.py
+++ b/keras/src/quantizers/modes/int4.py
@@ -1,11 +1,11 @@
 from keras.src.dtype_policies.dtype_policy import Int4DTypePolicy
 from keras.src.dtype_policies.dtype_policy import QuantizedDTypePolicy
 from keras.src.dtype_policies.dtype_policy_map import DTypePolicyMap
-from keras.src.quantizers.mode_registry import QuantizationMode
 from keras.src.quantizers.quantization_config import Int4QuantizationConfig
+from keras.src.quantizers.strategy_registry import QuantizationStrategy
 
 
-class Int4Mode(QuantizationMode):
+class Int4Strategy(QuantizationStrategy):
     """W4A16 weight-only quantization (packed int4 weights)."""
 
     name = "int4"

--- a/keras/src/quantizers/modes/int8.py
+++ b/keras/src/quantizers/modes/int8.py
@@ -1,8 +1,8 @@
-from keras.src.quantizers.mode_registry import QuantizationMode
 from keras.src.quantizers.quantization_config import Int8QuantizationConfig
+from keras.src.quantizers.strategy_registry import QuantizationStrategy
 
 
-class Int8Mode(QuantizationMode):
+class Int8Strategy(QuantizationStrategy):
     """W8A8 dynamic quantization (int8 weights times int8 activations)."""
 
     name = "int8"

--- a/keras/src/quantizers/modes/ternary.py
+++ b/keras/src/quantizers/modes/ternary.py
@@ -1,8 +1,8 @@
-from keras.src.quantizers.mode_registry import QuantizationMode
 from keras.src.quantizers.quantization_config import TernaryQuantizationConfig
+from keras.src.quantizers.strategy_registry import QuantizationStrategy
 
 
-class TernaryMode(QuantizationMode):
+class TernaryStrategy(QuantizationStrategy):
     """Ternary (BitNet b1.58) quantization: weights in `{-1, 0, +1}`.
 
     The quantization rule (threshold and scale) is owned by the layer, so

--- a/keras/src/quantizers/quantization_config.py
+++ b/keras/src/quantizers/quantization_config.py
@@ -1,5 +1,5 @@
 from keras.src.api_export import keras_export
-from keras.src.quantizers import mode_registry
+from keras.src.quantizers import strategy_registry
 from keras.src.saving import serialization_lib
 
 
@@ -259,7 +259,7 @@ def validate_and_resolve_config(mode, config):
     This function validates the quantization config and resolves the mode.
     If mode is not provided, it is inferred from the config.
     If config is not provided, a default config is inferred from the mode
-    through the mode's registered descriptor.
+    through the mode's registered strategy.
 
     Args:
         mode: Quantization mode.
@@ -280,7 +280,7 @@ def validate_and_resolve_config(mode, config):
             )
         # `default_config` raises for modes that require an explicit config
         # (gptq/awq need a calibration dataset).
-        config = mode_registry.get_mode(mode).default_config()
+        config = strategy_registry.get_strategy(mode).default_config()
     else:
         if not isinstance(config, QuantizationConfig):
             raise ValueError(
@@ -304,17 +304,17 @@ def validate_and_resolve_config(mode, config):
     mode = config.mode
 
     # Mode-specific config validation (e.g. gptq requires a `GPTQConfig`).
-    mode_registry.get_mode(mode).validate_config(config)
+    strategy_registry.get_strategy(mode).validate_config(config)
 
     return config
 
 
 def _validate_mode(mode):
     """Validates quantization mode."""
-    if mode is not None and not mode_registry.is_registered(mode):
+    if mode is not None and not strategy_registry.is_registered(mode):
         raise ValueError(
             "Invalid quantization mode. "
-            f"Expected one of {mode_registry.registered_mode_names()}. "
+            f"Expected one of {strategy_registry.registered_modes()}. "
             f"Received: mode={mode}"
         )
 
@@ -322,8 +322,10 @@ def _validate_mode(mode):
 def get_block_size_for_layer(layer, config):
     """Determine the block size for int4 quantization.
 
-    The resolution logic lives on the int4 mode descriptor
-    (`Int4Mode.resolve_block_size`); this wrapper remains until the layer
+    The resolution logic lives on the int4 strategy
+    (`Int4Strategy.resolve_block_size`); this wrapper remains until the layer
     call sites dispatch through the registry.
     """
-    return mode_registry.get_mode("int4").resolve_block_size(layer, config)
+    return strategy_registry.get_strategy("int4").resolve_block_size(
+        layer, config
+    )

--- a/keras/src/quantizers/strategy_registry.py
+++ b/keras/src/quantizers/strategy_registry.py
@@ -1,8 +1,8 @@
-"""Registry of quantization modes.
+"""Registry of quantization strategies, one per mode.
 
 This module is the single dispatch point for quantization behavior. Each
 quantization mode (`"int8"`, `"int4"`, `"float8"`, `"ternary"`,
-`"gptq"`, `"awq"`) is described by one `QuantizationMode` descriptor that
+`"gptq"`, `"awq"`) is implemented by one `QuantizationStrategy` that
 owns:
 
 - the mode's config class and default-config resolution,
@@ -16,14 +16,16 @@ The registry is internal API (`keras.src.quantizers`). Adding a mode is a
 registration rather than an edit of every resolution helper:
 
 ```python
-from keras.src.quantizers.mode_registry import QuantizationMode
-from keras.src.quantizers.mode_registry import register_quantization_mode
+from keras.src.quantizers.strategy_registry import QuantizationStrategy
+from keras.src.quantizers.strategy_registry import (
+    register_quantization_strategy,
+)
 
-class MyMode(QuantizationMode):
+class MyStrategy(QuantizationStrategy):
     name = "my_mode"
     ...
 
-register_quantization_mode(MyMode())
+register_quantization_strategy(MyStrategy())
 ```
 
 This module must stay import-light: it is consulted lazily from
@@ -31,11 +33,11 @@ This module must stay import-light: it is consulted lazily from
 not pull in layers or policies at module level.
 """
 
-_MODES = {}  # name -> QuantizationMode, in registration order.
+_MODE_TO_STRATEGY = {}  # mode -> QuantizationStrategy, in registration order.
 
 
-class QuantizationMode:
-    """Descriptor for one quantization mode.
+class QuantizationStrategy:
+    """Implementation of one quantization mode.
 
     Subclasses set `name` and `config_cls` and override the hooks whose
     behavior differs from the defaults derived from those attributes.
@@ -104,8 +106,8 @@ class QuantizationMode:
 
     # --- Per-layer hyperparameter resolution ------------------------------
 
-    # Mode-specific `resolve_*` helpers live on the concrete descriptors
-    # (e.g. `Int4Mode.resolve_block_size`). They all share the precedence:
+    # Mode-specific `resolve_*` helpers live on the concrete strategies
+    # (e.g. `Int4Strategy.resolve_block_size`). They all share the precedence:
     # explicit config > layer's quantized dtype policy > DTypePolicyMap
     # entry > mode-specific fallback.
 
@@ -154,8 +156,8 @@ class QuantizationMode:
         del model, config, structure, filters
 
 
-def register_quantization_mode(mode):
-    """Registers a `QuantizationMode` descriptor.
+def register_quantization_strategy(strategy):
+    """Registers a `QuantizationStrategy`.
 
     Accepts an instance or a class (instantiated with no arguments), and
     returns its argument unchanged so it can also be used as a class
@@ -164,7 +166,7 @@ def register_quantization_mode(mode):
     `keras.src.quantizers.modes` instead, where the order is written down
     rather than left to the import order.
 
-    The descriptor is validated at registration time, not at first use:
+    The strategy is validated at registration time, not at first use:
     the name must be a non-empty string, must not be registered already,
     must not contain the policy-grammar separators ("/" and "_from_"),
     must not shadow a standard dtype or mixed-precision policy name, and
@@ -176,14 +178,14 @@ def register_quantization_mode(mode):
     from keras.src import backend
     from keras.src.dtype_policies.dtype_policy import QUANTIZATION_MODES
 
-    descriptor = mode() if isinstance(mode, type) else mode
-    name = descriptor.name
+    instance = strategy() if isinstance(strategy, type) else strategy
+    name = instance.name
     if not isinstance(name, str) or not name:
         raise ValueError(
-            "A quantization mode must define a non-empty string `name`. "
+            "A quantization strategy must define a non-empty string `name`. "
             f"Received: name={name!r}"
         )
-    if name in _MODES:
+    if name in _MODE_TO_STRATEGY:
         raise ValueError(
             f"A quantization mode named '{name}' is already registered."
         )
@@ -205,7 +207,7 @@ def register_quantization_mode(mode):
                 "conflicts with a standard dtype or mixed-precision "
                 "policy name."
             )
-    for existing in _MODES:
+    for existing in _MODE_TO_STRATEGY:
         builtin_involved = (
             existing in QUANTIZATION_MODES or name in QUANTIZATION_MODES
         )
@@ -219,36 +221,37 @@ def register_quantization_mode(mode):
                 "no mode name may share a prefix with a built-in mode."
             )
     has_config_source = (
-        descriptor.config_cls is not None
-        or descriptor.requires_config
-        or type(descriptor).default_config
-        is not QuantizationMode.default_config
+        instance.config_cls is not None
+        or instance.requires_config
+        or type(instance).default_config
+        is not QuantizationStrategy.default_config
     )
     if not has_config_source:
         raise ValueError(
-            f"Quantization mode '{name}' must define `config_cls`, set "
+            f"Quantization strategy '{name}' must define `config_cls`, set "
             "`requires_config = True`, or override `default_config()`."
         )
-    _MODES[name] = descriptor
-    # Return the argument, not the descriptor: as a class decorator this
+    _MODE_TO_STRATEGY[name] = instance
+    # Return the argument, not the strategy: as a class decorator this
     # must leave the class bound to its name, still subclassable.
-    return mode
+    return strategy
 
 
-def unregister_quantization_mode(name):
-    """Removes a registered mode (intended for tests)."""
-    _MODES.pop(name, None)
+def unregister_quantization_strategy(mode):
+    """Removes the strategy registered for `mode` (intended for tests)."""
+    _MODE_TO_STRATEGY.pop(mode, None)
 
 
-def get_mode(name):
-    """Returns the descriptor registered under `name`, or `None`."""
-    return _MODES.get(name)
+def get_strategy(mode):
+    """Returns the strategy registered for `mode`, or `None`."""
+    return _MODE_TO_STRATEGY.get(mode)
 
 
-def is_registered(name):
-    return name in _MODES
+def is_registered(mode):
+    """Whether a strategy is registered for `mode`."""
+    return mode in _MODE_TO_STRATEGY
 
 
-def registered_mode_names():
-    """All registered mode names, as a tuple, in registration order."""
-    return tuple(_MODES)
+def registered_modes():
+    """All registered modes, as a tuple, in registration order."""
+    return tuple(_MODE_TO_STRATEGY)

--- a/keras/src/quantizers/strategy_registry_test.py
+++ b/keras/src/quantizers/strategy_registry_test.py
@@ -3,38 +3,38 @@ from absl.testing import parameterized
 from keras.src import dtype_policies
 from keras.src import testing
 from keras.src.dtype_policies.dtype_policy import QUANTIZATION_MODES
-from keras.src.quantizers import mode_registry
+from keras.src.quantizers import strategy_registry
 
 
-class ModeRegistryTest(testing.TestCase):
+class StrategyRegistryTest(testing.TestCase):
     def test_builtin_modes_match_public_tuple(self):
         # The registration order is observable (validation error messages
         # render the registered-names tuple), so it must stay identical to
         # the public QUANTIZATION_MODES constant.
         self.assertEqual(
-            mode_registry.registered_mode_names(), QUANTIZATION_MODES
+            strategy_registry.registered_modes(), QUANTIZATION_MODES
         )
         for name in QUANTIZATION_MODES:
-            self.assertIsNotNone(mode_registry.get_mode(name))
+            self.assertIsNotNone(strategy_registry.get_strategy(name))
 
     def test_unknown_mode(self):
-        self.assertIsNone(mode_registry.get_mode("bogus"))
-        self.assertFalse(mode_registry.is_registered("bogus"))
+        self.assertIsNone(strategy_registry.get_strategy("bogus"))
+        self.assertFalse(strategy_registry.is_registered("bogus"))
 
     def test_register_requires_name(self):
-        class Nameless(mode_registry.QuantizationMode):
+        class Nameless(strategy_registry.QuantizationStrategy):
             requires_config = True
 
         with self.assertRaisesRegex(ValueError, "non-empty string `name`"):
-            mode_registry.register_quantization_mode(Nameless)
+            strategy_registry.register_quantization_strategy(Nameless)
 
     def test_register_rejects_duplicates(self):
-        class Duplicate(mode_registry.QuantizationMode):
+        class Duplicate(strategy_registry.QuantizationStrategy):
             name = "int8"
             requires_config = True
 
         with self.assertRaisesRegex(ValueError, "already registered"):
-            mode_registry.register_quantization_mode(Duplicate)
+            strategy_registry.register_quantization_strategy(Duplicate)
 
     @parameterized.named_parameters(
         ("existing_builtin_is_prefix", "int42"),
@@ -45,33 +45,33 @@ class ModeRegistryTest(testing.TestCase):
         # strings, so no mode name may share a prefix with a built-in.
         colliding_name = name
 
-        class Colliding(mode_registry.QuantizationMode):
+        class Colliding(strategy_registry.QuantizationStrategy):
             name = colliding_name
             requires_config = True
 
         with self.assertRaisesRegex(ValueError, "collides"):
-            mode_registry.register_quantization_mode(Colliding)
+            strategy_registry.register_quantization_strategy(Colliding)
 
     def test_register_allows_custom_prefix_overlap(self):
         # Externally registered modes match only their exact grammar
         # (name, name + "/", name + "_from_"), so two custom modes may
         # share a prefix without ambiguity.
-        class Custom(mode_registry.QuantizationMode):
+        class Custom(strategy_registry.QuantizationStrategy):
             name = "custom"
             requires_config = True
 
-        class CustomTwo(mode_registry.QuantizationMode):
+        class CustomTwo(strategy_registry.QuantizationStrategy):
             name = "custom2"
             requires_config = True
 
-        mode_registry.register_quantization_mode(Custom)
+        strategy_registry.register_quantization_strategy(Custom)
         try:
-            mode_registry.register_quantization_mode(CustomTwo)
+            strategy_registry.register_quantization_strategy(CustomTwo)
             policy = dtype_policies.get("custom2_from_float32")
             self.assertEqual(policy.quantization_mode, "custom2")
         finally:
-            mode_registry.unregister_quantization_mode("custom")
-            mode_registry.unregister_quantization_mode("custom2")
+            strategy_registry.unregister_quantization_strategy("custom")
+            strategy_registry.unregister_quantization_strategy("custom2")
 
     @parameterized.named_parameters(
         ("slash", "my/mode", "must not contain"),
@@ -85,58 +85,58 @@ class ModeRegistryTest(testing.TestCase):
         # policy-string parsing.
         reserved_name = name
 
-        class Reserved(mode_registry.QuantizationMode):
+        class Reserved(strategy_registry.QuantizationStrategy):
             name = reserved_name
             requires_config = True
 
         with self.assertRaisesRegex(ValueError, error):
-            mode_registry.register_quantization_mode(Reserved)
+            strategy_registry.register_quantization_strategy(Reserved)
 
     def test_registered_name_does_not_capture_ordinary_policies(self):
         # Policy strings are routed by mode name, but only through the
         # quantized grammar (bare name, name + "/", name + "_from_"). A
         # registered mode whose name prefixes ordinary policy strings (like
         # "mixed" prefixing "mixed_bfloat16") must not hijack them.
-        class MixedMode(mode_registry.QuantizationMode):
+        class MixedMode(strategy_registry.QuantizationStrategy):
             name = "mixed"
             requires_config = True
 
-        mode_registry.register_quantization_mode(MixedMode)
+        strategy_registry.register_quantization_strategy(MixedMode)
         try:
             policy = dtype_policies.get("mixed_bfloat16")
             self.assertIsNone(policy.quantization_mode)
             self.assertEqual(policy.compute_dtype, "bfloat16")
         finally:
-            mode_registry.unregister_quantization_mode("mixed")
+            strategy_registry.unregister_quantization_strategy("mixed")
 
     def test_register_as_decorator_keeps_the_class(self):
-        # Registering returns its argument, so a decorated descriptor stays
+        # Registering returns its argument, so a decorated strategy stays
         # a class and can still be subclassed.
-        @mode_registry.register_quantization_mode
-        class Decorated(mode_registry.QuantizationMode):
+        @strategy_registry.register_quantization_strategy
+        class Decorated(strategy_registry.QuantizationStrategy):
             name = "decorated"
             requires_config = True
 
         try:
             self.assertIsInstance(Decorated, type)
-            self.assertIsNotNone(mode_registry.get_mode("decorated"))
+            self.assertIsNotNone(strategy_registry.get_strategy("decorated"))
 
             class Sub(Decorated):
                 name = "decorated_sub"
 
             self.assertIsInstance(Sub, type)
         finally:
-            mode_registry.unregister_quantization_mode("decorated")
+            strategy_registry.unregister_quantization_strategy("decorated")
 
     def test_register_requires_config_source(self):
         # A mode must be able to produce a config: via config_cls, via
         # requires_config (explicit config mandatory), or by overriding
         # default_config. Registration fails otherwise, not first use.
-        class NoConfig(mode_registry.QuantizationMode):
+        class NoConfig(strategy_registry.QuantizationStrategy):
             name = "noconfig"
 
         with self.assertRaisesRegex(ValueError, "must define `config_cls`"):
-            mode_registry.register_quantization_mode(NoConfig)
+            strategy_registry.register_quantization_strategy(NoConfig)
 
 
 class PolicyCodecCorpusTest(testing.TestCase):

--- a/keras/src/utils/summary_utils.py
+++ b/keras/src/utils/summary_utils.py
@@ -485,15 +485,15 @@ def print_quantization_summary(model, verbose=True):
 
         # Packed sub-byte modes store two values per byte, so the logical
         # (unpacked) element count is a multiple of the stored count. The
-        # multiplier is owned by the mode's descriptor.
+        # multiplier is owned by the mode's strategy.
         # Imported here, not at module scope: this module is pulled in
         # while `keras.src.ops` is still initializing, and the quantizers
         # package imports back into `keras.src.ops`.
-        from keras.src.quantizers import mode_registry
+        from keras.src.quantizers import strategy_registry
 
-        descriptor = mode_registry.get_mode(mode)
+        strategy = strategy_registry.get_strategy(mode)
         multiplier = (
-            descriptor.summary_byte_multiplier if descriptor is not None else 1
+            strategy.summary_byte_multiplier if strategy is not None else 1
         )
         logical_params = math.prod(primary.shape) * multiplier
         float_bytes = logical_params * 4  # float32 baseline.


### PR DESCRIPTION
## Description
One naming convention for the quantization registry: `mode` is always the string the public API uses (`quantize(mode="int8")`, `layer.quantization_mode`, dtype policies, the keys of `variable_serialization_spec`), and the object that implements a mode is a `QuantizationStrategy`, held in variables named `strategy`.

Before, the same object was a "descriptor" in some places and a "mode" in others, and the string was `mode` or `mode_name` depending on the call site.

The class was called `QuantizationMode`; it holds the mode's logic (its variables, forward pass, quantized values, policy codec and config resolution). The built-in classes follow: `Int8Strategy`, `Int4Strategy`, `Float8Strategy`, `CalibrationStrategy`, `GPTQStrategy`, `AWQStrategy`, `TernaryStrategy`. `mode_registry.get_mode(name)` becomes `get_strategy(mode)`

`register_quantization_mode` keeps its name (it registers a mode, keyed by the strategy's `name`).

No behavior change.

## Contributor Agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
