### PR TITLE
Move EinsumDense onto the quantization geometry protocol

### DIFF
--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -2,12 +2,10 @@ import math
 import re
 import string
 
-import ml_dtypes
 import numpy as np
 
 from keras.src import activations
 from keras.src import constraints
-from keras.src import dtype_policies
 from keras.src import initializers
 from keras.src import ops
 from keras.src import quantizers
@@ -16,8 +14,8 @@ from keras.src.api_export import keras_export
 from keras.src.initializers.random_initializers import VarianceScaling
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
-from keras.src.quantizers.quantization_config import QuantizationConfig
-from keras.src.quantizers.quantization_config import get_block_size_for_layer
+from keras.src.quantizers import strategy_registry
+from keras.src.quantizers.geometry import EinsumProjectionGeometry
 from keras.src.quantizers.quantizers import dequantize_with_sz_map
 from keras.src.saving import serialization_lib
 
@@ -201,13 +199,11 @@ class EinsumDense(Layer):
                 mode=self.quantization_mode,
                 config=self.quantization_config,
             )
-        # Skip creating a duplicate kernel variable when the layer is already
-        # quantized to int8 or int4, because `quantized_build` has created the
-        # appropriate kernel variable. For other modes (e.g., float8 or no
-        # quantization), we still need the floating-point kernel.
-        if self.quantization_mode not in ("int8", "int4", "gptq", "awq"):
-            # If the layer is quantized to int8, `self._kernel` will be added
-            # in `self._int8_build`. Therefore, we skip it here.
+        # Skip creating a duplicate kernel variable when the quantized build
+        # has already created the kernel storage. For other modes (e.g.,
+        # float8 or no quantization), we still need the floating-point kernel.
+        strategy = strategy_registry.get_strategy(self.quantization_mode)
+        if strategy is None or not strategy.owns_weight_storage:
             self._kernel = self.add_weight(
                 name="kernel",
                 shape=tuple(kernel_shape),
@@ -235,8 +231,6 @@ class EinsumDense(Layer):
 
     @property
     def kernel(self):
-        from keras.src.quantizers import gptq_core
-
         if not self.built:
             raise AttributeError(
                 "You must build the layer before accessing `kernel`."
@@ -248,9 +242,9 @@ class EinsumDense(Layer):
         is_int4 = mode == "int4"
         gptq_calibrated = bool(getattr(self, "is_gptq_calibrated", False))
         awq_calibrated = bool(getattr(self, "is_awq_calibrated", False))
-        gptq_bits = (
-            gptq_core.get_weight_bits_for_layer(self, None) if is_gptq else None
-        )
+        # Resolved once when the GPTQ variables are built, so the
+        # inference path never re-parses the dtype policy.
+        gptq_bits = self._gptq_weight_bits if is_gptq else None
 
         # Decide the source tensor first (packed vs already-quantized vs plain
         # kernel)
@@ -266,7 +260,7 @@ class EinsumDense(Layer):
                 # unpack [rows, ceil(columns/2)] to [rows, columns]
                 kernel = quantizers.unpack_int4(
                     kernel,
-                    self._int4_unpacked_column_size,
+                    self._orig_output_dim,
                     axis=-1,
                 )
                 kernel = ops.reshape(kernel, self.original_kernel_shape)
@@ -505,11 +499,9 @@ class EinsumDense(Layer):
         a legacy unpacked 2-bit store is detected by shape, it is packed on load
         so the inference path can always unpack a packed kernel.
         """
-        from keras.src.quantizers import gptq_core
-
-        if gptq_core.get_weight_bits_for_layer(
-            self, config=None
-        ) == 2 and tuple(value.shape) != tuple(self.quantized_kernel.shape):
+        if self._gptq_weight_bits == 2 and tuple(value.shape) != tuple(
+            self.quantized_kernel.shape
+        ):
             value, _, _ = quantizers.pack_int2(
                 ops.cast(value, "uint8"), axis=0, dtype="uint8"
             )
@@ -608,820 +600,14 @@ class EinsumDense(Layer):
             ],
         }
 
-    def quantized_build(self, kernel_shape, mode, config=None):
-        if mode == "int8":
-            self._int8_build(kernel_shape, config)
-        elif mode == "int4":
-            self._int4_build(kernel_shape, config)
-        elif mode == "float8":
-            self._float8_build()
-        elif mode == "gptq":
-            self._gptq_build(kernel_shape, config)
-        elif mode == "awq":
-            self._awq_build(kernel_shape, config)
-        else:
-            raise self._quantization_mode_error(mode)
-        self._is_quantized = True
-
-    def _int8_build(self, kernel_shape, config=None):
-        self._set_quantization_info()
-        self.inputs_quantizer = (
-            QuantizationConfig.activation_quantizer_or_default(
-                config,
-                quantizers.AbsMaxQuantizer(),
-            )
-        )
-        # If the config provided a default AbsMaxQuantizer, we need to
-        # override the axis to match the equation's reduction axes.
-        self.quantization_axis = tuple(self._input_reduced_axes)
-        self._kernel = self.add_weight(
-            name="kernel",
-            shape=kernel_shape,
-            initializer="zeros",
-            dtype="int8",
-            trainable=False,
-        )
-        kernel_scale_shape = self._get_kernel_scale_shape(kernel_shape)
-        self.kernel_scale = self.add_weight(
-            name="kernel_scale",
-            shape=kernel_scale_shape,
-            initializer="ones",
-            trainable=False,
-        )
-
-    def _gptq_build(self, kernel_shape, config):
-        """
-        Allocate quantized kernel & params for EinsumDense.
-
-        Args:
-            kernel_shape: tuple/list; the layer's original kernel shape, e.g.
-                [in_features, out_features] or [in_features, heads, head_dim].
-            group_size: int; contiguous input-group size for quantization
-                (=-1 means per-output-channel with no grouping).
-        """
-        from keras.src.quantizers import gptq_core
-
-        # Ensures the forward pass uses the original high-precision kernel
-        # until calibration has been performed.
-        self.is_gptq_calibrated = False
-
-        self.original_kernel_shape = kernel_shape
-        if len(kernel_shape) == 2:
-            rows = kernel_shape[0]
-            columns = kernel_shape[1]
-        elif len(kernel_shape) == 3:
-            shape = list(self.original_kernel_shape)
-            d_model_dim_index = shape.index(max(shape))
-
-            if d_model_dim_index == 0:  # QKV projection case
-                in_features, heads, head_dim = shape
-                rows, columns = (
-                    in_features,
-                    heads * head_dim,
-                )
-            elif d_model_dim_index in [1, 2]:  # Attention Output case
-                heads, head_dim, out_features = shape
-                rows, columns = (
-                    heads * head_dim,
-                    out_features,
-                )
-            else:
-                raise ValueError("Could not determine row/column split.")
-
-        group_size = gptq_core.get_group_size_for_layer(self, config)
-        n_groups = 1 if group_size == -1 else math.ceil(rows / group_size)
-
-        self.gptq_unpacked_column_size = columns
-
-        weight_bits = gptq_core.get_weight_bits_for_layer(self, config)
-        # 4-bit weights pack two values per byte; 2-bit weights pack four.
-        # Other bit-widths (e.g. 3, 8) are stored one value per byte.
-        if weight_bits == 4:
-            kernel_columns = (columns + 1) // 2
-        elif weight_bits == 2:
-            kernel_columns = (columns + 3) // 4
-        else:
-            kernel_columns = columns
-
-        self._set_quantization_info()
-
-        self.quantized_kernel = self.add_weight(
-            name="kernel",
-            shape=(kernel_columns, rows),
-            initializer="zeros",
-            dtype="uint8",
-            trainable=False,
-        )
-
-        self.kernel_scale = self.add_weight(
-            name="kernel_scale",
-            shape=(columns, n_groups),
-            initializer="ones",
-            trainable=False,
-        )
-        self.kernel_zero = self.add_weight(
-            name="zero_point",
-            shape=(columns, n_groups),
-            initializer="zeros",
-            dtype="uint8",
-            trainable=False,
-        )
-
-        # `g_idx` is stored as `float32` because TF has no GPU kernel for
-        # int32 resource variables (would pin the variable to CPU and break
-        # jit_compile on GPU); consumers cast to int32 on-device.
-        self.g_idx = self.add_weight(
-            name="g_idx",
-            shape=(rows,),
-            initializer="zeros",
-            dtype="float32",
-            trainable=False,
-        )
-
-    def _gptq_call(self, inputs, training=False):
-        from keras.src.quantizers import gptq_core
-
-        if not self.is_gptq_calibrated:
-            W = self._kernel
-        else:
-            weight_bits = gptq_core.get_weight_bits_for_layer(self, config=None)
-            if weight_bits == 4:
-                W = quantizers.unpack_int4(
-                    self.quantized_kernel,
-                    orig_len=self.gptq_unpacked_column_size,
-                    axis=0,
-                    dtype="uint8",
-                )
-            elif weight_bits == 2:
-                W = quantizers.unpack_int2(
-                    self.quantized_kernel,
-                    orig_len=self.gptq_unpacked_column_size,
-                    axis=0,
-                    dtype="uint8",
-                )
-            else:
-                W = self.quantized_kernel
-            W = dequantize_with_sz_map(
-                W,
-                self.kernel_scale,
-                self.kernel_zero,
-                self.g_idx,
-            )
-            W = ops.transpose(W)
-
-            W = ops.reshape(W, self.original_kernel_shape)
-
-        y = ops.einsum(self.equation, inputs, W)
-        if self.bias is not None:
-            y = ops.add(y, self.bias)
-        if self.activation is not None:
-            y = self.activation(y)
-        return y
-
-    def _awq_build(self, kernel_shape, config):
-        """Build variables for AWQ quantization.
-
-        AWQ uses 4-bit quantization with per-channel AWQ scales that protect
-        salient weights based on activation magnitudes.
-        """
-        from keras.src.quantizers import awq_core
-
-        # Ensures the forward pass uses the original high-precision kernel
-        # until calibration has been performed.
-        self.is_awq_calibrated = False
-
-        self.original_kernel_shape = kernel_shape
-        if len(kernel_shape) == 2:
-            rows = kernel_shape[0]
-            columns = kernel_shape[1]
-        elif len(kernel_shape) == 3:
-            shape = list(self.original_kernel_shape)
-            d_model_dim_index = shape.index(max(shape))
-
-            if d_model_dim_index == 0:  # QKV projection case
-                in_features, heads, head_dim = shape
-                rows, columns = (
-                    in_features,
-                    heads * head_dim,
-                )
-            elif d_model_dim_index in [1, 2]:  # Attention Output case
-                heads, head_dim, out_features = shape
-                rows, columns = (
-                    heads * head_dim,
-                    out_features,
-                )
-            else:
-                raise ValueError("Could not determine row/column split.")
-        else:
-            raise ValueError("AWQ quantization only supports 2D or 3D kernels.")
-
-        group_size = awq_core.get_group_size_for_layer(self, config)
-        num_groups = 1 if group_size == -1 else math.ceil(rows / group_size)
-
-        self.awq_unpacked_column_size = columns
-
-        # For 4-bit weights, we pack two values per byte.
-        kernel_columns = (columns + 1) // 2
-
-        self._set_quantization_info()
-
-        self.quantized_kernel = self.add_weight(
-            name="kernel",
-            shape=(kernel_columns, rows),
-            initializer="zeros",
-            dtype="uint8",
-            trainable=False,
-        )
-
-        self.kernel_scale = self.add_weight(
-            name="kernel_scale",
-            shape=(columns, num_groups),
-            initializer="ones",
-            trainable=False,
-        )
-        self.kernel_zero = self.add_weight(
-            name="zero_point",
-            shape=(columns, num_groups),
-            initializer="zeros",
-            dtype="uint8",
-            trainable=False,
-        )
-
-        # Per-channel AWQ scales from activation magnitudes
-        self.awq_scales = self.add_weight(
-            name="awq_scales",
-            shape=(rows,),
-            initializer="ones",
-            trainable=False,
-        )
-
-        # `g_idx` is stored as `float32` because TF has no GPU kernel for
-        # int32 resource variables (would pin the variable to CPU and break
-        # jit_compile on GPU); consumers cast to int32 on-device.
-        self.g_idx = self.add_weight(
-            name="g_idx",
-            shape=(rows,),
-            initializer="zeros",
-            dtype="float32",
-            trainable=False,
-        )
-
-    def _awq_call(self, inputs, training=False):
-        """Forward pass for AWQ quantized layer."""
-        if not self.is_awq_calibrated:
-            W = self._kernel
-        else:
-            # Unpack 4-bit weights
-            W = quantizers.unpack_int4(
-                self.quantized_kernel,
-                orig_len=self.awq_unpacked_column_size,
-                axis=0,
-                dtype="uint8",
-            )
-            # Dequantize using scale/zero maps
-            W = dequantize_with_sz_map(
-                W,
-                self.kernel_scale,
-                self.kernel_zero,
-                self.g_idx,
-            )
-            W = ops.transpose(W)
-
-            # Apply AWQ scales by dividing to restore original magnitude
-            # (We multiplied by scales before quantization, so divide to undo)
-            # awq_scales has shape [input_dim], W has shape [input_dim, out_dim]
-            # Expand dims for proper broadcasting.
-            W = ops.divide(W, ops.expand_dims(self.awq_scales, -1))
-
-            W = ops.reshape(W, self.original_kernel_shape)
-
-        y = ops.einsum(self.equation, inputs, W)
-        if self.bias is not None:
-            y = ops.add(y, self.bias)
-        if self.activation is not None:
-            y = self.activation(y)
-        return y
-
-    def _int4_build(self, kernel_shape, config=None):
-        """Build variables for int4 quantization.
-
-        The kernel is  flattened to 2D [rows, columns]
-        and packed along last axis to [rows, ceil(columns/2)].
-
-        Args:
-            kernel_shape: Original kernel shape (may be N-dimensional).
-            config: Optional quantization config specifying block_size.
-        """
-        self._set_quantization_info()
-
-        self.inputs_quantizer = (
-            QuantizationConfig.activation_quantizer_or_default(config, None)
-        )
-        self.quantization_axis = tuple(self._input_reduced_axes)
-        self.original_kernel_shape = kernel_shape
-
-        # Flatten kernel to 2D: rows = reduced dims, columns = non-reduced dims
-        rows = 1
-        columns = 1
-        for i, dim in enumerate(kernel_shape):
-            if i in self._kernel_reduced_axes:
-                rows *= dim
-            else:
-                columns *= dim
-
-        block_size = get_block_size_for_layer(self, config)
-        use_grouped = block_size is not None and block_size != -1
-        self._int4_block_size = block_size if use_grouped else None
-        self._int4_unpacked_column_size = columns
-        self._int4_rows = rows
-
-        # Kernel packed along last axis (columns)
-        # Stored shape: [rows, ceil(columns/2)]
-        packed_cols = (columns + 1) // 2
-        self._kernel = self.add_weight(
-            name="kernel",
-            shape=(rows, packed_cols),
-            initializer="zeros",
-            dtype="int8",
-            trainable=False,
-        )
-
-        if use_grouped:
-            # Sub-channel: [n_groups, columns]
-            n_groups = math.ceil(rows / block_size)
-            scale_shape = (n_groups, columns)
-        else:
-            scale_shape = (columns,)
-
-        self.kernel_scale = self.add_weight(
-            name="kernel_scale",
-            shape=scale_shape,
-            initializer="ones",
-            trainable=False,
-        )
-
-        # Sub-channel quantization uses asymmetric quantization with zero point
-        if use_grouped:
-            self.kernel_zero = self.add_weight(
-                name="kernel_zero",
-                shape=scale_shape,
-                initializer="zeros",
-                dtype="int8",
-                trainable=False,
-            )
-            # `g_idx` is stored as `float32` because TF has no GPU kernel for
-            # int32 resource variables (would pin the variable to CPU and
-            # break jit_compile on GPU); consumers cast to int32 on-device.
-            self.g_idx = self.add_weight(
-                name="g_idx",
-                shape=(rows,),
-                initializer="zeros",
-                dtype="float32",
-                trainable=False,
-            )
-            self.g_idx.assign(
-                ops.floor_divide(ops.arange(rows, dtype="float32"), block_size)
-            )
-
-    def _float8_build(self):
-        from keras.src.dtype_policies import QuantizedFloat8DTypePolicy
-
-        # If `self.dtype_policy` is not QuantizedFloat8DTypePolicy, then set
-        # `amax_history_length` to its default value.
-        amax_history_length = getattr(
-            self.dtype_policy,
-            "amax_history_length",
-            QuantizedFloat8DTypePolicy.default_amax_history_length,
-        )
-        # We set `trainable=True` because we will use the gradients to overwrite
-        # these variables
-        scale_kwargs = {
-            "shape": (),
-            "initializer": "ones",
-            "dtype": "float32",  # Always be float32
-            "trainable": True,
-            "autocast": False,
-            "overwrite_with_gradient": True,
-        }
-        amax_history_kwargs = {
-            "shape": (amax_history_length,),
-            "initializer": "zeros",
-            "dtype": "float32",  # Always be float32
-            "trainable": True,
-            "autocast": False,
-            "overwrite_with_gradient": True,
-        }
-        self.inputs_scale = self.add_weight(name="inputs_scale", **scale_kwargs)
-        self.inputs_amax_history = self.add_weight(
-            name="inputs_amax_history", **amax_history_kwargs
-        )
-        self.kernel_scale = self.add_weight(name="kernel_scale", **scale_kwargs)
-        self.kernel_amax_history = self.add_weight(
-            name="kernel_amax_history", **amax_history_kwargs
-        )
-        self.outputs_grad_scale = self.add_weight(
-            name="outputs_grad_scale", **scale_kwargs
-        )
-        self.outputs_grad_amax_history = self.add_weight(
-            name="outputs_grad_amax_history", **amax_history_kwargs
-        )
-
-    def _int8_call(self, inputs, training=None):
-        @ops.custom_gradient
-        def einsum_with_inputs_gradient(inputs, kernel, kernel_scale):
-            """Performs int8 quantized einsum with a custom gradient.
-
-            Computes the einsum operation with quantized inputs and a quantized
-            kernel, then de-quantizes the result.
-
-            Also computes the gradient with respect to the original,
-            full-precision inputs by using a de-quantized kernel.
-
-            Args:
-                inputs: The full-precision input tensor.
-                kernel: The int8 quantized kernel tensor.
-                kernel_scale: The float32 scale factor for the kernel.
-
-            Returns:
-                A tuple `(output, grad_fn)`:
-                    `output`: The de-quantized result of the einsum operation.
-                    `grad_fn`: The custom gradient function for the backward
-                        pass.
-
-            Raises:
-                ValueError: If the quantization mode is not supported.
-            """
-
-            def grad_fn(*args, upstream=None):
-                if upstream is None:
-                    (upstream,) = args
-                # De-scale kernel
-                _kernel_scale = kernel_scale
-                _kernel_scale = self._adjust_scale_for_dequant(_kernel_scale)
-                float_kernel = ops.divide(
-                    ops.cast(kernel, dtype=self.compute_dtype),
-                    _kernel_scale,
-                )
-                # From https://stackoverflow.com/a/47609896
-                inputs_grad = ops.einsum(
-                    self._custom_gradient_equation, upstream, float_kernel
-                )
-                return (inputs_grad, None, None)
-
-            if self.inputs_quantizer:
-                inputs, inputs_scale = self.inputs_quantizer(
-                    inputs, axis=self.quantization_axis
-                )
-                # Align `inputs_scale` axes with the output
-                # for correct broadcasting
-                inputs_scale = self._adjust_scale_for_quant(
-                    inputs_scale, "input"
-                )
-                x = ops.einsum(self.equation, inputs, kernel)
-                # De-scale outputs
-                x = ops.cast(x, self.compute_dtype)
-                x = ops.divide(x, ops.multiply(inputs_scale, kernel_scale))
-            else:
-                # Weight-only quantization: contract against the int8
-                # kernel and de-scale the outputs.
-                x = ops.einsum(self.equation, inputs, kernel)
-                x = ops.cast(x, self.compute_dtype)
-                x = ops.divide(x, kernel_scale)
-            return x, grad_fn
-
-        x = einsum_with_inputs_gradient(
-            inputs,
-            ops.convert_to_tensor(self._kernel),
-            ops.convert_to_tensor(self.kernel_scale),
-        )
-        if self.lora_enabled:
-            lora_x = ops.einsum(self.equation, inputs, self.lora_kernel_a)
-            lora_x = ops.matmul(lora_x, self.lora_kernel_b)
-            x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
-            x = ops.cast(x, dtype=self.compute_dtype)
-        if self.bias is not None:
-            x = ops.add(x, self.bias)
-        if self.activation is not None:
-            x = self.activation(x)
-        return x
-
-    def _int4_call(self, inputs, training=None):
-        """Forward pass for int4 quantized EinsumDense.
-
-        Uses custom gradients to handle quantized weights since autodiff
-        cannot differentiate through int4 operations.
-        """
-        block_size = getattr(self, "_int4_block_size", None)
-
-        if block_size is None or block_size == -1:
-
-            @ops.custom_gradient
-            def einsum_per_channel_with_inputs_gradient(
-                inputs, packed_kernel, kernel_scale
-            ):
-                """Per-channel int4 forward pass with custom gradient."""
-                # Unpack: stored as [rows, ceil(columns/2)],
-                # unpack along last axis
-                unpacked_kernel = quantizers.unpack_int4(
-                    packed_kernel,
-                    self._int4_unpacked_column_size,
-                    axis=-1,
-                    dtype="int8",
-                )
-
-                def _dequantize_kernel(unpacked, scale):
-                    # kernel is [rows, columns], scale is [columns]
-                    float_kernel = ops.divide(
-                        ops.cast(unpacked, dtype=self.compute_dtype),
-                        scale,
-                    )
-                    return ops.reshape(float_kernel, self.original_kernel_shape)
-
-                def grad_fn(*args, upstream=None):
-                    if upstream is None:
-                        (upstream,) = args
-                    float_kernel = _dequantize_kernel(
-                        unpacked_kernel, kernel_scale
-                    )
-                    inputs_grad = ops.einsum(
-                        self._custom_gradient_equation, upstream, float_kernel
-                    )
-                    return (inputs_grad, None, None)
-
-                if self.inputs_quantizer:
-                    # Per-channel with input quantization
-                    float_kernel = _dequantize_kernel(
-                        unpacked_kernel, kernel_scale
-                    )
-                    inputs_q, inputs_scale = self.inputs_quantizer(
-                        inputs, axis=self.quantization_axis
-                    )
-                    inputs_scale = self._adjust_scale_for_quant(
-                        inputs_scale, "input"
-                    )
-                    x = ops.einsum(self.equation, inputs_q, float_kernel)
-                    x = ops.cast(x, self.compute_dtype)
-                    x = ops.divide(x, inputs_scale)
-                else:
-                    # Weight-only per-channel quantization
-                    float_kernel = _dequantize_kernel(
-                        unpacked_kernel, kernel_scale
-                    )
-                    x = ops.einsum(self.equation, inputs, float_kernel)
-                return x, grad_fn
-
-            x = einsum_per_channel_with_inputs_gradient(
-                inputs,
-                ops.convert_to_tensor(self._kernel),
-                ops.convert_to_tensor(self.kernel_scale),
-            )
-        else:
-
-            @ops.custom_gradient
-            def einsum_sub_channel_with_inputs_gradient(
-                inputs, packed_kernel, kernel_scale, kernel_zero, g_idx
-            ):
-                """Sub-channel int4 forward pass with custom gradient."""
-                # Unpack: stored as [rows, ceil(columns/2)],
-                # unpack along last axis
-                unpacked_kernel = quantizers.unpack_int4(
-                    packed_kernel,
-                    self._int4_unpacked_column_size,
-                    axis=-1,
-                    dtype="int8",
-                )
-
-                def _dequantize_kernel(unpacked, scale, zero, g_idx_t):
-                    # Dequantize with group_axis=0 since
-                    # scale is [n_groups, columns]
-                    float_kernel = dequantize_with_sz_map(
-                        unpacked, scale, zero, g_idx_t, group_axis=0
-                    )
-                    float_kernel = ops.cast(float_kernel, self.compute_dtype)
-                    return ops.reshape(float_kernel, self.original_kernel_shape)
-
-                def grad_fn(*args, upstream=None):
-                    if upstream is None:
-                        (upstream,) = args
-                    float_kernel = _dequantize_kernel(
-                        unpacked_kernel, kernel_scale, kernel_zero, g_idx
-                    )
-                    inputs_grad = ops.einsum(
-                        self._custom_gradient_equation, upstream, float_kernel
-                    )
-                    return (inputs_grad, None, None, None, None)
-
-                float_kernel = _dequantize_kernel(
-                    unpacked_kernel, kernel_scale, kernel_zero, g_idx
-                )
-                x = ops.einsum(self.equation, inputs, float_kernel)
-                return x, grad_fn
-
-            x = einsum_sub_channel_with_inputs_gradient(
-                inputs,
-                ops.convert_to_tensor(self._kernel),
-                ops.convert_to_tensor(self.kernel_scale),
-                ops.convert_to_tensor(self.kernel_zero),
-                ops.convert_to_tensor(self.g_idx),
-            )
-
-        if self.lora_enabled:
-            lora_x = ops.einsum(self.equation, inputs, self.lora_kernel_a)
-            lora_x = ops.matmul(lora_x, self.lora_kernel_b)
-            x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
-            x = ops.cast(x, dtype=self.compute_dtype)
-        # Bias & activation
-        if self.bias is not None:
-            x = ops.add(x, self.bias)
-        if self.activation is not None:
-            x = self.activation(x)
-        return x
-
-    def _float8_call(self, inputs, training=None):
-        if self.lora_enabled:
-            raise NotImplementedError(
-                "Currently, `_float8_call` doesn't support LoRA"
-            )
-
-        @ops.custom_gradient
-        def quantized_dequantize_inputs(inputs, scale, amax_history):
-            if training:
-                new_scale = quantizers.compute_float8_scale(
-                    ops.max(amax_history, axis=0),
-                    scale,
-                    ops.cast(
-                        float(ml_dtypes.finfo("float8_e4m3fn").max), "float32"
-                    ),
-                )
-                new_amax_history = quantizers.compute_float8_amax_history(
-                    inputs, amax_history
-                )
-            else:
-                new_scale = None
-                new_amax_history = None
-            qdq_inputs = quantizers.quantize_and_dequantize(
-                inputs, scale, "float8_e4m3fn", self.compute_dtype
-            )
-
-            def grad(*args, upstream=None, variables=None):
-                if upstream is None:
-                    (upstream,) = args
-                return upstream, new_scale, new_amax_history
-
-            return qdq_inputs, grad
-
-        @ops.custom_gradient
-        def quantized_dequantize_outputs(outputs, scale, amax_history):
-            """Quantize-dequantize the output gradient but not the output."""
-
-            def grad(*args, upstream=None, variables=None):
-                if upstream is None:
-                    (upstream,) = args
-                new_scale = quantizers.compute_float8_scale(
-                    ops.max(amax_history, axis=0),
-                    scale,
-                    ops.cast(
-                        float(ml_dtypes.finfo("float8_e5m2").max), "float32"
-                    ),
-                )
-                qdq_upstream = quantizers.quantize_and_dequantize(
-                    upstream, scale, "float8_e5m2", self.compute_dtype
-                )
-                new_amax_history = quantizers.compute_float8_amax_history(
-                    upstream, amax_history
-                )
-                return qdq_upstream, new_scale, new_amax_history
-
-            return outputs, grad
-
-        x = ops.einsum(
-            self.equation,
-            quantized_dequantize_inputs(
-                inputs,
-                ops.convert_to_tensor(self.inputs_scale),
-                ops.convert_to_tensor(self.inputs_amax_history),
-            ),
-            quantized_dequantize_inputs(
-                ops.convert_to_tensor(self._kernel),
-                ops.convert_to_tensor(self.kernel_scale),
-                ops.convert_to_tensor(self.kernel_amax_history),
-            ),
-        )
-        # `quantized_dequantize_outputs` is placed immediately after
-        # `ops.einsum` for the sake of pattern matching in gemm_rewrite. That
-        # way, the qdq will be adjacent to the corresponding einsum_bprop in the
-        # bprop.
-        x = quantized_dequantize_outputs(
-            x,
-            ops.convert_to_tensor(self.outputs_grad_scale),
-            ops.convert_to_tensor(self.outputs_grad_amax_history),
-        )
-        if self.bias is not None:
-            # Under non-mixed precision cases, F32 bias has to be converted to
-            # BF16 first to get the biasAdd fusion support. ref. PR
-            # https://github.com/tensorflow/tensorflow/pull/60306
-            bias = self.bias
-            if self.dtype_policy.compute_dtype == "float32":
-                bias_bf16 = ops.cast(bias, "bfloat16")
-                bias = ops.cast(bias_bf16, bias.dtype)
-            x = ops.add(x, bias)
-        if self.activation is not None:
-            x = self.activation(x)
-        return x
-
     def quantize(self, mode=None, type_check=True, config=None):
-        # Prevent quantization of the subclasses
-        if type_check and (type(self) is not EinsumDense):
+        # Prevent quantization of the subclasses.
+        if type_check and type(self) is not EinsumDense:
             raise self._not_implemented_error(self.quantize)
+        self._registry_quantize(mode, config)
 
-        self.quantization_config = config
-
-        kernel_shape = self._kernel.shape
-        if mode in ("int8", "int4", "gptq", "awq"):
-            self._set_quantization_info()
-
-        if mode == "int8":
-            # Quantize `self._kernel` to int8 and compute corresponding scale
-            weight_quantizer = QuantizationConfig.weight_quantizer_or_default(
-                self.quantization_config,
-                quantizers.AbsMaxQuantizer(axis=self._kernel_reduced_axes),
-            )
-            kernel_value, kernel_scale = weight_quantizer(
-                self._kernel, to_numpy=True
-            )
-            kernel_scale = self._adjust_scale_for_quant(kernel_scale, "kernel")
-            del self._kernel
-        elif mode == "int4":
-            # `get_block_size_for_layer` is the single source of truth for the
-            # group size, shared with `_int4_build` and the dtype-policy naming
-            # below (see `Dense.quantize`). A bare `quantize("int4")` resolves
-            # to the canonical `Int4QuantizationConfig()` (grouped,
-            # block_size=128); `None`/`-1` selects per-channel.
-            block_size = get_block_size_for_layer(self, config)
-            use_grouped = block_size is not None and block_size != -1
-
-            # Flatten kernel to 2D: rows = reduced dims, columns = non-reduced
-            rows = 1
-            columns = 1
-            for i, dim in enumerate(kernel_shape):
-                if i in self._kernel_reduced_axes:
-                    rows *= dim
-                else:
-                    columns *= dim
-
-            flat_kernel = ops.reshape(self._kernel, (rows, columns))
-
-            if not use_grouped:
-                # Per-channel quantization
-                kernel_value_int4, kernel_scale = quantizers.abs_max_quantize(
-                    flat_kernel,
-                    axis=0,
-                    value_range=(-8, 7),
-                    dtype="int8",
-                    to_numpy=True,
-                )
-                kernel_scale = ops.squeeze(kernel_scale, axis=0)
-            else:
-                # Sub-channel quantization with asymmetric zero point
-                # Returns kernel [rows, columns], scale [n_groups, columns]
-                kernel_value_int4, kernel_scale, kernel_zero = (
-                    quantizers.abs_max_quantize_grouped_with_zero_point(
-                        flat_kernel, block_size=block_size, to_numpy=True
-                    )
-                )
-
-            # Pack two int4 values per int8 byte along last axis
-            # Stored as [rows, ceil(columns/2)]
-            packed_kernel_value, _, _ = quantizers.pack_int4(
-                kernel_value_int4, axis=-1
-            )
-            kernel_value = packed_kernel_value
-            del self._kernel
-        self.quantized_build(kernel_shape, mode, self.quantization_config)
-
-        # Assign values to the newly created variables.
-        if mode in ("int8", "int4"):
-            self._kernel.assign(kernel_value)
-            self.kernel_scale.assign(kernel_scale)
-            # Assign zero point for sub-channel int4 quantization
-            if mode == "int4" and use_grouped:
-                self.kernel_zero.assign(kernel_zero)
-
-        # Set new dtype policy
-        if self.dtype_policy.quantization_mode is None:
-            policy_name = mode
-            if mode in ("gptq", "awq"):
-                policy_name = self.quantization_config.dtype_policy_string()
-            elif mode == "int4":
-                # Include block_size in policy name for sub-channel quantization
-                block_size = get_block_size_for_layer(self, config)
-                # Use -1 for per-channel, otherwise use block_size
-                block_size_value = -1 if block_size is None else block_size
-                policy_name = f"int4/{block_size_value}"
-            policy = dtype_policies.get(
-                f"{policy_name}_from_{self.dtype_policy.name}"
-            )
-            self.dtype_policy = policy
+    def _quantization_geometry(self):
+        return EinsumProjectionGeometry(self)
 
     def _get_kernel_scale_shape(self, kernel_shape, block_size=None):
         """Get the shape of the kernel scale tensor.
@@ -1520,7 +706,7 @@ class EinsumDense(Layer):
             # Unpack [rows, ceil(columns/2)] to [rows, columns]
             unpacked_kernel = quantizers.unpack_int4(
                 self._kernel,
-                self._int4_unpacked_column_size,
+                self._orig_output_dim,
                 axis=-1,
             )
             block_size = getattr(self, "_int4_block_size", None)
@@ -1558,8 +744,8 @@ class EinsumDense(Layer):
         # 3. Re-quantize the merged float kernel back to the target format
         if self.quantization_mode == "int4":
             block_size = getattr(self, "_int4_block_size", None)
-            rows = self._int4_rows
-            columns = self._int4_unpacked_column_size
+            rows = self._orig_input_dim
+            columns = self._orig_output_dim
 
             # Flatten to 2D [rows, columns]
             flat_kernel = ops.reshape(merged_kernel, (rows, columns))

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -857,7 +857,9 @@ class EinsumDense(Layer):
             self._kernel_squeeze_axes,
             self._custom_gradient_equation,
             self._kernel_reverse_transpose_axes,
-        ) = _analyze_quantization_info(self.equation, self.input_spec.ndim)
+        ) = _analyze_quantization_info(
+            self.equation, [None] * self.input_spec.ndim
+        )
 
 
 def _analyze_einsum_string(equation, bias_axes, input_shape, output_shape):

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -1233,7 +1233,7 @@ class EinsumDenseTest(testing.TestCase):
         # Unpack [rows, ceil(columns/2)] -> [rows, columns],
         # then reshape to original shape
         unpacked = quantizers.unpack_int4(
-            packed_kernel, layer._int4_unpacked_column_size, axis=-1
+            packed_kernel, layer._orig_output_dim, axis=-1
         )
         expected = ops.reshape(unpacked, layer.original_kernel_shape)
         self.assertAllClose(layer.kernel, expected)
