### PR TITLE
Fix: share HDF5 validation for cumulative file editor weight checks

### DIFF
--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -45,7 +45,7 @@ _H5_SHAPE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
 _H5_SHAPE_BOMB_MAX_EXPANSION = 1000
 
 
-def _reject_h5_shape_bomb(h5_file):
+def _reject_h5_shape_bomb(h5_file, file_size=None):
     """Reject a cumulative shape/decompression-bomb HDF5 weights file.
 
     `KerasFileEditor` walks the weights in `_extract_weights_from_store` rather
@@ -57,27 +57,46 @@ def _reject_h5_shape_bomb(h5_file):
     the file against the bytes actually stored on disk, mirroring the loader's
     HDF5 shape-bomb guard, so opening an untrusted file cannot drive the editor
     into memory exhaustion (CWE-789 / CWE-409 / CWE-400).
+
+    `file_size` is the bytes stored on disk; the caller passes the archive's
+    recorded size (or the OS file size) so the check does not depend on
+    `h5py.File.id.get_filesize()`, which can be unreliable for stream-backed
+    files. It falls back to that when no size is provided.
     """
-    try:
-        file_size = h5_file.id.get_filesize()
-    except Exception:
-        # If the on-disk size cannot be determined, skip the check rather than
-        # break opening the file.
-        return
+    if file_size is None:
+        try:
+            file_size = h5_file.id.get_filesize()
+        except Exception:
+            # If the on-disk size cannot be determined, skip the check rather
+            # than break opening the file.
+            return
     if file_size <= 0:
         return
     total_declared = 0
 
-    def _accumulate(_name, obj):
+    def _accumulate(group):
         nonlocal total_declared
-        # A null-dataspace dataset has `shape is None`; skip it (`math.prod`
-        # would raise on `None`).
-        if isinstance(obj, h5py.Dataset) and obj.shape is not None:
-            total_declared += math.prod(obj.shape) * obj.dtype.itemsize
+        for key in group.keys():
+            # Check the link type before accessing the child so an
+            # `ExternalLink`/`SoftLink` is rejected rather than resolved: the
+            # external file is never opened, and a soft-link cycle cannot
+            # recurse (mirrors `_extract_weights_from_store`).
+            child_class = group.get(
+                key, default=None, getclass=True, getlink=True
+            )
+            if child_class in (h5py.ExternalLink, h5py.SoftLink):
+                raise ValueError(
+                    f"Not allowed: H5 file with {child_class.__name__}"
+                )
+            obj = group[key]
+            if isinstance(obj, h5py.Group):
+                _accumulate(obj)
+            elif isinstance(obj, h5py.Dataset) and obj.shape is not None:
+                # A null-dataspace dataset has `shape is None`; skip it
+                # (`math.prod` would raise on `None`).
+                total_declared += math.prod(obj.shape) * obj.dtype.itemsize
 
-    # `visititems` only walks hard-linked datasets; external/soft links are
-    # rejected separately by `_extract_weights_from_store` when accessed.
-    h5_file.visititems(_accumulate)
+    _accumulate(h5_file)
     if (
         total_declared > _H5_SHAPE_BOMB_FLOOR_BYTES
         and total_declared > _H5_SHAPE_BOMB_MAX_EXPANSION * file_size
@@ -154,7 +173,21 @@ class KerasFileEditor:
                 f"Received: filepath={filepath}"
             )
 
-        _reject_h5_shape_bomb(weights_store.h5_file)
+        # Pass the archive's recorded weights size (or OS file size) so the
+        # shape-bomb ratio check does not rely on `get_filesize()`, which can
+        # be unreliable for the stream-backed `.keras` weights member.
+        file_size = None
+        if filepath.endswith(".keras"):
+            try:
+                file_size = zf.getinfo(f"{saving_lib._VARS_FNAME}.h5").file_size
+            except KeyError:
+                pass
+        elif filepath.endswith(".weights.h5"):
+            try:
+                file_size = os.path.getsize(filepath)
+            except OSError:
+                pass
+        _reject_h5_shape_bomb(weights_store.h5_file, file_size=file_size)
         weights_dict, object_metadata = self._extract_weights_from_store(
             weights_store.h5_file
         )

