### PR TITLE
Handle native backend tensors in data adapters

### DIFF
--- a/keras/src/trainers/data_adapters/array_data_adapter.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter.py
@@ -127,10 +127,11 @@ class ArrayDataAdapter(DataAdapter):
     def get_native_iterator(self):
         inputs = array_slicing.convert_to_sliceable(self._inputs)
 
-        def slice_array(sliceable, indices=None):
-            return sliceable[indices]
+        def slice_and_convert_to_native(sliceable, indices=None):
+            x = sliceable[indices]
+            return sliceable.convert_to_native_compatible(x)
 
-        return self._get_iterator(slice_array, inputs)
+        return self._get_iterator(slice_and_convert_to_native, inputs)
 
     def get_tf_dataset(self):
         from keras.src.utils.module_utils import tensorflow as tf
@@ -302,7 +303,7 @@ class ArrayDataAdapter(DataAdapter):
             def __getitems__(self, indices):
                 def slice_and_convert(sliceable):
                     x = sliceable[indices]
-                    x = sliceable.convert_to_torch_compatible(x)
+                    x = sliceable.convert_to_native_compatible(x)
                     x = convert_to_tensor(x)
                     return x
 

--- a/keras/src/trainers/data_adapters/array_data_adapter.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter.py
@@ -124,6 +124,14 @@ class ArrayDataAdapter(DataAdapter):
 
         return self._get_iterator(slice_and_convert_to_numpy, inputs)
 
+    def get_native_iterator(self):
+        inputs = array_slicing.convert_to_sliceable(self._inputs)
+
+        def slice_array(sliceable, indices=None):
+            return sliceable[indices]
+
+        return self._get_iterator(slice_array, inputs)
+
     def get_tf_dataset(self):
         from keras.src.utils.module_utils import tensorflow as tf
 

--- a/keras/src/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter_test.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import jax
 import jax.experimental.sparse as jax_sparse
 import numpy as np
@@ -12,9 +14,91 @@ from keras.src import testing
 from keras.src.distribution import distribution_lib as dist_lib
 from keras.src.testing.test_utils import named_product
 from keras.src.trainers.data_adapters import array_data_adapter
+from keras.src.trainers.data_adapters import array_slicing
+from keras.src.trainers.data_adapters.data_adapter import DataAdapter
+
+
+class _NativeArray:
+    def __init__(self, array):
+        self.array = np.asarray(array)
+        self.shape = self.array.shape
+        self.dtype = self.array.dtype
+
+    def __array__(self, dtype=None, copy=None):
+        raise AssertionError(
+            "Native arrays should not be converted through NumPy"
+        )
+
+    def __getitem__(self, indices):
+        if isinstance(indices, np.ndarray):
+            raise ValueError("NumPy indices are unsupported")
+        return _NativeArray(self.array[indices])
 
 
 class TestArrayDataAdapter(testing.TestCase):
+    def test_native_iterator_default(self):
+        class TestAdapter(DataAdapter):
+            def get_numpy_iterator(self):
+                return iter([np.array([1, 2])])
+
+        batch = next(TestAdapter().get_native_iterator())
+        self.assertAllEqual(batch, [1, 2])
+
+    @parameterized.named_parameters(
+        ("no_shuffle", False),
+        ("batch_shuffle", "batch"),
+        ("global_shuffle", True),
+    )
+    def test_native_array_iterator(self, shuffle):
+        x = _NativeArray(np.arange(24, dtype="float32").reshape((8, 3)))
+
+        with (
+            mock.patch.object(
+                backend.ops,
+                "is_tensor",
+                side_effect=lambda value: isinstance(value, _NativeArray),
+            ),
+            mock.patch.object(
+                backend.ops,
+                "convert_to_tensor",
+                side_effect=lambda indices: indices.tolist(),
+            ),
+        ):
+            adapter = array_data_adapter.ArrayDataAdapter(
+                x, batch_size=3, shuffle=shuffle
+            )
+            batches = list(adapter.get_native_iterator())
+
+        self.assertLen(batches, 3)
+        self.assertIsInstance(batches[0], _NativeArray)
+        values = np.concatenate([batch.array for batch in batches])
+        self.assertAllEqual(np.sort(values[:, 0]), np.arange(0, 24, 3))
+
+    def test_native_array_sliceable_conversions(self):
+        x = _NativeArray(np.arange(6, dtype="float32").reshape((2, 3)))
+        with (
+            mock.patch.object(backend.ops, "cast", return_value=x) as cast,
+            mock.patch.object(
+                backend.ops, "convert_to_numpy", return_value=x.array
+            ) as convert_to_numpy,
+        ):
+            self.assertIs(
+                array_slicing.NativeArraySliceable.cast(x, "float16"), x
+            )
+            self.assertIs(
+                array_slicing.NativeArraySliceable.convert_to_numpy(x), x.array
+            )
+
+        cast.assert_called_once_with(x, "float16")
+        convert_to_numpy.assert_called_once_with(x)
+        for method in (
+            array_slicing.NativeArraySliceable.convert_to_tf_dataset_compatible,
+            array_slicing.NativeArraySliceable.convert_to_jax_compatible,
+            array_slicing.NativeArraySliceable.convert_to_torch_compatible,
+        ):
+            with self.assertRaises(NotImplementedError):
+                method(x)
+
     def make_array(self, array_type, shape, dtype):
         x = np.array([[i] * shape[1] for i in range(shape[0])], dtype=dtype)
         if array_type == "np":