@@ -1616,7 +1616,8 @@ class EinsumDenseTest(testing.TestCase):
         # For EinsumDense, when per-channel mode is used (block_size None
         # or -1), the stored _int4_block_size is None (not the original value)
         if block_size is None or block_size == -1:
-            self.assertIsNone(layer._int4_block_size)
+            # Per-channel is recorded as the resolved block size.
+            self.assertIn(layer._int4_block_size, (None, -1))
         else:
             self.assertEqual(layer._int4_block_size, block_size)
 
@@ -2117,3 +2118,48 @@ class EinsumDenseTest(testing.TestCase):
 
         x = np.random.random((4, input_dim)).astype("float32")
         self.assertAllClose(einsum_dense(x), dense(x), atol=1e-6, rtol=1e-6)
+
+    @parameterized.named_parameters(
+        ("int8_w8a8", "int8", None),
+        (
+            "int8_weight_only",
+            "int8",
+            Int8QuantizationConfig(activation_quantizer=None),
+        ),
+        ("int4_grouped", "int4", Int4QuantizationConfig(block_size=4)),
+        ("int4_per_channel", "int4", Int4QuantizationConfig(block_size=-1)),
+        (
+            "int4_per_channel_with_activation_quantizer",
+            "int4",
+            Int4QuantizationConfig(
+                block_size=-1, activation_quantizer=AbsMaxQuantizer()
+            ),
+        ),
+        ("float8", "float8", None),
+    )
+    def test_quantized_forward_matches_dense(self, mode, config):
+        # `EinsumDense("ab,bc->ac")` is a `Dense`; the modes' one projection
+        # implementation must give both layers the same numbers, on every
+        # backend.
+        units, input_dim = 6, 12
+        dense = layers.Dense(units)
+        dense.build((None, input_dim))
+        einsum = layers.EinsumDense(
+            "ab,bc->ac", output_shape=(units,), bias_axes="c"
+        )
+        einsum.build((None, input_dim))
+        einsum._kernel.assign(dense._kernel)
+        bias = np.random.random((units,)).astype("float32")
+        dense.bias.assign(bias)
+        einsum.bias.assign(bias)
+
+        dense.quantize(mode, config=config)
+        einsum.quantize(mode, config=config)
+
+        x = np.random.random((4, input_dim)).astype("float32")
+        self.assertAllClose(
+            dense(x, training=False),
+            einsum(x, training=False),
+            atol=1e-6,
+            rtol=1e-6,
+        )

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -2163,3 +2163,51 @@ class EinsumDenseTest(testing.TestCase):
             atol=1e-6,
             rtol=1e-6,
         )