--- a/keras/src/saving/file_editor.py
+++ b/keras/src/saving/file_editor.py
@@ -35,6 +35,62 @@ def is_ipython_notebook():
         return False
 
 
+# An HDF5 weights file whose datasets cumulatively declare more than this floor
+# of array data, and more than `_H5_SHAPE_BOMB_MAX_EXPANSION` times the bytes
+# actually stored on disk, is treated as a shape/decompression bomb
+# (CWE-789 / CWE-409). Mirrors the loader's HDF5 guard so the editor enjoys the
+# same protection (it walks the weights itself instead of going through the
+# loader's `safe_get_h5_dataset`).
+_H5_SHAPE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
+_H5_SHAPE_BOMB_MAX_EXPANSION = 1000
+
+
+def _reject_h5_shape_bomb(h5_file):
+    """Reject a cumulative shape/decompression-bomb HDF5 weights file.
+
+    `KerasFileEditor` walks the weights in `_extract_weights_from_store` rather
+    than through the loader's ratio-checked `safe_get_h5_dataset`, and its
+    per-dataset size guard has no decompression-ratio bound and no cumulative
+    budget: a dataset declaring just under the per-dataset limit while storing
+    almost nothing, or several such datasets, are read into memory in full from
+    a few-KB file. This bounds the cumulative declared size of every dataset in
+    the file against the bytes actually stored on disk, mirroring the loader's
+    HDF5 shape-bomb guard, so opening an untrusted file cannot drive the editor
+    into memory exhaustion (CWE-789 / CWE-409 / CWE-400).
+    """
+    try:
+        file_size = h5_file.id.get_filesize()
+    except Exception:
+        # If the on-disk size cannot be determined, skip the check rather than
+        # break opening the file.
+        return
+    if file_size <= 0:
+        return
+    total_declared = 0
+
+    def _accumulate(_name, obj):
+        nonlocal total_declared
+        # A null-dataspace dataset has `shape is None`; skip it (`math.prod`
+        # would raise on `None`).
+        if isinstance(obj, h5py.Dataset) and obj.shape is not None:
+            total_declared += math.prod(obj.shape) * obj.dtype.itemsize
+
+    # `visititems` only walks hard-linked datasets; external/soft links are
+    # rejected separately by `_extract_weights_from_store` when accessed.
+    h5_file.visititems(_accumulate)
+    if (
+        total_declared > _H5_SHAPE_BOMB_FLOOR_BYTES
+        and total_declared > _H5_SHAPE_BOMB_MAX_EXPANSION * file_size
+    ):
+        declared_str = summary_utils.readable_memory_size(total_declared)
+        stored_str = summary_utils.readable_memory_size(file_size)
+        raise ValueError(
+            "Refusing to open a potential decompression/shape bomb: the "
+            f"HDF5 weights declare {declared_str} of array data but only "
+            f"{stored_str} are stored on disk."
+        )
+
+
 @keras_export("keras.saving.KerasFileEditor")
 class KerasFileEditor:
     """Utility to inspect, edit, and resave Keras weights files.
@@ -98,6 +154,7 @@ class KerasFileEditor:
                 f"Received: filepath={filepath}"
             )
 
+        _reject_h5_shape_bomb(weights_store.h5_file)
         weights_dict, object_metadata = self._extract_weights_from_store(
             weights_store.h5_file
         )

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -209,3 +209,19 @@ class SavingTest(testing.TestCase):
         self.assertLess(os.path.getsize(bomb_fpath), 1 << 20)  # tiny on disk
         with self.assertRaisesRegex(ValueError, "shape bomb"):
             KerasFileEditor(bomb_fpath)
+
+    def test_shape_bomb_guard_rejects_external_link(self):
+        # The guard traverses the group manually and rejects an external/soft
+        # link itself (without resolving it), rather than relying only on
+        # `_extract_weights_from_store` to catch it.
+        from keras.src.saving.file_editor import _reject_h5_shape_bomb
+
+        secret_fpath = os.path.join(self.get_temp_dir(), "secret.h5")
+        with h5py.File(secret_fpath, "w") as f:
+            f.create_dataset("k", data=np.zeros((2, 2), "float32"))
+        mal_fpath = os.path.join(self.get_temp_dir(), "mal.weights.h5")
+        with h5py.File(mal_fpath, "w") as f:
+            f["ext"] = h5py.ExternalLink(secret_fpath, "/")
+        with h5py.File(mal_fpath, "r") as f:
+            with self.assertRaisesRegex(ValueError, "ExternalLink"):
+                _reject_h5_shape_bomb(f, file_size=os.path.getsize(mal_fpath))

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -161,3 +161,51 @@ class SavingTest(testing.TestCase):
 
         with self.assertRaisesRegex(ValueError, "virtual"):
             KerasFileEditor(virtual_fpath)
+
+    def test_rejects_shape_bomb(self):
+        # A few-KB file whose dataset declares far more than it stores on disk
+        # (chunked + gzip + fillvalue) must be rejected before the editor reads
+        # it into memory.
+        bomb_fpath = os.path.join(self.get_temp_dir(), "bomb.weights.h5")
+        with h5py.File(bomb_fpath, "w") as f:
+            vars_group = (
+                f.create_group("layers")
+                .create_group("dense")
+                .create_group("vars")
+            )
+            vars_group.create_dataset(
+                "0",
+                shape=(128 * (1 << 20),),  # 128 MiB declared, ~0 stored
+                dtype="uint8",
+                chunks=(1 << 20,),
+                compression="gzip",
+                fillvalue=0,
+            )
+        self.assertLess(os.path.getsize(bomb_fpath), 1 << 20)  # tiny on disk
+        with self.assertRaisesRegex(ValueError, "shape bomb"):
+            KerasFileEditor(bomb_fpath)
+
+    def test_rejects_cumulative_shape_bomb(self):
+        # Several datasets that each declare under the floor but jointly declare
+        # far more than is stored: the cumulative guard must reject them.
+        bomb_fpath = os.path.join(
+            self.get_temp_dir(), "cumulative_bomb.weights.h5"
+        )
+        with h5py.File(bomb_fpath, "w") as f:
+            vars_group = (
+                f.create_group("layers")
+                .create_group("dense")
+                .create_group("vars")
+            )
+            for i in range(3):  # 3 x 32 MiB declared = 96 MiB total
+                vars_group.create_dataset(
+                    str(i),
+                    shape=(32 * (1 << 20),),
+                    dtype="uint8",
+                    chunks=(1 << 20,),
+                    compression="gzip",
+                    fillvalue=0,
+                )
+        self.assertLess(os.path.getsize(bomb_fpath), 1 << 20)  # tiny on disk
+        with self.assertRaisesRegex(ValueError, "shape bomb"):
+            KerasFileEditor(bomb_fpath)

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -53,6 +53,11 @@ _MEMORY_UPPER_BOUND = 0.5  # 50%
 # Mirrors the `_ZIP_MEMBER_*` guard used by `_reject_zip_bomb`.
 _NPZ_MEMBER_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
 _NPZ_MEMBER_MAX_EXPANSION = 100
+# Floor for the *cumulative* (whole-archive) npz guard. A much lower floor than
+# the per-member one lets the cumulative guard also catch a single member that
+# declares just under the per-member floor, as well as several sub-floor
+# members that are read into memory together (see `_reject_npz_archive_bomb`).
+_NPZ_CUMULATIVE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
 
 
 _MODEL_CARD_TEMPLATE = """