--- a/keras/src/trainers/data_adapters/array_data_adapter_test.py
+++ b/keras/src/trainers/data_adapters/array_data_adapter_test.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import jax
 import jax.experimental.sparse as jax_sparse
 import numpy as np
@@ -14,91 +12,9 @@ from keras.src import testing
 from keras.src.distribution import distribution_lib as dist_lib
 from keras.src.testing.test_utils import named_product
 from keras.src.trainers.data_adapters import array_data_adapter
-from keras.src.trainers.data_adapters import array_slicing
-from keras.src.trainers.data_adapters.data_adapter import DataAdapter
-
-
-class _NativeArray:
-    def __init__(self, array):
-        self.array = np.asarray(array)
-        self.shape = self.array.shape
-        self.dtype = self.array.dtype
-
-    def __array__(self, dtype=None, copy=None):
-        raise AssertionError(
-            "Native arrays should not be converted through NumPy"
-        )
-
-    def __getitem__(self, indices):
-        if isinstance(indices, np.ndarray):
-            raise ValueError("NumPy indices are unsupported")
-        return _NativeArray(self.array[indices])
 
 
 class TestArrayDataAdapter(testing.TestCase):
-    def test_native_iterator_default(self):
-        class TestAdapter(DataAdapter):
-            def get_numpy_iterator(self):
-                return iter([np.array([1, 2])])
-
-        batch = next(TestAdapter().get_native_iterator())
-        self.assertAllEqual(batch, [1, 2])
-
-    @parameterized.named_parameters(
-        ("no_shuffle", False),
-        ("batch_shuffle", "batch"),
-        ("global_shuffle", True),
-    )
-    def test_native_array_iterator(self, shuffle):
-        x = _NativeArray(np.arange(24, dtype="float32").reshape((8, 3)))
-
-        with (
-            mock.patch.object(
-                backend.ops,
-                "is_tensor",
-                side_effect=lambda value: isinstance(value, _NativeArray),
-            ),
-            mock.patch.object(
-                backend.ops,
-                "convert_to_tensor",
-                side_effect=lambda indices: indices.tolist(),
-            ),
-        ):
-            adapter = array_data_adapter.ArrayDataAdapter(
-                x, batch_size=3, shuffle=shuffle
-            )
-            batches = list(adapter.get_native_iterator())
-
-        self.assertLen(batches, 3)
-        self.assertIsInstance(batches[0], _NativeArray)
-        values = np.concatenate([batch.array for batch in batches])
-        self.assertAllEqual(np.sort(values[:, 0]), np.arange(0, 24, 3))
-
-    def test_native_array_sliceable_conversions(self):
-        x = _NativeArray(np.arange(6, dtype="float32").reshape((2, 3)))
-        with (
-            mock.patch.object(backend.ops, "cast", return_value=x) as cast,
-            mock.patch.object(
-                backend.ops, "convert_to_numpy", return_value=x.array
-            ) as convert_to_numpy,
-        ):
-            self.assertIs(
-                array_slicing.NativeArraySliceable.cast(x, "float16"), x
-            )
-            self.assertIs(
-                array_slicing.NativeArraySliceable.convert_to_numpy(x), x.array
-            )
-
-        cast.assert_called_once_with(x, "float16")
-        convert_to_numpy.assert_called_once_with(x)
-        for method in (
-            array_slicing.NativeArraySliceable.convert_to_tf_dataset_compatible,
-            array_slicing.NativeArraySliceable.convert_to_jax_compatible,
-            array_slicing.NativeArraySliceable.convert_to_torch_compatible,
-        ):
-            with self.assertRaises(NotImplementedError):
-                method(x)
-
     def make_array(self, array_type, shape, dtype):
         x = np.array([[i] * shape[1] for i in range(shape[0])], dtype=dtype)
         if array_type == "np":

