### PR TITLE
Fall back to backend conversion in the numpy iterator

### DIFF
--- a/keras/src/trainers/data_adapters/data_adapter_utils.py
+++ b/keras/src/trainers/data_adapters/data_adapter_utils.py
@@ -295,7 +295,12 @@ def get_numpy_iterator(iterable):
             if hasattr(x, "__array__"):
                 if is_torch_tensor(x):
                     x = x.cpu()
-                x = np.asarray(x)
+                try:
+                    x = np.asarray(x)
+                except (ValueError, TypeError, RuntimeError):
+                    # The backend knows how to convert its own tensors when
+                    # `__array__` does not, e.g. a bfloat16 MLX array.
+                    x = ops.convert_to_numpy(x)
         return x
 
     for batch in iterable:


### PR DESCRIPTION
## Description

`get_numpy_iterator` converts anything with `__array__` through `np.asarray`. mlx 0.32 added `__array__` to its arrays and it raises for bfloat16, since the buffer protocol has no format for it, so every `fit` over bfloat16 mlx inputs now fails inside the iterator. This falls back to the backend's own `convert_to_numpy` when `np.asarray` raises, the same fallback #23596 adds to array slicing.

Nothing changes for the built in backends, `np.asarray` still handles their tensors first. Verified on keras-mlx against mlx 0.32.2, the dense, einsum_dense, embedding and reversible_embedding files go from 10 quantize failures to 297 passed.

## Contributor Agreement

**Please review our [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed.