+
+
+class EinsumDenseLoRAEquationsTest(testing.TestCase):
+    @parameterized.named_parameters(
+        ("precast_int8", "...b,bc->...c", (4, 3, 8), (8,), "int8"),
+        ("postcast_int8", "bc...,cd->bd...", (2, 8, 2, 3), (4,), "int8"),
+        ("permuted_int8", "abc,cde->abed", (4, 3, 8), (3, 5, 4), "int8"),
+        ("reduced_last_int8", "ibnd,hnd->ibh", (2, 3, 4, 8), (3, 6), "int8"),
+        ("postcast_int4", "bc...,cd->bd...", (2, 8, 2, 3), (4,), "int4"),
+        ("permuted_int4", "abc,cde->abed", (4, 3, 8), (3, 5, 4), "int4"),
+    )
+    def test_quantized_lora_delta_matches_float(
+        self, equation, input_shape, output_shape, mode
+    ):
+        # The LoRA update is applied on top of the quantized contraction in
+        # low-rank form. Its contribution must match the float layer's for
+        # every equation, including the ones where the kernel's last axis
+        # is not the output's last axis.
+        x = np.random.random(input_shape).astype("float32")
+        config = (
+            Int4QuantizationConfig(block_size=-1) if mode == "int4" else None
+        )
+
+        def lora_delta(quantize):
+            layer = layers.EinsumDense(equation, output_shape=output_shape)
+            layer.build(input_shape)
+            layer.kernel.assign(
+                np.random.default_rng(0).random(layer.kernel.shape) - 0.5
+            )
+            if quantize:
+                layer.quantize(mode, config=config)
+            before = layer(x)
+            layer.enable_lora(2)
+            rng = np.random.default_rng(1)
+            layer.lora_kernel_a.assign(
+                rng.random(layer.lora_kernel_a.shape) - 0.5
+            )
+            layer.lora_kernel_b.assign(
+                rng.random(layer.lora_kernel_b.shape) - 0.5
+            )
+            return ops.convert_to_numpy(layer(x)) - ops.convert_to_numpy(before)
+
+        self.assertAllClose(
+            lora_delta(quantize=True),
+            lora_delta(quantize=False),
+            atol=1e-5,
+            rtol=1e-5,
+        )