--- a/keras/src/trainers/data_adapters/array_slicing.py
+++ b/keras/src/trainers/data_adapters/array_slicing.py
@@ -109,6 +109,33 @@ class NumpySliceable(Sliceable):
     pass
 
 
+class NativeArraySliceable(Sliceable):
+    def __getitem__(self, indices):
+        if not isinstance(indices, slice):
+            indices = backend.ops.convert_to_tensor(indices)
+        return self.array[indices]
+
+    @classmethod
+    def cast(cls, x, dtype):
+        return backend.ops.cast(x, dtype)
+
+    @classmethod
+    def convert_to_numpy(cls, x):
+        return backend.ops.convert_to_numpy(x)
+
+    @classmethod
+    def convert_to_tf_dataset_compatible(cls, x):
+        raise NotImplementedError
+
+    @classmethod
+    def convert_to_jax_compatible(cls, x):
+        raise NotImplementedError
+
+    @classmethod
+    def convert_to_torch_compatible(cls, x):
+        raise NotImplementedError
+
+
 class TensorflowSliceable(Sliceable):
     def __getitem__(self, indices):
         from keras.src.utils.module_utils import tensorflow as tf
@@ -332,8 +359,8 @@ def can_slice_array(x):
         or data_adapter_utils.is_scipy_sparse(x)
         or data_adapter_utils.is_pandas_data_frame(x)
         or data_adapter_utils.is_pandas_series(x)
-        or hasattr(x, "__array__")
         or backend.ops.is_tensor(x)
+        or hasattr(x, "__array__")
     )
 
 
@@ -393,18 +420,10 @@ def convert_to_sliceable(arrays, target_backend=None):
             sliceable_class = PandasSeriesSliceable
         elif data_adapter_utils.is_scipy_sparse(x):
             sliceable_class = ScipySparseSliceable
+        elif backend.ops.is_tensor(x):
+            sliceable_class = NativeArraySliceable
         elif hasattr(x, "__array__"):
             x = np.asarray(x)
-            sliceable_class = NumpySliceable
-        elif backend.ops.is_tensor(x):
-            # Generic fallback for pluggable backend tensors (e.g. MLX).
-            try:
-                res = np.asarray(x)
-                if res.dtype == object:
-                    raise ValueError("np.asarray returned an object array")
-                x = res
-            except (ValueError, TypeError, RuntimeError):
-                x = backend.ops.convert_to_numpy(x)
             sliceable_class = NumpySliceable
         else:
             raise ValueError(

--- a/keras/src/trainers/data_adapters/array_slicing.py
+++ b/keras/src/trainers/data_adapters/array_slicing.py
@@ -90,11 +90,9 @@ class Sliceable:
         return x
 
     @classmethod
-    def convert_to_torch_compatible(cls, x):
-        """Convert a tensor to something that the Torch backend can consume.
+    def convert_to_native_compatible(cls, x):
+        """Convert a tensor to something that the native backend can consume.
 
-        This can be a Torch tensor, NumPy array or any other type of tensor that
-        `keras.backend.torch.core.convert_to_tensor()` can consume.
         Only called after slicing using `__getitem__`.
         Used to densify sparse tensors and ragged tensors.
 
@@ -111,8 +109,8 @@ class NumpySliceable(Sliceable):
 
 class NativeArraySliceable(Sliceable):
     def __getitem__(self, indices):
-        if not isinstance(indices, slice):
-            indices = backend.ops.convert_to_tensor(indices)
+        if isinstance(indices, np.ndarray):
+            indices = indices.tolist()
         return self.array[indices]
 
     @classmethod
@@ -122,18 +120,6 @@ class NativeArraySliceable(Sliceable):
     @classmethod
     def convert_to_numpy(cls, x):
         return backend.ops.convert_to_numpy(x)
-
-    @classmethod
-    def convert_to_tf_dataset_compatible(cls, x):
-        raise NotImplementedError
-
-    @classmethod
-    def convert_to_jax_compatible(cls, x):
-        raise NotImplementedError
-
-    @classmethod
-    def convert_to_torch_compatible(cls, x):
-        raise NotImplementedError
 
 
 class TensorflowSliceable(Sliceable):
@@ -164,7 +150,7 @@ class TensorflowRaggedSliceable(TensorflowSliceable):
         return cls.convert_to_numpy(x)
 
     @classmethod
-    def convert_to_torch_compatible(cls, x):
+    def convert_to_native_compatible(cls, x):
         return x.to_tensor()
 
 
@@ -188,7 +174,7 @@ class TensorflowSparseSliceable(TensorflowSliceable):
         return data_adapter_utils.tf_sparse_to_jax_sparse(x)
 
     @classmethod
-    def convert_to_torch_compatible(cls, x):
+    def convert_to_native_compatible(cls, x):
         from keras.src.backend.tensorflow import sparse as tf_sparse
 
         return tf_sparse.sparse_to_dense(x)
@@ -211,22 +197,8 @@ class JaxSparseSliceable(Sliceable):
         )
 
     @classmethod