@@ -447,6 +452,11 @@ def _model_from_config(config_json, custom_objects, compile, safe_mode):
 # The 4 GiB floor matches the HDF5 dataset guard for CVE-2026-0897.
 _ZIP_MEMBER_BOMB_FLOOR_BYTES = 1 << 32  # 4 GiB
 _ZIP_MEMBER_MAX_EXPANSION = 100
+# Floor for the *cumulative* (whole-archive) guard below. A much lower floor
+# than the per-member one lets the cumulative guard also catch a single member
+# that declares just under the per-member floor, as well as the several
+# independent member reads on the load path that each stay under it.
+_ZIP_CUMULATIVE_BOMB_FLOOR_BYTES = 1 << 26  # 64 MiB
 
 
 def _reject_zip_bomb(archive, name):
@@ -464,6 +474,35 @@ def _reject_zip_bomb(archive, name):
         )
 
 
+def _reject_zip_archive_bomb(archive):
+    """Raise if a ZIP archive is cumulatively a decompression bomb (CWE-409).
+
+    `_reject_zip_bomb` bounds a *single* member, but its per-member floor can
+    be evaded by a member declaring just under the floor, or by the several
+    members that the load path reads into memory independently (`config.json`,
+    `model.weights.h5`, and the shard map), each staying under it. This bounds
+    the *cumulative* declared size of every member against the bytes actually
+    stored on disk, using the same expansion ratio. Genuine `.keras` archives
+    store their members uncompressed (declared size ~= stored size), so this
+    only fires on archives that declare far more than they store.
+    """
+    total_declared = 0
+    total_stored = 0
+    for info in archive.infolist():
+        total_declared += info.file_size
+        total_stored += info.compress_size
+    if (
+        total_declared > _ZIP_CUMULATIVE_BOMB_FLOOR_BYTES
+        and total_declared > _ZIP_MEMBER_MAX_EXPANSION * total_stored
+    ):
+        raise ValueError(
+            "Not allowed: the archive declares "
+            f"{readable_memory_size(total_declared)} across its members but "
+            f"only {readable_memory_size(total_stored)} are stored on disk; "
+            "refusing to load a potential decompression bomb."
+        )
+
+
 def _safe_zip_read(archive, name):
     """Read a ZIP member into memory, rejecting bombs (see CWE-409)."""
     _reject_zip_bomb(archive, name)