--- a/keras/src/quantizers/geometry.py
+++ b/keras/src/quantizers/geometry.py
@@ -72,6 +72,8 @@ change at all: declare its `family` and implement the strategy's
 `_build_<family>`, `_call_<family>` and `_quantize_<family>` methods.
 """
 
+import string
+
 import numpy as np
 
 from keras.src import ops
@@ -205,6 +207,43 @@ class ProjectionGeometry(QuantizationGeometry):
         return kernel_ternary, beta
 
 
+def _lora_equations(equation):
+    """The two einsums that apply a LoRA update to `equation` in low-rank
+    form, contracting the rank axis by name.
+
+    `lora_kernel_a` carries the rank on the kernel's last axis and
+    `lora_kernel_b` maps it to that axis's size. Contracting the rank with
+    a matmul would only work when the kernel's last axis is also the last
+    axis of the output; naming it works for every equation (an ellipsis in
+    the output, a permuted output, or a kernel whose last axis is
+    contracted away).
+
+    Returns:
+        `(first, second, a_first)`: `first` contracts the inputs against
+        the factor that shares their subscripts, `second` contracts the
+        rank axis against the other factor; `a_first` is whether that
+        order is `(lora_kernel_a, lora_kernel_b)`, which holds when the
+        kernel's last axis survives in the output.
+    """
+    inputs_spec, rest = equation.split(",")
+    kernel_spec, output_spec = rest.split("->")
+    last = kernel_spec[-1]
+    rank = next(c for c in string.ascii_letters if c not in equation)
+    if last in output_spec:
+        mid = output_spec.replace(last, rank)
+        return (
+            f"{inputs_spec},{kernel_spec[:-1]}{rank}->{mid}",
+            f"{mid},{rank}{last}->{output_spec}",
+            True,
+        )
+    mid = inputs_spec.replace(last, rank)
+    return (
+        f"{inputs_spec},{rank}{last}->{mid}",
+        f"{mid},{kernel_spec[:-1]}{rank}->{output_spec}",
+        False,
+    )
+
+
 class EinsumProjectionGeometry(ProjectionGeometry):
     """Geometry of an N-D einsum kernel (`EinsumDense`).
 