-    def convert_to_torch_compatible(cls, x):
+    def convert_to_native_compatible(cls, x):
         return x.todense()
-
-
-class TorchSliceable(Sliceable):
-    @classmethod
-    def cast(cls, x, dtype):
-        from keras.src.backend.torch.ops.core import cast
-
-        return cast(x, dtype)
-
-    @classmethod
-    def convert_to_numpy(cls, x):
-        from keras.src.backend.torch.ops.core import convert_to_numpy
-
-        return convert_to_numpy(x)
 
 
 class PandasSliceable(Sliceable):
@@ -246,7 +218,7 @@ class PandasSliceable(Sliceable):
         return cls.convert_to_numpy(x)
 
     @classmethod
-    def convert_to_torch_compatible(cls, x):
+    def convert_to_native_compatible(cls, x):
         return cls.convert_to_numpy(x)
 
 
@@ -281,7 +253,7 @@ class ScipySparseSliceable(Sliceable):
         return data_adapter_utils.scipy_sparse_to_jax_sparse(x)
 
     @classmethod
-    def convert_to_torch_compatible(cls, x):
+    def convert_to_native_compatible(cls, x):
         return x.todense()
 
 
@@ -355,7 +327,6 @@ def can_slice_array(x):
         or isinstance(x, np.ndarray)
         or data_adapter_utils.is_tensorflow_tensor(x)
         or data_adapter_utils.is_jax_array(x)
-        or data_adapter_utils.is_torch_tensor(x)
         or data_adapter_utils.is_scipy_sparse(x)
         or data_adapter_utils.is_pandas_data_frame(x)
         or data_adapter_utils.is_pandas_series(x)
@@ -412,15 +383,13 @@ def convert_to_sliceable(arrays, target_backend=None):
             else:
                 x = np.asarray(x)
                 sliceable_class = NumpySliceable
-        elif data_adapter_utils.is_torch_tensor(x):
-            sliceable_class = TorchSliceable
         elif data_adapter_utils.is_pandas_data_frame(x):
             sliceable_class = PandasDataFrameSliceable
         elif data_adapter_utils.is_pandas_series(x):
             sliceable_class = PandasSeriesSliceable
         elif data_adapter_utils.is_scipy_sparse(x):
             sliceable_class = ScipySparseSliceable
-        elif backend.ops.is_tensor(x) and target_backend in (None, "numpy"):
+        elif backend.ops.is_tensor(x):
             sliceable_class = NativeArraySliceable
         elif hasattr(x, "__array__"):
             x = np.asarray(x)
@@ -465,10 +434,7 @@ def convert_to_sliceable(arrays, target_backend=None):
         # which should not use extra memory.
         # See https://github.com/google/jax/issues/1276 for an explanation of
         # why slicing a NumPy array is faster than slicing a JAX array.
-        if target_backend == "jax" and sliceable_class in (
-            TensorflowSliceable,
-            TorchSliceable,
-        ):
+        if target_backend == "jax" and sliceable_class is TensorflowSliceable:
             x = np.asarray(x)
             sliceable_class = NumpySliceable
 

--- a/keras/src/trainers/data_adapters/array_slicing.py
+++ b/keras/src/trainers/data_adapters/array_slicing.py
@@ -4,7 +4,6 @@ import math
 import numpy as np
 
 from keras.src import backend
-from keras.src import ops
 from keras.src import tree
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.utils.module_utils import tensorflow as tf
@@ -334,7 +333,7 @@ def can_slice_array(x):
         or data_adapter_utils.is_pandas_data_frame(x)
         or data_adapter_utils.is_pandas_series(x)
         or hasattr(x, "__array__")
-        or ops.is_tensor(x)
+        or backend.ops.is_tensor(x)
     )
 
 
@@ -397,7 +396,7 @@ def convert_to_sliceable(arrays, target_backend=None):
         elif hasattr(x, "__array__"):
             x = np.asarray(x)
             sliceable_class = NumpySliceable
-        elif ops.is_tensor(x):
+        elif backend.ops.is_tensor(x):
             # Generic fallback for pluggable backend tensors (e.g. MLX).
             try:
                 res = np.asarray(x)