@@ -473,6 +512,7 @@ def _safe_zip_read(archive, name):
 
 def _load_model_from_fileobj(fileobj, custom_objects, compile, safe_mode):
     with zipfile.ZipFile(fileobj, "r") as zf:
+        _reject_zip_archive_bomb(zf)
         config_json = _safe_zip_read(zf, _CONFIG_FILENAME)
 
         model = _model_from_config(
@@ -641,6 +681,7 @@ def load_weights_only(
             weights_store = ShardedH5IOStore(filepath, mode="r")
         elif filepath_str.endswith(".keras"):
             archive = zipfile.ZipFile(filepath, "r")
+            _reject_zip_archive_bomb(archive)
             weights_store = H5IOStore(_VARS_FNAME_H5, archive=archive, mode="r")
 
         failed_saveables = set()
@@ -1769,6 +1810,29 @@ class ShardedH5IOStore(H5IOStore):
         return False
 
 
+def _npz_member_declared_bytes(zip_file, member_name):
+    """Return `(declared_bytes, stored_bytes)` for an npz `.npy` member.
+
+    Reads only the `.npy` header (which carries the declared shape and dtype),
+    so it never allocates the array itself. Returns `None` if the member is
+    absent from the archive.
+    """
+    try:
+        info = zip_file.getinfo(f"{member_name}.npy")
+    except KeyError:
+        return None
+    with zip_file.open(info) as member_file:
+        major, _ = npy_format.read_magic(member_file)
+        read_header = getattr(
+            npy_format,
+            f"read_array_header_{major}_0",
+            npy_format.read_array_header_2_0,
+        )
+        shape, _, dtype = read_header(member_file)
+    declared_bytes = math.prod(shape) * dtype.itemsize
+    return declared_bytes, info.compress_size
+
+
 class NpzIOStore:
     def __init__(self, root_path, archive=None, mode="r"):
         """Numerical variable store backed by NumPy.savez/load.
@@ -1790,6 +1854,7 @@ class NpzIOStore:
             else:
                 self.f = open(root_path, mode="rb")
             self.contents = np.load(self.f, allow_pickle=False)
+            self._reject_npz_archive_bomb()
 
     def make(self, path, metadata=None):
         if not path:
@@ -1820,20 +1885,11 @@ class NpzIOStore:
         zip_file = getattr(self.contents, "zip", None)
         if zip_file is None:
             return
-        try:
-            info = zip_file.getinfo(f"{path}.npy")
-        except KeyError:
+        sizes = _npz_member_declared_bytes(zip_file, path)
+        if sizes is None:
             return
-        with zip_file.open(info) as member_file:
-            major, _ = npy_format.read_magic(member_file)
-            read_header = getattr(
-                npy_format,
-                f"read_array_header_{major}_0",
-                npy_format.read_array_header_2_0,
-            )
-            shape, _, dtype = read_header(member_file)
-        declared_bytes = math.prod(shape) * dtype.itemsize
-        stored_bytes = max(info.compress_size, 1)
+        declared_bytes, compress_size = sizes
+        stored_bytes = max(compress_size, 1)
         if (
             declared_bytes > _NPZ_MEMBER_BOMB_FLOOR_BYTES
             and declared_bytes > _NPZ_MEMBER_MAX_EXPANSION * stored_bytes
@@ -1841,7 +1897,40 @@ class NpzIOStore:
             raise ValueError(
                 f"Refusing to load npz weight '{path}': its header declares "
                 f"{readable_memory_size(declared_bytes)} but only "
-                f"{readable_memory_size(info.compress_size)} is stored on "
+                f"{readable_memory_size(compress_size)} is stored on "
+                "disk; refusing to load a potential decompression bomb."
+            )
+
+    def _reject_npz_archive_bomb(self):
+        """Guard against an npz that is cumulatively a shape/decompression bomb.
+
+        `_reject_npz_bomb` bounds a *single* member, but its per-member floor
+        can be evaded by a member declaring just under it, or by several
+        members that each stay under it and are read into memory together.
+        This bounds the *cumulative* declared size of every member against the
+        bytes actually stored on disk, using the same expansion ratio, so
+        sub-floor members cannot sum without bound (CWE-789 / CWE-409).
+        """
+        zip_file = getattr(self.contents, "zip", None)
+        if zip_file is None:
+            return
+        total_declared = 0
+        total_stored = 0
+        for member_name in self.contents.files:
+            sizes = _npz_member_declared_bytes(zip_file, member_name)
+            if sizes is None:
+                continue
+            declared_bytes, compress_size = sizes
+            total_declared += declared_bytes
+            total_stored += compress_size
+        if (
+            total_declared > _NPZ_CUMULATIVE_BOMB_FLOOR_BYTES
+            and total_declared > _NPZ_MEMBER_MAX_EXPANSION * total_stored
+        ):
+            raise ValueError(
+                "Refusing to load npz weights: the archive declares "
+                f"{readable_memory_size(total_declared)} across its members "
+                f"but only {readable_memory_size(total_stored)} is stored on "
                 "disk; refusing to load a potential decompression bomb."
             )
 

--- a/keras/src/saving/saving_lib_test.py
+++ b/keras/src/saving/saving_lib_test.py
@@ -1744,6 +1744,54 @@ class SafeZipReadTest(testing.TestCase):
             with self.assertRaisesRegex(ValueError, "decompression bomb"):
                 saving_lib.load_model(evil)
 
+    def test_rejects_cumulative_archive_bomb_under_floor(self):
+        # Several members that each stay under the (real, 4 GiB) per-member
+        # floor but jointly declare far more than is stored on disk: the
+        # per-member guard passes each one, the cumulative guard rejects them.
+        path = os.path.join(self.get_temp_dir(), "a.zip")
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for i in range(4):
+                zf.writestr(f"m{i}.json", b"A" * 100_000)
+        self.assertLess(os.path.getsize(path), 1 << 16)  # tiny file on disk
+        with mock.patch.object(
+            saving_lib, "_ZIP_CUMULATIVE_BOMB_FLOOR_BYTES", 64
+        ):
+            with zipfile.ZipFile(path, "r") as zf:
+                # The per-member guard (real 4 GiB floor) passes each member.
+                for i in range(4):
+                    saving_lib._reject_zip_bomb(zf, f"m{i}.json")
+                # The cumulative guard rejects the archive as a whole.
+                with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                    saving_lib._reject_zip_archive_bomb(zf)
+
+    def test_load_model_rejects_cumulative_bomb(self):
+        # End-to-end: a tiny `.keras` whose config.json declares well under the
+        # 4 GiB per-member floor (so `_reject_zip_bomb` passes) is still
+        # rejected by the cumulative guard before any member is read.
+        path = os.path.join(self.get_temp_dir(), "bomb.keras")
+        payload = b'{"x":"' + b" " * 400_000 + b'"}'
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("metadata.json", b'{"keras_version":"3"}')
+            zf.writestr("config.json", payload)
+        self.assertLess(os.path.getsize(path), 1 << 16)  # tiny file on disk
+        with mock.patch.object(
+            saving_lib, "_ZIP_CUMULATIVE_BOMB_FLOOR_BYTES", 64
+        ):
+            with self.assertRaisesRegex(ValueError, "decompression bomb"):
+                saving_lib.load_model(path)
+
+    def test_does_not_reject_genuine_keras(self):
+        # A genuine `.keras` (members stored ~uncompressed, ratio ~1) must pass
+        # both the direct cumulative guard and an end-to-end load.
+        model = keras.Sequential(
+            [keras.Input((16,)), keras.layers.Dense(64), keras.layers.Dense(8)]
+        )
+        path = os.path.join(self.get_temp_dir(), "good.keras")
+        model.save(path)
+        with zipfile.ZipFile(path, "r") as zf:
+            saving_lib._reject_zip_archive_bomb(zf)  # must not raise
+        keras.saving.load_model(path)  # must not raise
+
 
 class SafeGetH5DatasetTest(testing.TestCase):
     def _shape_bomb_file(self):
@@ -1856,15 +1904,55 @@ class SavingNpzIOStoreTest(testing.TestCase):
         with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
             zf.writestr(f"{name}.npy", header.getvalue() + data)
 
+    def _write_npz_members(self, path, members, descr="<f8"):
+        """Write several members, each declaring `shape` but storing no data.
+
+        `members` is an iterable of `(name, shape)`; every member's `.npy`
+        header declares its array while almost nothing is stored on disk.
+        """
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for name, shape in members:
+                header = BytesIO()
+                np.lib.format.write_array_header_1_0(
+                    header,
+                    {"descr": descr, "fortran_order": False, "shape": shape},
+                )
+                zf.writestr(f"{name}.npy", header.getvalue())
+
     def test_npz_io_store_rejects_shape_bomb(self):
-        # Member declares an 8 PiB array but stores only its header.
+        # A single member declaring an 8 PiB array but storing only its header
+        # is rejected by the cumulative guard when the store is opened.
         temp_filepath = os.path.join(self.get_temp_dir(), "bomb.npz")
         self._write_npz_member(temp_filepath, "w", shape=(2**50,))
-        store = saving_lib.NpzIOStore(temp_filepath, mode="r")
-        with self.assertRaisesRegex(
-            ValueError, r"Refusing to load npz weight 'w'"
+        with self.assertRaisesRegex(ValueError, "decompression bomb"):
+            saving_lib.NpzIOStore(temp_filepath, mode="r")
+
+    def test_npz_io_store_rejects_cumulative_bomb(self):
+        # Several members each below the 4 GiB per-member floor that jointly
+        # declare far more than is stored: the per-member guard misses them,
+        # the cumulative guard rejects the store at open.
+        temp_filepath = os.path.join(self.get_temp_dir(), "cumulative.npz")
+        elems = (3 << 30) // 8  # 3 GiB of float64 each, below the 4 GiB floor
+        self._write_npz_members(
+            temp_filepath, [(f"w{i}", (elems,)) for i in range(3)]
+        )
+        self.assertLess(os.path.getsize(temp_filepath), 1 << 16)  # tiny file
+        with self.assertRaisesRegex(ValueError, "decompression bomb"):
+            saving_lib.NpzIOStore(temp_filepath, mode="r")
+
+    def test_npz_io_store_per_member_guard(self):
+        # With the cumulative floor raised, a single member over the 4 GiB
+        # per-member floor is still rejected by the per-member guard on `get`.
+        temp_filepath = os.path.join(self.get_temp_dir(), "bomb.npz")
+        self._write_npz_member(temp_filepath, "w", shape=(2**50,))
+        with mock.patch.object(
+            saving_lib, "_NPZ_CUMULATIVE_BOMB_FLOOR_BYTES", 1 << 62
         ):
-            store.get("w")
+            store = saving_lib.NpzIOStore(temp_filepath, mode="r")
+            with self.assertRaisesRegex(
+                ValueError, r"Refusing to load npz weight 'w'"
+            ):
+                store.get("w")
 
     def test_npz_io_store_loads_normal_array(self):
         temp_filepath = os.path.join(self.get_temp_dir(), "store.npz")


### PR DESCRIPTION
## Summary

`KerasFileEditor` reads all datasets into memory, but its per-dataset size limit does not bound their combined expansion. This PR checks cumulative declared HDF5 dataset sizes before reading any arrays, for both standalone `.weights.h5` files and weights embedded in `.keras` archives.

The preflight check traverses metadata only and reuses the loader's group and dataset validators. The editor also uses the shared dataset validator when extracting weights, keeping external/virtual dataset checks consistent with model loading.

## Relationship to #23161 and #23655

Supersedes #23161, which was automatically closed for inactivity and cannot be reopened by the author. The original branch history is retained.

**Depends on #23655**, the replacement for #23159. This branch includes its NPZ removal and shared ZIP archive validation. The editor invokes that ZIP check before opening archive members. Once #23655 merges, this PR contains only the HDF5/editor follow-up.

## Fix

- `keras/src/saving/saving_lib.py` — add a cumulative HDF5 metadata preflight that reuses `safe_get_h5_group()` and `safe_get_h5_dataset()`.
- Reject external/soft links before resolution and detect cyclic hard-linked groups. Handle scalar, empty, and null datasets plus named datatypes during preflight.
- `keras/src/saving/file_editor.py` — run preflight using the filesystem size or ZIP member's uncompressed size, and reuse the loader's dataset validator instead of duplicated checks.
- Close the HDF5 store and ZIP archive on both success and rejection.

## Test plan

`keras/src/saving/file_editor_test.py` and `saving_lib_test.py`:

- Reject single and cumulative oversized datasets in both standalone HDF5 files and `.keras` archives.
- Make array reads fail to verify rejection occurs before reading dataset contents.
- Cover metadata-only traversal, explicit file-size accounting, link rejection, cycle detection, and resource closure.
- Preserve normal file inspection, editing, model saving, and weight loading.

```text
$ KERAS_BACKEND=tensorflow python -m pytest \
    keras/src/saving/file_editor_test.py \
    keras/src/saving/saving_lib_test.py \
    keras/src/saving/saving_api_test.py
159 passed, 7 skipped

$ KERAS_BACKEND=torch python -m pytest \
    keras/src/saving/file_editor_test.py \
    keras/src/saving/saving_lib_test.py
97 passed
```

Verified with Python 3.12.13, TensorFlow 2.21.0, and PyTorch 2.14.0. Repository-wide Ruff lint and formatting checks pass, API generation produces no changes, and `git diff --check` is clean.

## Disclosure

OpenAI Codex assisted with the follow-up implementation, tests, validation, and this description.

## CLA

@LinZiyuu <lin******05​@gmail.com>

## Contributor agreement

- [x] I am a human, and not a bot.
- [x] I will be responsible for responding to review comments in a timely manner.
- [x] I will work with the maintainers to push this PR forward until submission.