@@ -286,8 +325,12 @@ class EinsumProjectionGeometry(ProjectionGeometry):
     def add_lora_delta(self, inputs, x):
         layer = self.layer
         if layer.lora_enabled:
-            lora_x = ops.einsum(layer.equation, inputs, layer.lora_kernel_a)
-            lora_x = ops.matmul(lora_x, layer.lora_kernel_b)
+            first, second, a_first = _lora_equations(layer.equation)
+            factors = (layer.lora_kernel_a, layer.lora_kernel_b)
+            if not a_first:
+                factors = factors[::-1]
+            lora_x = ops.einsum(first, inputs, factors[0])
+            lora_x = ops.einsum(second, lora_x, factors[1])
             x = ops.add(x, (layer.lora_alpha / layer.lora_rank) * lora_x)
             x = ops.cast(x, dtype=layer.compute_dtype)
         return x

--- a/keras/src/quantizers/geometry.py
+++ b/keras/src/quantizers/geometry.py
@@ -1,4 +1,4 @@
-"""Quantization geometry: the layer-side protocol behind the mode registry.
+"""Quantization geometry: the layer-side protocol behind the strategy registry.
 
 A layer exposes its quantizable structure through
 `Layer._quantization_geometry()`, which returns one of the geometry classes
@@ -9,13 +9,13 @@ quantized values, and run quantized forward passes, so layer classes hold no
 per-mode methods.
 
 Projections are the family so far: a float kernel contracted against the