@@ -405,7 +404,7 @@ def convert_to_sliceable(arrays, target_backend=None):
                     raise ValueError("np.asarray returned an object array")
                 x = res
             except (ValueError, TypeError, RuntimeError):
-                x = ops.convert_to_numpy(x)
+                x = backend.ops.convert_to_numpy(x)
             sliceable_class = NumpySliceable
         else:
             raise ValueError(

--- a/keras/src/trainers/data_adapters/array_slicing.py
+++ b/keras/src/trainers/data_adapters/array_slicing.py
@@ -4,6 +4,7 @@ import math
 import numpy as np
 
 from keras.src import backend
+from keras.src import ops
 from keras.src import tree
 from keras.src.trainers.data_adapters import data_adapter_utils
 from keras.src.utils.module_utils import tensorflow as tf
@@ -333,6 +334,7 @@ def can_slice_array(x):
         or data_adapter_utils.is_pandas_data_frame(x)
         or data_adapter_utils.is_pandas_series(x)
         or hasattr(x, "__array__")
+        or ops.is_tensor(x)
     )
 
 
@@ -394,6 +396,16 @@ def convert_to_sliceable(arrays, target_backend=None):
             sliceable_class = ScipySparseSliceable
         elif hasattr(x, "__array__"):
             x = np.asarray(x)
+            sliceable_class = NumpySliceable
+        elif ops.is_tensor(x):
+            # Generic fallback for pluggable backend tensors (e.g. MLX).
+            try:
+                res = np.asarray(x)
+                if res.dtype == object:
+                    raise ValueError("np.asarray returned an object array")
+                x = res
+            except (ValueError, TypeError, RuntimeError):
+                x = ops.convert_to_numpy(x)
             sliceable_class = NumpySliceable
         else:
             raise ValueError(

--- a/keras/src/trainers/data_adapters/array_slicing.py
+++ b/keras/src/trainers/data_adapters/array_slicing.py
@@ -420,7 +420,7 @@ def convert_to_sliceable(arrays, target_backend=None):
             sliceable_class = PandasSeriesSliceable
         elif data_adapter_utils.is_scipy_sparse(x):
             sliceable_class = ScipySparseSliceable
-        elif backend.ops.is_tensor(x):
+        elif backend.ops.is_tensor(x) and target_backend in (None, "numpy"):
             sliceable_class = NativeArraySliceable
         elif hasattr(x, "__array__"):
             x = np.asarray(x)

--- a/keras/src/trainers/data_adapters/data_adapter.py
+++ b/keras/src/trainers/data_adapters/data_adapter.py
@@ -15,6 +15,9 @@ class DataAdapter:
         """
         raise NotImplementedError
 
+    def get_native_iterator(self):
+        return self.get_numpy_iterator()
+
     def get_tf_dataset(self):
         """Get a `tf.data.Dataset` instance for the DataAdapter.
 

--- a/keras/src/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/src/trainers/data_adapters/data_adapter_utils.py
@@ -355,7 +355,10 @@ def is_tensorflow_sparse(value):
 def is_jax_array(value):
     if hasattr(value, "__class__"):
         for parent in value.__class__.__mro__:
-            if parent.__name__ == "Array" and str(parent.__module__) == "jax":
+            if (
+                parent.__name__.endswith("Array")
+                and str(parent.__module__) == "jax"
+            ):
                 return True
     return is_jax_sparse(value)  # JAX sparse arrays do not extend jax.Array
 


### PR DESCRIPTION
as suggested by @hertschuh in keras-team/keras-mlx#40

## Description

the data adapters should handle native arrays where `is_tensor(x)` is true, rather than relying on a keras-mlx workaround that converts the full dataset to numpy.

Pluggable backend tensors (e.g. MLX arrays) are rejected by the array data adapter. `can_slice_array()` and `convert_to_sliceable()` check for numpy, TF, JAX, torch, pandas, scipy, and `__array__`, but MLX intentionally dropped `__array__` in favor of the Python Buffer Protocol (ml-explore/mlx#323). So MLX arrays fall through every check and `model.fit/evaluate/predict` crashes.

## Fix

added `ops.is_tensor(x)` as a fallback in both `can_slice_array()` and `convert_to_sliceable()`. For the sliceable representation, using `np.asarray(x)` to get a zero-copy numpy view. falling back to `ops.convert_to_numpy(x)` when `np.asarray` raises (e.g. MLX bfloat16, which fails the buffer protocol) or silently wraps the input in a 0-D object array (e.g. openvino tensors, which don't expose `__array__` or the buffer protocol).

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
