### PR TITLE
Fixed the broken link in PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Fixes #<!-- issue number -->
 
 ## Contributor Agreement
 
-**Please review our [PR Contribution Policy](https://github.com/keras-team/keras/issues/23601) and [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**
+**Please review our [PR Contribution Policy](https://github.com/keras-team/keras/issues/23601) and [AI-Assisted Contribution Policy](https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**
 
 - [ ] This PR is linked to an issue that has been assigned to me (see `Fixes #xxx` above).
 - [ ] I am a human, and not a bot.


### PR DESCRIPTION
## Description
The AI assisted contribution policy appears to resolve to an incorrect link. I simply replaced the link with the proper path to the section in the .md file.

The issue & the PR might appear trivial but it really bugged me a lot so did not overthink and just pushed a fix.

Fixes #23617

## Contributor Agreement

**Please review our [PR Contribution Policy](https://github.com/keras-team/keras/issues/23601) and [AI-Assisted Contribution Policy](../CONTRIBUTING.md#ai-assisted-contribution-policy) and check all boxes below before submitting your PR for review:**

- [x] This PR is linked to an issue that has been assigned to me (see `Fixes #xxx` above).
- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

**Note:** Failing to adhere to this agreement may result in your future PRs no longer being reviewed. PRs without a linked, assigned issue will be converted to draft.