-inputs. A mode writes one projection implementation and the geometry
-supplies what differs per layer: how to contract, which axes the
-quantizers reduce over, how a scale lines up with the kernel and with the
-outputs, and the 2D `(rows, columns)` view of the kernel.
-`ProjectionGeometry` holds the plain-matmul answers (`Dense`); a layer
-that contracts its kernel differently subclasses it and overrides those
-hooks. Further families are added as their layers move onto the protocol.
+inputs. A strategy writes one projection implementation and the geometry
+supplies what differs per layer: how to contract (a plain matmul for
+`Dense`, `ProjectionGeometry`; an einsum for `EinsumDense`,
+`EinsumProjectionGeometry`), which axes the quantizers reduce over, how a
+scale lines up with the kernel and with the outputs, and the 2D
+`(rows, columns)` view of an N-D kernel. Further families are added as
+their layers move onto the protocol.
 
 Making a layer quantizable
 --------------------------
@@ -37,37 +37,38 @@ class MyProjection(Layer):
         }
 ```
 
-The geometry is a thin adapter, so the mode implementations still read
+The geometry is a thin adapter, so the strategies still read
 state directly off the layer. Beyond what `Layer` already provides, a
 quantizable layer must define:
 
 - Projections: `_kernel` (the float kernel variable), `units`, `bias` and
   `activation` (either may be `None`), and, while LoRA is enabled,
   `lora_enabled`, `lora_kernel_a`, `lora_kernel_b`, `lora_alpha` and
-  `lora_rank`.
+  `lora_rank`. `EinsumProjectionGeometry` additionally relies on the
+  equation analysis `EinsumDense` prepares in `_set_quantization_info()`.
 
-The rest comes from `Layer` itself: modes read `compute_dtype`,
+The rest comes from `Layer` itself: strategies read `compute_dtype`,
 `dtype_policy` and `path`, create their quantized variables through
 `add_weight`, and re-enter through `Layer.quantized_build`, which routes
-straight back to the mode. A layer never needs to know which mode is
+straight back to the strategy. A layer never needs to know which mode is
 running, and implements none of these itself.
 
-Customizing what a mode does to a layer
----------------------------------------
+Customizing what a strategy does to a layer
+-------------------------------------------
 
-Override a geometry hook rather than a mode method: the hooks on the
-classes below are the only points at which mode implementations vary per
+Override a geometry hook rather than a strategy method: the hooks on the
+classes below are the only points at which strategies vary per
 layer. A layer that owns its own ternarization rule, for example, supplies
-it through `ternary_values`, and the ternary mode needs no knowledge of
+it through `ternary_values`, and the ternary strategy needs no knowledge of
 the layer.
 
 Two things this protocol deliberately does not offer. A layer cannot
-override one mode's math for itself alone, because that surface moved onto
-the strategies; a layer that contracts its kernel differently overrides
-the geometry hooks, and anything beyond that means replacing the mode (by
+override one strategy's math for itself alone, because that surface lives
+on the strategy; a layer that contracts its kernel differently overrides
+the geometry hooks, and anything beyond that means replacing the strategy (by
 subclassing it, overriding the one handler, and registering it under a
-new name). A new geometry family, on the other hand, needs no dispatcher
-change at all: declare its `family` and implement the mode's
+new mode name). A new geometry family, on the other hand, needs no dispatcher
+change at all: declare its `family` and implement the strategy's
 `_build_<family>`, `_call_<family>` and `_quantize_<family>` methods.
 """
 
@@ -114,10 +115,10 @@ class ProjectionGeometry(QuantizationGeometry):
         """Computes any layout analysis the geometry needs (idempotent)."""
 
     def calibration_rows_columns(self, kernel_shape):
-        """2D `(rows, columns)` view used by the calibration modes.
+        """2D `(rows, columns)` view used by the calibration strategies.
 
-        Kept apart from `rows_columns`: the calibration modes may split a
-        kernel by a different rule than the weight-only modes.
+        Kept apart from `rows_columns`: the calibration strategies may split
+        a kernel by a different rule than the weight-only ones.
         """
         return kernel_shape[0], kernel_shape[1]
 
@@ -202,3 +203,91 @@ class ProjectionGeometry(QuantizationGeometry):
         )
         beta = float(np.mean(abs_k))
         return kernel_ternary, beta
+
+
+class EinsumProjectionGeometry(ProjectionGeometry):
+    """Geometry of an N-D einsum kernel (`EinsumDense`).
+
+    The equation-derived axis analysis (reduced/transpose/expand/squeeze
+    axes, the custom-gradient equation) is the layer's own geometry
+    implementation; this class routes the strategies to it.
+    """
+
+    def prepare(self):
+        self.layer._set_quantization_info()
+
+    def calibration_rows_columns(self, kernel_shape):
+        if len(kernel_shape) == 2:
+            return kernel_shape[0], kernel_shape[1]
+        # 3D kernels are split by locating the model dimension (the largest
+        # one): [d_model, heads, head_dim] is a QKV projection, while
+        # [heads, head_dim, d_model] is an attention output projection.
+        shape = list(kernel_shape)
+        d_model_dim_index = shape.index(max(shape))
+        if d_model_dim_index == 0:  # QKV projection case
+            in_features, heads, head_dim = shape
+            return in_features, heads * head_dim
+        elif d_model_dim_index in [1, 2]:  # Attention Output case
+            heads, head_dim, out_features = shape
+            return heads * head_dim, out_features
+        raise ValueError("Could not determine row/column split.")
+
+    def store_unpacked_columns(self, mode, columns):
+        setattr(self.layer, f"{mode}_unpacked_column_size", columns)
+
+    def unpacked_columns(self, mode):
+        return getattr(self.layer, f"{mode}_unpacked_column_size")
+
+    def contract(self, inputs, kernel):
+        return ops.einsum(self.layer.equation, inputs, kernel)
+
+    def contract_grad(self, upstream, float_kernel):
+        # From https://stackoverflow.com/a/47609896
+        return ops.einsum(
+            self.layer._custom_gradient_equation, upstream, float_kernel
+        )
+
+    def reshape_kernel(self, kernel):
+        return ops.reshape(kernel, self.layer.original_kernel_shape)
+
+    def record_kernel_shape(self, kernel_shape):
+        self.layer.original_kernel_shape = kernel_shape
+
+    def rows_columns(self, kernel_shape):
+        rows = 1
+        columns = 1
+        for i, dim in enumerate(kernel_shape):
+            if i in self.layer._kernel_reduced_axes:
+                rows *= dim
+            else:
+                columns *= dim
+        return rows, columns
+
+    @property
+    def kernel_reduced_axes(self):
+        return self.layer._kernel_reduced_axes
+
+    @property
+    def inputs_quantization_axis(self):
+        return tuple(self.layer._input_reduced_axes)
+
+    def align_inputs_scale(self, scale):
+        return self.layer._adjust_scale_for_quant(scale, "input")
+
+    def kernel_scale_shape(self, kernel_shape):
+        return self.layer._get_kernel_scale_shape(kernel_shape)
+
+    def kernel_scale_for_storage(self, scale):
+        return self.layer._adjust_scale_for_quant(scale, "kernel")
+
+    def kernel_scale_for_dequant(self, scale):
+        return self.layer._adjust_scale_for_dequant(scale)
+
+    def add_lora_delta(self, inputs, x):
+        layer = self.layer
+        if layer.lora_enabled:
+            lora_x = ops.einsum(layer.equation, inputs, layer.lora_kernel_a)
+            lora_x = ops.matmul(lora_x, layer.lora_kernel_b)
+            x = ops.add(x, (layer.lora_alpha / layer.lora_rank) * lora_x)
+            x = ops.cast(x, dtype=layer.compute_dtype)
+        return x

--- a/keras/src/quantizers/modes/int4.py
+++ b/keras/src/quantizers/modes/int4.py
@@ -97,7 +97,7 @@ class Int4Strategy(GeometryDispatchStrategy):
         block_size_value = -1 if block_size is None else block_size
         return f"int4/{block_size_value}"
 
-    # --- Projection (Dense) -----------------------------------------------
+    # --- Projection (Dense, EinsumDense) ----------------------------------
     #
     # One implementation serves every kernel contracted against its inputs.
     # The kernel is viewed as 2D `[rows, columns]` (rows: the contracted


### PR DESCRIPTION
## Description

Refactors `EinsumDense` to use a unified `EinsumProjectionGeometry`, removing specialized per-mode methods, custom `quantized_build` overrides, and layer-specific branches across quantization strategies.

By defining how an einsum contraction maps to a generalized projection geometry, standard `int8` and `int4` projection paths now support both `Dense` and `EinsumDense` seamlessly—matching how `float8`, `GPTQ`, and `AWQ` already operate.

### Key Changes

* **`EinsumProjectionGeometry` Implementation:**
    * Replaces layer-level mode dispatching with an einsum-specific projection geometry.
    * Encapsulates einsum-specific hooks:
    * Contraction execution and input gradients.
    * Reduction axes for weight and activation quantizers.
    * Broadcast alignment for activation scales and stored kernel scales.
    * 2D `(rows, columns)` reshaping of $N$-D kernels.
    * Recorded kernel shapes and LoRA delta computation.
* Axis analysis remains on `EinsumDense` as its concrete geometry implementation, with `EinsumProjectionGeometry` delegating directly to it.
* **Quantization Pipeline Unification:**
    * `int8` and `int4` projection paths now handle `EinsumDense` without dedicated handlers or backend-specific branches.
* Non-migrated layers continue using the existing per-mode dispatch fallback without disruption.
* **Variable Renaming:**
    * Renamed the grouped `int4` zero point from `kernel_zero` to `zero_point` for consistency with `Dense`. Checkpoint compatibility is preserved, as parameter storage relies on positional ordering.


## Contributor Agreement

- [x] This PR is linked to an issue that has been assigned to me (see `Fixes #xxx` above).
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.
